### PR TITLE
JMX metric gatherer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,18 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  openjdk8:
     docker:
       - image: circleci/openjdk:8-jdk
-
+  integration:
+    machine:
+      image: ubuntu-1604:201903-01
+jobs:
+  build:
+    executor: openjdk8
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -51,3 +57,45 @@ jobs:
       - run:
           name: Build validation
           command: make build
+
+  integration-tests:
+    executor: integration
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+    # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx1g
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=4"
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - gradle-
+
+      - run:
+          name: Integration Tests
+          command: make integration-test
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle" }}
+workflows:
+  version: 2
+  verification:
+    jobs:
+      - build
+      - integration-tests:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           command: make build
 
   integration-tests:
+    # machine executor required for testcontainers docker access
     executor: integration
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ assemble:
 .PHONY: test
 test:
 	./gradlew test
+
+.PHONY: integration-test
+integration-test:
+	./gradlew -Pojc.integration.test=true test

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	./gradlew -Pojc.integration.test=true test
+	./gradlew -Pojc.integration.tests=true test

--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ feature or via instrumentation, this project is hopefully for you.
 
 *This project is in its early stages and doesn't provide any assurances of stability or production readiness.*
 
+
+## Provided Libraries
+
+* [JMX Metric Gatherer](./contrib/jmx-metrics/README.md)
+
 ## Getting Started
 
 ```bash
 # Build the complete project
 $ make build
+
+# Run integration tests
+$ make integration-test
 
 # Clean artifacts
 $ make clean

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ allprojects {
         mavenCentral()
     }
 
-    if (Gradle.properties['ojc.integration.test'] == 'true') {
-        System.setProperty('ojc.integration.test', 'true')
+    if (property('ojc.integration.tests') == 'true') {
+        tasks.withType(Test) {
+            systemProperty 'ojc.integration.tests', 'true'
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,8 @@ allprojects {
         jcenter()
         mavenCentral()
     }
+
+    if (Gradle.properties['ojc.integration.test'] == 'true') {
+        System.setProperty('ojc.integration.test', 'true')
+    }
 }

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -1,0 +1,112 @@
+# JMX Metric Gatherer
+
+This utility provides an easy framework for gathering and reporting metrics based on queried
+MBeans from a JMX server.  It loads a custom Groovy script and establishes a helpful, bound `otel`
+object with methods for obtaining MBeans and constructing synchronous OpenTelemetry instruments:
+
+### Usage
+
+```bash
+$ java -D<otel.jmx.metrics.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config ./optional_config.properties]
+```
+
+##### `optional_config.properties` example
+
+```properties
+otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
+otel.jmx.metrics.groovy.script = /opt/script.groovy
+otel.jmx.metrics.interval.seconds = 5
+otel.jmx.metrics.exporter.type = otlp
+otel.jmx.metrics.exporter.otlp.endpoint = my-opentelemetry-collector:55680
+otel.jmx.metrics.username = my-username
+otel.jmx.metrics.password = my-password
+```
+
+##### `script.groovy` example
+
+```groovy
+import io.opentelemetry.common.Labels
+
+def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
+def load = loadMatches.first()
+
+def lvr = otel.longValueRecorder(
+        "cassandra.storage.load",
+        "Size, in bytes, of the on disk data size this node manages",
+        "By", [myConstantLabelKey:"myConstantLabelValue"]
+)
+
+lvr.record(load.Count, Labels.of("myKey", "myVal"))
+```
+
+As configured in the example, this metric gatherer will configure an otlp gRPC metric exporter
+at the `otel.jmx.metrics.exporter.otlp.endpoint` and establish an MBean server connection using the
+provided `otel.jmx.metrics.service.url`. After loading the Groovy script whose path is specified
+via `otel.jmx.metrics.groovy.script`, it will then run the script on the specified
+`otel.jmx.metrics.interval.seconds` and export the resulting metrics.
+
+### JMX Query Helpers
+
+- `otel.queryJmx(String objectNameStr)`
+   - This method will query the connected JMX application for the given `objectName`, which can
+   include wildcards.  The return value will be a `List<GroovyMBean>` of zero or more
+   [`GroovyMBean` objects](http://docs.groovy-lang.org/latest/html/api/groovy/jmx/GroovyMBean.html),
+   which are conveniently wrapped to make accessing attributes on the MBean simple.
+   See http://groovy-lang.org/jmx.html for more information about their usage.
+
+- `otel.queryJmx(javax.management.ObjectName objectName)`
+   - This helper has the same functionality as its other signature, but takes an `ObjectName`
+   instance if constructing raw names is undesired.
+
+### OpenTelemetry Synchronous Instrument Helpers
+
+- `otel.doubleCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.doubleValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+
+- `otel.longValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+
+These methods will return a new or previously registered instance of the applicable metric
+instruments.  Each one provides three additional signatures  where labels, unit, and description
+aren't desired upon invocation.
+
+- `otel.<meterMethod>(String name, String description, String unit)` - `labels` are empty map.
+
+- `otel.<meterMethod>(String name, String description)` - `unit` is "1" and `labels` are empty map.
+
+- `otel.<meterMethod>(String name)` - `description` is empty string, `unit` is "1" and `labels` are empty map.
+
+### Compatibility
+
+This metric extension supports Java 7+, though SASL is only supported where
+`com.sun.security.sasl.Provider` is available.
+
+### Configuration
+
+The following properties are supported via the command line or specified config properties file `(-config)`.
+Those provided as command line properties take priority of those contained in a properties file.
+
+| Property | Required | Description |
+| ------------- | -------- | ----------- |
+| `otel.jmx.metrics.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
+| `otel.jmx.metrics.groovy.script` | **yes** | The path for the desired Groovy script. |
+| `otel.jmx.metrics.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10 by default. |
+| `otel.jmx.metrics.exporter.type` | no | The type of `io.opentelemetry.sdk.metrics.export.MetricExporter` to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
+| `otel.jmx.metrics.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
+| `otel.jmx.metrics.exporter.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
+| `otel.jmx.metrics.exporter.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
+| `otel.jmx.metrics.username` | no | Username for JMX authentication, if applicable. |
+| `otel.jmx.metrics.password` | no | Password for JMX authentication, if applicable. |
+| `otel.jmx.metrics.keystore.path` | no | The key store path is required if client authentication is enabled on the target JVM. |
+| `otel.jmx.metrics.keystore.password` | no | The key store file password if required. |
+| `otel.jmx.metrics.keystore.type` | no | The key store type. |
+| `otel.jmx.metrics.truststore.path` | no | The trusted store path if the TLS profile is required. |
+| `otel.jmx.metrics.truststore.password` | no | The trust store file password if required. |
+| `otel.jmx.metrics.remote.profiles` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
+| `otel.jmx.metrics.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -13,13 +13,13 @@ $ java -D<otel.jmx.metrics.property=value> -jar io.opentelemetry.contrib.jmx-met
 ##### `optional_config.properties` example
 
 ```properties
-otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
-otel.jmx.metrics.groovy.script = /opt/script.groovy
-otel.jmx.metrics.interval.seconds = 5
-otel.jmx.metrics.exporter.type = otlp
-otel.jmx.metrics.exporter.otlp.endpoint = my-opentelemetry-collector:55680
-otel.jmx.metrics.username = my-username
-otel.jmx.metrics.password = my-password
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
+otel.jmx.groovy.script = /opt/script.groovy
+otel.jmx.interval.milliseconds = 5000
+otel.exporter = otlp
+otel.otlp.endpoint = my-opentelemetry-collector:55680
+otel.jmx.username = my-username
+otel.jmx.password = my-password
 ```
 
 ##### `script.groovy` example
@@ -40,10 +40,10 @@ lvr.record(load.Count, Labels.of("myKey", "myVal"))
 ```
 
 As configured in the example, this metric gatherer will configure an otlp gRPC metric exporter
-at the `otel.jmx.metrics.exporter.otlp.endpoint` and establish an MBean server connection using the
-provided `otel.jmx.metrics.service.url`. After loading the Groovy script whose path is specified
-via `otel.jmx.metrics.groovy.script`, it will then run the script on the specified
-`otel.jmx.metrics.interval.seconds` and export the resulting metrics.
+at the `otel.otlp.endpoint` and establish an MBean server connection using the
+provided `otel.jmx.service.url`. After loading the Groovy script whose path is specified
+via `otel.jmx.groovy.script`, it will then run the script on the specified
+`otel.jmx.interval.milliseconds` and export the resulting metrics.
 
 ### JMX Query Helpers
 
@@ -94,19 +94,22 @@ Those provided as command line properties take priority of those contained in a 
 
 | Property | Required | Description |
 | ------------- | -------- | ----------- |
-| `otel.jmx.metrics.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
-| `otel.jmx.metrics.groovy.script` | **yes** | The path for the desired Groovy script. |
-| `otel.jmx.metrics.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10 by default. |
-| `otel.jmx.metrics.exporter.type` | no | The type of `io.opentelemetry.sdk.metrics.export.MetricExporter` to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
-| `otel.jmx.metrics.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
-| `otel.jmx.metrics.exporter.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
-| `otel.jmx.metrics.exporter.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
-| `otel.jmx.metrics.username` | no | Username for JMX authentication, if applicable. |
-| `otel.jmx.metrics.password` | no | Password for JMX authentication, if applicable. |
-| `otel.jmx.metrics.keystore.path` | no | The key store path is required if client authentication is enabled on the target JVM. |
-| `otel.jmx.metrics.keystore.password` | no | The key store file password if required. |
-| `otel.jmx.metrics.keystore.type` | no | The key store type. |
-| `otel.jmx.metrics.truststore.path` | no | The trusted store path if the TLS profile is required. |
-| `otel.jmx.metrics.truststore.password` | no | The trust store file password if required. |
-| `otel.jmx.metrics.remote.profiles` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
-| `otel.jmx.metrics.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |
+| `otel.jmx.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
+| `otel.jmx.groovy.script` | **yes** | The path for the desired Groovy script. |
+| `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10 by default. |
+| `otel.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
+| `otel.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
+| `otel.otlp.metric.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |
+| `otel.otlp.use.tls` | no | Whether to use TLS for otlp channel.  Setting any value evaluates to `true`. |
+| `otel.otlp.metadata` | no | Any headers to include in otlp exporter metric submissions.  Of the form `'header1=value1;header2=value2'` |
+| `otel.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
+| `otel.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
+| `otel.jmx.username` | no | Username for JMX authentication, if applicable. |
+| `otel.jmx.password` | no | Password for JMX authentication, if applicable. |
+| `javax.net.ssl.keyStore` | no | The key store path is required if client authentication is enabled on the target JVM. |
+| `javax.net.ssl.keyStorePassword` | no | The key store file password if required. |
+| `javax.net.ssl.keyStoreType` | no | The key store type. |
+| `javax.net.ssl.trustStore` | no | The trusted store path if the TLS profile is required. |
+| `javax.net.ssl.trustStorePassword` | no | The trust store file password if required. |
+| `otel.jmx.remote.profiles` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
+| `otel.jmx.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -111,5 +111,5 @@ Those provided as command line properties take priority of those contained in a 
 | `javax.net.ssl.keyStoreType` | no | The key store type. |
 | `javax.net.ssl.trustStore` | no | The trusted store path if the TLS profile is required. |
 | `javax.net.ssl.trustStorePassword` | no | The trust store file password if required. |
-| `otel.jmx.remote.profiles` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
+| `otel.jmx.remote.profile` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
 | `otel.jmx.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -96,7 +96,7 @@ Those provided as command line properties take priority of those contained in a 
 | ------------- | -------- | ----------- |
 | `otel.jmx.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
 | `otel.jmx.groovy.script` | **yes** | The path for the desired Groovy script. |
-| `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10 by default. |
+| `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10000 by default. |
 | `otel.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
 | `otel.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
 | `otel.otlp.metric.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -7,7 +7,7 @@ object with methods for obtaining MBeans and constructing synchronous OpenTeleme
 ### Usage
 
 ```bash
-$ java -D<otel.jmx.metrics.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config ./optional_config.properties]
+$ java -D<otel.jmx.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config ./optional_config.properties]
 ```
 
 ##### `optional_config.properties` example

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.github.johnrengelman.shadow" version "6.0.0"
+    id "application"
 }
 
 apply from: project.contrib
@@ -21,11 +22,7 @@ sourceSets.test.groovy.srcDirs = [
 sourceSets.main.java.srcDirs = []
 sourceSets.test.java.srcDirs = []
 
-jar {
-    manifest {
-        attributes('Main-Class': 'io.opentelemetry.contrib.jmxmetrics.JmxMetrics')
-    }
-}
+mainClassName = 'io.opentelemetry.contrib.jmxmetrics.JmxMetrics'
 
 def versions = [
     grpc : '1.30.2',

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -27,19 +27,18 @@ jar {
     }
 }
 
-ext {
-    versions = [
-        grpc : '1.30.2',
-        protobuf : '3.11.4',
-        groovy : '2.5.11',
-        slf4j : "1.7.30",
-        prometheus: "0.8.1",
-    ]
-    deps = [
-        slf4j                       : "org.slf4j:slf4j-api:${versions.slf4j}",
-        testcontainers              : "org.testcontainers:testcontainers:1.14.3",
-    ]
-}
+def versions = [
+    grpc : '1.30.2',
+    protobuf : '3.11.4',
+    groovy : '2.5.11',
+    slf4j : "1.7.30",
+    prometheus: "0.8.1",
+]
+
+def deps = [
+    slf4j : "org.slf4j:slf4j-api:${versions.slf4j}",
+    testcontainers : "org.testcontainers:testcontainers:1.14.3",
+]
 
 dependencies {
     implementation "com.google.guava:guava:25.0-jre",

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -38,10 +38,7 @@ def deps = [
 ]
 
 dependencies {
-    implementation "com.google.guava:guava:25.0-jre",
-            "com.google.protobuf:protobuf-java:${versions.protobuf}",
-            "com.google.protobuf:protobuf-java-util:${versions.protobuf}",
-            "io.grpc:grpc-netty-shaded:${versions.grpc}",
+    implementation "io.grpc:grpc-netty-shaded:${versions.grpc}",
             "org.codehaus.groovy:groovy-jmx:${versions.groovy}",
             "org.codehaus.groovy:groovy:${versions.groovy}",
             "io.prometheus:simpleclient:${versions.prometheus}",

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -1,0 +1,79 @@
+plugins {
+    id "com.github.johnrengelman.shadow" version "6.0.0"
+}
+
+apply from: project.contrib
+apply plugin: 'com.github.johnrengelman.shadow'
+
+archivesBaseName = 'io.opentelemetry.contrib.jmx-metrics'
+
+description = 'JMX metrics gathering Groovy script runner'
+
+// we are joint compiling so rely on groovy plugin entirely
+sourceSets.main.groovy.srcDirs = [
+    "src/main/java",
+    "src/main/groovy"
+]
+sourceSets.test.groovy.srcDirs = [
+    "src/test/java",
+    "src/test/groovy"
+]
+sourceSets.main.java.srcDirs = []
+sourceSets.test.java.srcDirs = []
+
+jar {
+    manifest {
+        attributes('Main-Class': 'io.opentelemetry.contrib.jmxmetrics.JmxMetrics')
+    }
+}
+
+ext {
+    versions = [
+        grpc : '1.30.2',
+        protobuf : '3.11.4',
+        groovy : '2.5.11',
+        slf4j : "1.7.30",
+        prometheus: "0.8.1",
+    ]
+    deps = [
+        slf4j                       : "org.slf4j:slf4j-api:${versions.slf4j}",
+        testcontainers              : "org.testcontainers:testcontainers:1.14.3",
+    ]
+}
+
+dependencies {
+    implementation "com.google.guava:guava:25.0-jre",
+            "com.google.protobuf:protobuf-java:${versions.protobuf}",
+            "com.google.protobuf:protobuf-java-util:${versions.protobuf}",
+            "io.grpc:grpc-netty-shaded:${versions.grpc}",
+            "org.codehaus.groovy:groovy-jmx:${versions.groovy}",
+            "org.codehaus.groovy:groovy:${versions.groovy}",
+            "io.prometheus:simpleclient:${versions.prometheus}",
+            "io.prometheus:simpleclient_httpserver:${versions.prometheus}",
+            libraries.otelApi,
+            libraries.otelExporterLogging,
+            libraries.otelExporterOtlp,
+            libraries.otelExporterPrometheus,
+            libraries.otelExporterInMemory,
+            libraries.otelSdk,
+            deps.slf4j,
+            dependencies.create(group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j)
+
+    runtime "org.terracotta:jmxremote_optional-tc:1.0.5"
+
+    testImplementation "io.grpc:grpc-api:${versions.grpc}",
+            "io.grpc:grpc-protobuf:${versions.grpc}",
+            "io.grpc:grpc-stub:${versions.grpc}",
+            "io.grpc:grpc-testing:${versions.grpc}",
+            "org.codehaus.groovy:groovy-test:${versions.groovy}",
+            'io.rest-assured:rest-assured:4.2.0',
+            'org.awaitility:awaitility:3.0.0',
+            'org.apache.httpcomponents.client5:httpclient5-fluent:5.0.1',
+            deps.testcontainers,
+            libraries.otelProto
+}
+
+tasks.withType(Test) {
+    dependsOn shadowJar
+    systemProperty 'shadow.jar.path', shadowJar.archiveFile.asFile.get().path
+}

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -30,11 +30,11 @@ class OtelHelper {
     private static final String SCALAR = '1'
 
     private final JmxClient jmxClient
-    private final GroovyUtils groovyUtils
+    private final GroovyMetricEnvironment groovyMetricEnvironment
 
-    OtelHelper(JmxClient jmxClient, GroovyUtils groovyUtils) {
+    OtelHelper(JmxClient jmxClient, GroovyMetricEnvironment groovyMetricEnvironment) {
         this.jmxClient = jmxClient
-        this.groovyUtils = groovyUtils
+        this.groovyMetricEnvironment = groovyMetricEnvironment
     }
 
     /**
@@ -59,7 +59,7 @@ class OtelHelper {
     }
 
     DoubleCounter doubleCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getDoubleCounter(name, description, unit, labels)
+        return groovyMetricEnvironment.getDoubleCounter(name, description, unit, labels)
     }
 
     DoubleCounter doubleCounter(String name, String description, String unit) {
@@ -75,7 +75,7 @@ class OtelHelper {
     }
 
     LongCounter longCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getLongCounter(name, description, unit, labels)
+        return groovyMetricEnvironment.getLongCounter(name, description, unit, labels)
     }
 
     LongCounter longCounter(String name, String description, String unit) {
@@ -91,7 +91,7 @@ class OtelHelper {
     }
 
     DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getDoubleUpDownCounter(name, description, unit, labels)
+        return groovyMetricEnvironment.getDoubleUpDownCounter(name, description, unit, labels)
     }
 
     DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit) {
@@ -107,7 +107,7 @@ class OtelHelper {
     }
 
     LongUpDownCounter longUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getLongUpDownCounter(name, description, unit, labels)
+        return groovyMetricEnvironment.getLongUpDownCounter(name, description, unit, labels)
     }
 
     LongUpDownCounter longUpDownCounter(String name, String description, String unit) {
@@ -123,7 +123,7 @@ class OtelHelper {
     }
 
     DoubleValueRecorder doubleValueRecorder(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getDoubleValueRecorder(name, description, unit, labels)
+        return groovyMetricEnvironment.getDoubleValueRecorder(name, description, unit, labels)
     }
 
     DoubleValueRecorder doubleValueRecorder(String name, String description, String unit) {
@@ -139,7 +139,7 @@ class OtelHelper {
     }
 
     LongValueRecorder longValueRecorder(String name, String description, String unit, Map<String, String> labels) {
-        return groovyUtils.getLongValueRecorder(name, description, unit, labels)
+        return groovyMetricEnvironment.getLongValueRecorder(name, description, unit, labels)
     }
 
     LongValueRecorder longValueRecorder(String name, String description, String unit) {

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -27,11 +27,10 @@ import javax.management.MBeanServerConnection
 import javax.management.ObjectName
 
 class OtelHelper {
+    private static final String SCALAR = '1'
 
     private final JmxClient jmxClient
     private final GroovyUtils groovyUtils
-
-    final String scalar = '1'
 
     OtelHelper(JmxClient jmxClient, GroovyUtils groovyUtils) {
         this.jmxClient = jmxClient
@@ -68,7 +67,7 @@ class OtelHelper {
     }
 
     DoubleCounter doubleCounter(String name, String description) {
-        return doubleCounter(name, description, scalar)
+        return doubleCounter(name, description, SCALAR)
     }
 
     DoubleCounter doubleCounter(String name) {
@@ -84,7 +83,7 @@ class OtelHelper {
     }
 
     LongCounter longCounter(String name, String description) {
-        return longCounter(name, description, scalar)
+        return longCounter(name, description, SCALAR)
     }
 
     LongCounter longCounter(String name) {
@@ -100,7 +99,7 @@ class OtelHelper {
     }
 
     DoubleUpDownCounter doubleUpDownCounter(String name, String description) {
-        return doubleUpDownCounter(name, description, scalar)
+        return doubleUpDownCounter(name, description, SCALAR)
     }
 
     DoubleUpDownCounter doubleUpDownCounter(String name) {
@@ -116,7 +115,7 @@ class OtelHelper {
     }
 
     LongUpDownCounter longUpDownCounter(String name, String description) {
-        return longUpDownCounter(name, description, scalar)
+        return longUpDownCounter(name, description, SCALAR)
     }
 
     LongUpDownCounter longUpDownCounter(String name) {
@@ -132,7 +131,7 @@ class OtelHelper {
     }
 
     DoubleValueRecorder doubleValueRecorder(String name, String description) {
-        return doubleValueRecorder(name, description, scalar)
+        return doubleValueRecorder(name, description, SCALAR)
     }
 
     DoubleValueRecorder doubleValueRecorder(String name) {
@@ -148,7 +147,7 @@ class OtelHelper {
     }
 
     LongValueRecorder longValueRecorder(String name, String description) {
-        return longValueRecorder(name, description, scalar)
+        return longValueRecorder(name, description, SCALAR)
     }
 
     LongValueRecorder longValueRecorder(String name) {

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -1,0 +1,157 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import io.opentelemetry.metrics.DoubleCounter
+import io.opentelemetry.metrics.DoubleUpDownCounter
+import io.opentelemetry.metrics.DoubleValueRecorder
+import io.opentelemetry.metrics.LongCounter
+import io.opentelemetry.metrics.LongUpDownCounter
+import io.opentelemetry.metrics.LongValueRecorder
+
+import javax.management.MBeanServerConnection
+import javax.management.ObjectName
+
+class OtelHelper {
+
+    private final JmxClient jmxClient
+    private final GroovyUtils groovyUtils
+
+    final String scalar = '1'
+
+    OtelHelper(JmxClient jmxClient, GroovyUtils groovyUtils) {
+        this.jmxClient = jmxClient
+        this.groovyUtils = groovyUtils
+    }
+
+    /**
+     * Returns a list of {@link GroovyMBean} for a given object name String.
+     * @param objNameStr - the {@link String} representation of an object name or pattern, to be
+     * used as the argument to the basic {@link ObjectName} constructor for the JmxClient query.
+     * @return a {@link List<GroovyMBean>} from which to create metrics.
+     */
+    List<GroovyMBean> queryJmx(String objNameStr) {
+        return queryJmx(new ObjectName(objNameStr))
+    }
+
+    /**
+     * Returns a list of {@link GroovyMBean} for a given {@link ObjectName}.
+     * @param objName - the {@link ObjectName} used for the JmxClient query.
+     * @return a {@link List<GroovyMBean>} from which to create metrics.
+     */
+    List<GroovyMBean> queryJmx(ObjectName objName) {
+        Set<ObjectName> names = jmxClient.query(objName)
+        MBeanServerConnection server = jmxClient.connection
+        return names.collect { new GroovyMBean(server, it) }
+    }
+
+    DoubleCounter doubleCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleCounter(name, description, unit, labels)
+    }
+
+    DoubleCounter doubleCounter(String name, String description, String unit) {
+        return doubleCounter(name, description, unit, null)
+    }
+
+    DoubleCounter doubleCounter(String name, String description) {
+        return doubleCounter(name, description, scalar)
+    }
+
+    DoubleCounter doubleCounter(String name) {
+        return doubleCounter(name, '')
+    }
+
+    LongCounter longCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongCounter(name, description, unit, labels)
+    }
+
+    LongCounter longCounter(String name, String description, String unit) {
+        return longCounter(name, description, unit, null)
+    }
+
+    LongCounter longCounter(String name, String description) {
+        return longCounter(name, description, scalar)
+    }
+
+    LongCounter longCounter(String name) {
+        return longCounter(name, '')
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleUpDownCounter(name, description, unit, labels)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit) {
+        return doubleUpDownCounter(name, description, unit, null)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name, String description) {
+        return doubleUpDownCounter(name, description, scalar)
+    }
+
+    DoubleUpDownCounter doubleUpDownCounter(String name) {
+        return doubleUpDownCounter(name, '')
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongUpDownCounter(name, description, unit, labels)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description, String unit) {
+        return longUpDownCounter(name, description, unit, null)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name, String description) {
+        return longUpDownCounter(name, description, scalar)
+    }
+
+    LongUpDownCounter longUpDownCounter(String name) {
+        return longUpDownCounter(name, '')
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getDoubleValueRecorder(name, description, unit, labels)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description, String unit) {
+        return doubleValueRecorder(name, description, unit, null)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name, String description) {
+        return doubleValueRecorder(name, description, scalar)
+    }
+
+    DoubleValueRecorder doubleValueRecorder(String name) {
+        return doubleValueRecorder(name, '')
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description, String unit, Map<String, String> labels) {
+        return groovyUtils.getLongValueRecorder(name, description, unit, labels)
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description, String unit) {
+        return longValueRecorder(name, description, unit, null)
+    }
+
+    LongValueRecorder longValueRecorder(String name, String description) {
+        return longValueRecorder(name, description, scalar)
+    }
+
+    LongValueRecorder longValueRecorder(String name) {
+        return longValueRecorder(name, '')
+    }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ClientCallbackHandler.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ClientCallbackHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import javax.annotation.Nullable;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+public class ClientCallbackHandler implements CallbackHandler {
+  private final String username;
+  @Nullable private char[] password;
+  private final String realm;
+
+  /**
+   * Constructor for the {@link ClientCallbackHandler}, a CallbackHandler implementation for
+   * authenticating with an MBean server.
+   *
+   * @param username - authenticating username
+   * @param password - authenticating password (plaintext)
+   * @param realm - authenticating realm
+   */
+  public ClientCallbackHandler(final String username, final String password, final String realm) {
+    this.username = username;
+    if (password != null) {
+      this.password = password.toCharArray();
+    }
+    this.realm = realm;
+  }
+
+  @Override
+  public void handle(final Callback[] callbacks) throws UnsupportedCallbackException {
+    for (Callback callback : callbacks) {
+      if (callback instanceof NameCallback) {
+        ((NameCallback) callback).setName(this.username);
+      } else if (callback instanceof PasswordCallback) {
+        ((PasswordCallback) callback).setPassword(this.password);
+      } else if (callback instanceof RealmCallback) {
+        ((RealmCallback) callback).setText(this.realm);
+      } else {
+        throw new UnsupportedCallbackException(callback);
+      }
+    }
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ClientCallbackHandler.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ClientCallbackHandler.java
@@ -26,7 +26,7 @@ import javax.security.sasl.RealmCallback;
 
 public class ClientCallbackHandler implements CallbackHandler {
   private final String username;
-  @Nullable private char[] password;
+  @Nullable private final char[] password;
   private final String realm;
 
   /**
@@ -39,9 +39,7 @@ public class ClientCallbackHandler implements CallbackHandler {
    */
   public ClientCallbackHandler(final String username, final String password, final String realm) {
     this.username = username;
-    if (password != null) {
-      this.password = password.toCharArray();
-    }
+    this.password = password != null ? password.toCharArray() : null;
     this.realm = realm;
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ConfigurationException.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ConfigurationException.java
@@ -16,14 +16,14 @@
 
 package io.opentelemetry.contrib.jmxmetrics;
 
-public class ConfigureError extends RuntimeException {
+public class ConfigurationException extends RuntimeException {
   private static final long serialVersionUID = 0L;
 
-  public ConfigureError(final String message, final Throwable cause) {
+  public ConfigurationException(final String message, final Throwable cause) {
     super(message, cause);
   }
 
-  public ConfigureError(final String message) {
+  public ConfigurationException(final String message) {
     super(message);
   }
 }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ConfigureError.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/ConfigureError.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+public class ConfigureError extends RuntimeException {
+  private static final long serialVersionUID = 0L;
+
+  public ConfigureError(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public ConfigureError(final String message) {
+    super(message);
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-public class GroovyUtils {
+public class GroovyMetricEnvironment {
 
   private final Meter meter;
   private MetricExporter exporter;
@@ -52,7 +52,7 @@ public class GroovyUtils {
    * @param instrumentationName - meter's instrumentationName
    * @param instrumentationVersion - meter's instrumentationVersion
    */
-  public GroovyUtils(
+  public GroovyMetricEnvironment(
       final JmxConfig config,
       final String instrumentationName,
       final String instrumentationVersion) {
@@ -79,8 +79,8 @@ public class GroovyUtils {
    *
    * @param config - used to establish exporter type (logging by default) and connection info
    */
-  public GroovyUtils(final JmxConfig config) {
-    this(config, "jmx-metrics", "0.0.1");
+  public GroovyMetricEnvironment(final JmxConfig config) {
+    this(config, "io.opentelemetry.contrib.jmxmetrics", "0.0.1");
   }
 
   private static MetricProducer getMetricProducer() {

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -34,10 +34,13 @@ public class GroovyRunner {
   private static final Logger logger = Logger.getLogger(GroovyRunner.class.getName());
 
   private final Script script;
-  private final GroovyUtils gutil;
+  private final GroovyMetricEnvironment groovyMetricEnvironment;
 
-  GroovyRunner(final String groovyScript, final JmxClient jmxClient, final GroovyUtils gutil) {
-    this.gutil = gutil;
+  GroovyRunner(
+      final String groovyScript,
+      final JmxClient jmxClient,
+      final GroovyMetricEnvironment groovyMetricEnvironment) {
+    this.groovyMetricEnvironment = groovyMetricEnvironment;
 
     String scriptSource;
     try {
@@ -57,7 +60,7 @@ public class GroovyRunner {
     Binding binding = new Binding();
     binding.setVariable("log", logger);
 
-    OtelHelper otelHelper = new OtelHelper(jmxClient, this.gutil);
+    OtelHelper otelHelper = new OtelHelper(jmxClient, this.groovyMetricEnvironment);
     binding.setVariable("otel", otelHelper);
 
     script.setBinding(binding);
@@ -91,11 +94,11 @@ public class GroovyRunner {
   }
 
   public void flush() {
-    gutil.exportMetrics();
+    groovyMetricEnvironment.exportMetrics();
   }
 
   public void shutdown() {
     flush();
-    gutil.shutdown();
+    groovyMetricEnvironment.shutdown();
   }
 }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.codehaus.groovy.control.CompilationFailedException;
+
+public class GroovyRunner {
+  private static final Logger logger = Logger.getLogger(GroovyRunner.class.getName());
+
+  private final GroovyShell gshell = new GroovyShell();
+
+  private final Script script;
+  private final GroovyUtils gutil;
+
+  GroovyRunner(final String groovyScript, final JmxClient jmxClient, final GroovyUtils gutil) {
+    this.gutil = gutil;
+
+    String scriptSource;
+    try {
+      scriptSource = getFileAsString(groovyScript);
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to read groovy script", e);
+      throw new ConfigureError("Failed to read groovy script", e);
+    }
+
+    try {
+      this.script = gshell.parse(scriptSource);
+    } catch (CompilationFailedException e) {
+      logger.log(Level.SEVERE, "Failed to compile groovy script", e);
+      throw new ConfigureError("Failed to compile groovy script", e);
+    }
+
+    Binding binding = new Binding();
+    binding.setVariable("log", logger);
+
+    OtelHelper otelHelper = new OtelHelper(jmxClient, gutil);
+    binding.setVariable("otel", otelHelper);
+
+    script.setBinding(binding);
+  }
+
+  static String getFileAsString(final String fileName) throws IOException {
+    try (InputStream is = new FileInputStream(fileName)) {
+      return getFileFromInputStream(is);
+    }
+  }
+
+  static String getFileFromInputStream(final InputStream is) throws IOException {
+    if (is == null) {
+      return null;
+    }
+    try (InputStreamReader isr = new InputStreamReader(is, UTF_8);
+        BufferedReader reader = new BufferedReader(isr)) {
+      StringBuilder file = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        file.append(System.lineSeparator());
+        file.append(line);
+      }
+      return file.toString();
+    }
+  }
+
+  public void run() {
+    script.run();
+    flush();
+  }
+
+  public void flush() {
+    gutil.exportMetrics();
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -46,14 +46,14 @@ public class GroovyRunner {
       scriptSource = getFileAsString(groovyScript);
     } catch (IOException e) {
       logger.log(Level.SEVERE, "Failed to read groovy script", e);
-      throw new ConfigureError("Failed to read groovy script", e);
+      throw new ConfigurationException("Failed to read groovy script", e);
     }
 
     try {
       this.script = gshell.parse(scriptSource);
     } catch (CompilationFailedException e) {
       logger.log(Level.SEVERE, "Failed to compile groovy script", e);
-      throw new ConfigureError("Failed to compile groovy script", e);
+      throw new ConfigurationException("Failed to compile groovy script", e);
     }
 
     Binding binding = new Binding();

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -93,4 +93,9 @@ public class GroovyRunner {
   public void flush() {
     gutil.exportMetrics();
   }
+
+  public void shutdown() {
+    flush();
+    gutil.shutdown();
+  }
 }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -33,8 +33,6 @@ import org.codehaus.groovy.control.CompilationFailedException;
 public class GroovyRunner {
   private static final Logger logger = Logger.getLogger(GroovyRunner.class.getName());
 
-  private final GroovyShell gshell = new GroovyShell();
-
   private final Script script;
   private final GroovyUtils gutil;
 
@@ -50,7 +48,7 @@ public class GroovyRunner {
     }
 
     try {
-      this.script = gshell.parse(scriptSource);
+      this.script = new GroovyShell().parse(scriptSource);
     } catch (CompilationFailedException e) {
       logger.log(Level.SEVERE, "Failed to compile groovy script", e);
       throw new ConfigurationException("Failed to compile groovy script", e);
@@ -59,7 +57,7 @@ public class GroovyRunner {
     Binding binding = new Binding();
     binding.setVariable("log", logger);
 
-    OtelHelper otelHelper = new OtelHelper(jmxClient, gutil);
+    OtelHelper otelHelper = new OtelHelper(jmxClient, this.gutil);
     binding.setVariable("otel", otelHelper);
 
     script.setBinding(binding);

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
@@ -18,7 +18,6 @@ package io.opentelemetry.contrib.jmxmetrics;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.Labels;
-import io.opentelemetry.common.Labels.Builder;
 import io.opentelemetry.exporters.inmemory.InMemoryMetricExporter;
 import io.opentelemetry.exporters.logging.LoggingMetricExporter;
 import io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter;
@@ -61,8 +60,7 @@ public class GroovyUtils {
 
     switch (config.exporterType.toLowerCase()) {
       case "otlp":
-        exporter =
-            OtlpGrpcMetricExporter.newBuilder().setEndpoint(config.otlpExporterEndpoint).build();
+        exporter = OtlpGrpcMetricExporter.newBuilder().readProperties(config.properties).build();
         break;
       case "prometheus":
         configurePrometheus(config);
@@ -108,7 +106,7 @@ public class GroovyUtils {
   }
 
   private static Labels mapToLabels(final Map<String, String> labelMap) {
-    Builder labels = new Builder();
+    Labels.Builder labels = new Labels.Builder();
     if (labelMap != null) {
       for (Map.Entry<String, String> kv : labelMap.entrySet()) {
         labels.setLabel(kv.getKey(), kv.getValue());

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.common.Labels;
+import io.opentelemetry.common.Labels.Builder;
+import io.opentelemetry.exporters.inmemory.InMemoryMetricExporter;
+import io.opentelemetry.exporters.logging.LoggingMetricExporter;
+import io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporters.prometheus.PrometheusCollector;
+import io.opentelemetry.metrics.DoubleCounter;
+import io.opentelemetry.metrics.DoubleUpDownCounter;
+import io.opentelemetry.metrics.DoubleValueRecorder;
+import io.opentelemetry.metrics.LongCounter;
+import io.opentelemetry.metrics.LongUpDownCounter;
+import io.opentelemetry.metrics.LongValueRecorder;
+import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
+import io.prometheus.client.exporter.HTTPServer;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+public class GroovyUtils {
+
+  public Meter meter;
+  public MetricExporter exporter;
+  public HTTPServer prometheusServer;
+
+  /**
+   * A central context for creating and exporting metrics, to be used by groovy scripts via {@link
+   * io.opentelemetry.contrib.jmxmetrics.OtelHelper}.
+   *
+   * @param config - used to establish exporter type (logging by default) and connection info
+   * @param instrumentationName - meter's instrumentationName
+   * @param instrumentationVersion - meter's instrumentationVersion
+   */
+  public GroovyUtils(
+      final JmxConfig config,
+      final String instrumentationName,
+      final String instrumentationVersion) {
+    meter = OpenTelemetry.getMeter(instrumentationName, instrumentationVersion);
+
+    switch (config.exporterType.toLowerCase()) {
+      case "otlp":
+        exporter =
+            OtlpGrpcMetricExporter.newBuilder().setEndpoint(config.otlpExporterEndpoint).build();
+        break;
+      case "prometheus":
+        configurePrometheus(config);
+        break;
+      case "inmemory":
+        exporter = InMemoryMetricExporter.create();
+        break;
+      default:
+        exporter = new LoggingMetricExporter();
+        break;
+    }
+  }
+
+  /**
+   * Configures with default meter identifiers.
+   *
+   * @param config - used to establish exporter type (logging by default) and connection info
+   */
+  public GroovyUtils(final JmxConfig config) {
+    this(config, "jmx-metrics", "0.0.1");
+  }
+
+  private static MetricProducer getMetricProducer() {
+    return OpenTelemetrySdk.getMeterProvider().getMetricProducer();
+  }
+
+  private void configurePrometheus(final JmxConfig config) {
+    PrometheusCollector.newBuilder().setMetricProducer(getMetricProducer()).buildAndRegister();
+    try {
+      prometheusServer =
+          new HTTPServer(config.prometheusExporterHost, config.prometheusExporterPort);
+    } catch (IOException e) {
+      throw new ConfigureError("Cannot configure prometheus exporter server:", e);
+    }
+  }
+
+  /** Will collect all metrics from OpenTelemetrySdk and export via configured exporter. */
+  public void exportMetrics() {
+    if (exporter != null) {
+      Collection<MetricData> md = getMetricProducer().collectAllMetrics();
+      exporter.export(md);
+    }
+  }
+
+  private static Labels mapToLabels(final Map<String, String> labelMap) {
+    Builder labels = new Builder();
+    if (labelMap != null) {
+      for (Map.Entry<String, String> kv : labelMap.entrySet()) {
+        labels.setLabel(kv.getKey(), kv.getValue());
+      }
+    }
+    return labels.build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleCounter}
+   */
+  public DoubleCounter getDoubleCounter(
+      final String name,
+      final String description,
+      final String unit,
+      final Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongCounter}
+   */
+  public LongCounter getLongCounter(
+      final String name,
+      final String description,
+      final String unit,
+      final Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleUpDownCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleUpDownCounter}
+   */
+  public DoubleUpDownCounter getDoubleUpDownCounter(
+      final String name,
+      final String description,
+      final String unit,
+      Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleUpDownCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongUpDownCounter}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongUpDownCounter}
+   */
+  public LongUpDownCounter getLongUpDownCounter(
+      final String name,
+      final String description,
+      final String unit,
+      final Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longUpDownCounterBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link DoubleValueRecorder}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link DoubleValueRecorder}
+   */
+  public DoubleValueRecorder getDoubleValueRecorder(
+      final String name,
+      final String description,
+      final String unit,
+      final Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .doubleValueRecorderBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+
+  /**
+   * Build or retrieve previously registered {@link LongValueRecorder}.
+   *
+   * @param name - metric name
+   * @param description metric description
+   * @param unit - metric unit
+   * @param constantLabels - metric descriptor's constant labels
+   * @return new or memoized {@link LongValueRecorder}
+   */
+  public LongValueRecorder getLongValueRecorder(
+      final String name,
+      final String description,
+      final String unit,
+      final Map<String, String> constantLabels) {
+    Labels labels = mapToLabels(constantLabels);
+    return meter
+        .longValueRecorderBuilder(name)
+        .setDescription(description)
+        .setUnit(unit)
+        .setConstantLabels(labels)
+        .build();
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
@@ -40,9 +40,9 @@ import java.util.Map;
 
 public class GroovyUtils {
 
-  public Meter meter;
-  public MetricExporter exporter;
-  public HTTPServer prometheusServer;
+  private final Meter meter;
+  private MetricExporter exporter;
+  private HTTPServer prometheusServer;
 
   /**
    * A central context for creating and exporting metrics, to be used by groovy scripts via {@link
@@ -102,6 +102,12 @@ public class GroovyUtils {
     if (exporter != null) {
       Collection<MetricData> md = getMetricProducer().collectAllMetrics();
       exporter.export(md);
+    }
+  }
+
+  public void shutdown() {
+    if (prometheusServer != null) {
+      prometheusServer.stop();
     }
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyUtils.java
@@ -93,7 +93,7 @@ public class GroovyUtils {
       prometheusServer =
           new HTTPServer(config.prometheusExporterHost, config.prometheusExporterPort);
     } catch (IOException e) {
-      throw new ConfigureError("Cannot configure prometheus exporter server:", e);
+      throw new ConfigurationException("Cannot configure prometheus exporter server:", e);
     }
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
@@ -41,7 +41,7 @@ public class JmxClient {
   private final String username;
   private final String password;
   private final String realm;
-  private final String remoteProfiles;
+  private final String remoteProfile;
   @Nullable private JMXConnector jmxConn;
 
   JmxClient(final JmxConfig config) throws MalformedURLException {
@@ -49,7 +49,7 @@ public class JmxClient {
     this.username = config.username;
     this.password = config.password;
     this.realm = config.realm;
-    this.remoteProfiles = config.remoteProfiles;
+    this.remoteProfile = config.remoteProfile;
   }
 
   public MBeanServerConnection getConnection() {
@@ -71,7 +71,7 @@ public class JmxClient {
         Provider provider = (Provider) klass.getDeclaredConstructor().newInstance();
         Security.addProvider(provider);
 
-        env.put("jmx.remote.profiles", this.remoteProfiles);
+        env.put("jmx.remote.profile", this.remoteProfile);
         env.put(
             "jmx.remote.sasl.callback.handler",
             new ClientCallbackHandler(this.username, this.password, this.realm));

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
@@ -39,34 +39,15 @@ public class JmxClient {
   private final String username;
   private final String password;
   private final String realm;
-  private final String jmxRemoteProfiles;
+  private final String remoteProfiles;
   @Nullable private JMXConnector jmxConn;
 
   JmxClient(final JmxConfig config) throws MalformedURLException {
-    setSystemProperties(config);
     this.url = new JMXServiceURL(config.serviceUrl);
     this.username = config.username;
     this.password = config.password;
     this.realm = config.realm;
-    this.jmxRemoteProfiles = config.jmxRemoteProfiles;
-  }
-
-  private static void setSystemProperties(final JmxConfig config) {
-    if (!JmxConfig.isBlank(config.keyStorePath)) {
-      System.setProperty("javax.net.ssl.keyStore", config.keyStorePath);
-    }
-    if (!JmxConfig.isBlank(config.keyStorePassword)) {
-      System.setProperty("javax.net.ssl.keyStorePassword", config.keyStorePassword);
-    }
-    if (!JmxConfig.isBlank(config.keyStoreType)) {
-      System.setProperty("javax.net.ssl.keyStoreType", config.keyStoreType);
-    }
-    if (!JmxConfig.isBlank(config.trustStorePath)) {
-      System.setProperty("javax.net.ssl.trustStore", config.trustStorePath);
-    }
-    if (!JmxConfig.isBlank(config.trustStorePassword)) {
-      System.setProperty("javax.net.ssl.trustStorePassword", config.trustStorePassword);
-    }
+    this.remoteProfiles = config.remoteProfiles;
   }
 
   private MBeanServerConnection ensureConnected() {
@@ -88,7 +69,7 @@ public class JmxClient {
         Provider provider = (Provider) klass.getDeclaredConstructor().newInstance();
         Security.addProvider(provider);
 
-        env.put("jmx.remote.profiles", this.jmxRemoteProfiles);
+        env.put("jmx.remote.profiles", this.remoteProfiles);
         env.put(
             "jmx.remote.sasl.callback.handler",
             new ClientCallbackHandler(this.username, this.password, this.realm));

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxClient.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+public class JmxClient {
+  private static final Logger logger = Logger.getLogger(JmxClient.class.getName());
+
+  private final JMXServiceURL url;
+  private final String username;
+  private final String password;
+  private final String realm;
+  private final String jmxRemoteProfiles;
+  @Nullable private JMXConnector jmxConn;
+
+  JmxClient(final JmxConfig config) throws MalformedURLException {
+    setSystemProperties(config);
+    this.url = new JMXServiceURL(config.serviceUrl);
+    this.username = config.username;
+    this.password = config.password;
+    this.realm = config.realm;
+    this.jmxRemoteProfiles = config.jmxRemoteProfiles;
+  }
+
+  private static void setSystemProperties(final JmxConfig config) {
+    if (!JmxConfig.isBlank(config.keyStorePath)) {
+      System.setProperty("javax.net.ssl.keyStore", config.keyStorePath);
+    }
+    if (!JmxConfig.isBlank(config.keyStorePassword)) {
+      System.setProperty("javax.net.ssl.keyStorePassword", config.keyStorePassword);
+    }
+    if (!JmxConfig.isBlank(config.keyStoreType)) {
+      System.setProperty("javax.net.ssl.keyStoreType", config.keyStoreType);
+    }
+    if (!JmxConfig.isBlank(config.trustStorePath)) {
+      System.setProperty("javax.net.ssl.trustStore", config.trustStorePath);
+    }
+    if (!JmxConfig.isBlank(config.trustStorePassword)) {
+      System.setProperty("javax.net.ssl.trustStorePassword", config.trustStorePassword);
+    }
+  }
+
+  private MBeanServerConnection ensureConnected() {
+    if (jmxConn != null) {
+      try {
+        return jmxConn.getMBeanServerConnection();
+      } catch (IOException e) {
+        // Attempt to connect with authentication below.
+      }
+    }
+    try {
+      Map<String, Object> env = new HashMap<>();
+      if (!JmxConfig.isBlank(username)) {
+        env.put(JMXConnector.CREDENTIALS, new String[] {this.username, this.password});
+      }
+      try {
+        // Not all supported versions of Java contain this Provider
+        Class klass = Class.forName("com.sun.security.sasl.Provider");
+        Provider provider = (Provider) klass.getDeclaredConstructor().newInstance();
+        Security.addProvider(provider);
+
+        env.put("jmx.remote.profiles", this.jmxRemoteProfiles);
+        env.put(
+            "jmx.remote.sasl.callback.handler",
+            new ClientCallbackHandler(this.username, this.password, this.realm));
+      } catch (final ReflectiveOperationException e) {
+        logger.warning("SASL unsupported in current environment: " + e.getMessage());
+      }
+
+      jmxConn = JMXConnectorFactory.connect(url, env);
+      return jmxConn.getMBeanServerConnection();
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Could not connect to remote JMX server: ", e);
+      return null;
+    }
+  }
+
+  public MBeanServerConnection getConnection() {
+    return ensureConnected();
+  }
+
+  /**
+   * Query the MBean server for a given ObjectName.
+   *
+   * @param objectName ObjectName to query
+   * @return the set of applicable ObjectName instances found by server
+   */
+  public Set<ObjectName> query(final ObjectName objectName) {
+    MBeanServerConnection mbsc = ensureConnected();
+    if (mbsc == null) {
+      return null;
+    }
+
+    try {
+      return mbsc.queryNames(objectName, null);
+    } catch (IOException e) {
+      jmxConn = null;
+      return null;
+    }
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import java.util.Properties;
+
+public class JmxConfig {
+  public String serviceUrl;
+  public String groovyScript;
+
+  public int intervalMilliseconds;
+  public String exporterType;
+  public String otlpExporterEndpoint;
+
+  public String prometheusExporterHost;
+  public int prometheusExporterPort;
+
+  public String username;
+  public String password;
+
+  public String keyStorePath;
+  public String keyStorePassword;
+  public String keyStoreType;
+  public String trustStorePath;
+  public String trustStorePassword;
+  public String jmxRemoteProfiles;
+  public String realm;
+
+  private Properties properties;
+  private static final String prefix = "otel.jmx.metrics.";
+
+  public JmxConfig(final Properties properties) {
+    this.properties = new Properties(properties);
+    // command line takes precedence
+    this.properties.putAll(System.getProperties());
+
+    serviceUrl = getProperty("service.url", null);
+    groovyScript = getProperty("groovy.script", null);
+    try {
+      intervalMilliseconds = Integer.parseInt(getProperty("interval.milliseconds", "10000"));
+    } catch (NumberFormatException e) {
+      throw new ConfigureError("Failed to parse " + prefix + "interval.milliseconds", e);
+    }
+    exporterType = getProperty("exporter.type", "logging");
+    otlpExporterEndpoint = getProperty("exporter.otlp.endpoint", null);
+
+    prometheusExporterHost = getProperty("exporter.prometheus.host", "localhost");
+    try {
+      prometheusExporterPort = Integer.parseInt(getProperty("exporter.prometheus.port", "9090"));
+    } catch (NumberFormatException e) {
+      throw new ConfigureError("Failed to parse " + prefix + "exporter.prometheus.port", e);
+    }
+
+    username = getProperty("username", null);
+    password = getProperty("password", null);
+    keyStorePath = getProperty("keystore.path", null);
+    keyStorePassword = getProperty("keystore.password", null);
+    keyStoreType = getProperty("keystore.type", null);
+    trustStorePath = getProperty("truststore.path", null);
+    trustStorePassword = getProperty("truststore.password", null);
+    jmxRemoteProfiles = getProperty("remote.profiles", null);
+    realm = getProperty("realm", null);
+  }
+
+  public JmxConfig() {
+    this(new Properties());
+  }
+
+  private String getProperty(final String key, final String dfault) {
+    return properties.getProperty(prefix + key, dfault);
+  }
+
+  /**
+   * Will determine if parsed config is complete, setting any applicable defaults.
+   *
+   * @throws ConfigureError - Thrown if a configuration value is missing or invalid.
+   */
+  public void validate() throws ConfigureError {
+    if (isBlank(this.serviceUrl)) {
+      throw new ConfigureError(prefix + "service.url must be specified.");
+    }
+
+    if (isBlank(this.groovyScript)) {
+      throw new ConfigureError(prefix + "groovy.script must be specified.");
+    }
+
+    if (isBlank(this.otlpExporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
+      throw new ConfigureError(prefix + "exporter.endpoint must be specified for otlp format.");
+    }
+
+    if (this.intervalMilliseconds < 0) {
+      throw new ConfigureError(prefix + "interval.milliseconds must be positive.");
+    }
+
+    if (this.intervalMilliseconds == 0) {
+      this.intervalMilliseconds = 10;
+    }
+  }
+
+  /**
+   * Determines if a String is null or without non-whitespace chars.
+   *
+   * @param s - {@link String} to evaluate
+   * @return - if s is null or without non-whitespace chars.
+   */
+  public static boolean isBlank(final String s) {
+    if (s == null) {
+      return true;
+    }
+    return s.trim().length() == 0;
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -19,47 +19,50 @@ package io.opentelemetry.contrib.jmxmetrics;
 import java.util.Properties;
 
 public class JmxConfig {
-  private static final String PREFIX = "otel.";
-  private static final String SERVICE_URL = "jmx.service.url";
-  private static final String GROOVY_SCRIPT = "jmx.groovy.script";
-  private static final String INTERVAL_MILLISECONDS = "jmx.interval.milliseconds";
-  private static final String EXPORTER_TYPE = "exporter";
+  protected static final String PREFIX = "otel.";
+  protected static final String SERVICE_URL = PREFIX + "jmx.service.url";
+  protected static final String GROOVY_SCRIPT = PREFIX + "jmx.groovy.script";
+  protected static final String INTERVAL_MILLISECONDS = PREFIX + "jmx.interval.milliseconds";
+  protected static final String EXPORTER_TYPE = PREFIX + "exporter";
 
-  private static final String OTLP_ENDPOINT = "otlp.endpoint";
+  protected static final String OTLP_ENDPOINT = PREFIX + "otlp.endpoint";
 
-  private static final String PROMETHEUS_HOST = "prometheus.host";
-  private static final String PROMETHEUS_PORT = "prometheus.port";
+  protected static final String PROMETHEUS_HOST = PREFIX + "prometheus.host";
+  protected static final String PROMETHEUS_PORT = PREFIX + "prometheus.port";
 
-  private static final String JMX_USERNAME = "jmx.username";
-  private static final String JMX_PASSWORD = "jmx.password";
-  private static final String JMX_REMOTE_PROFILES = "jmx.remote.profiles";
-  private static final String JMX_REALM = "jmx.realm";
+  protected static final String JMX_USERNAME = PREFIX + "jmx.username";
+  protected static final String JMX_PASSWORD = PREFIX + "jmx.password";
+  protected static final String JMX_REMOTE_PROFILES = PREFIX + "jmx.remote.profiles";
+  protected static final String JMX_REALM = PREFIX + "jmx.realm";
 
-  public String serviceUrl;
-  public String groovyScript;
-  public int intervalMilliseconds;
-  public String exporterType;
+  public final String serviceUrl;
+  public final String groovyScript;
+  public final int intervalMilliseconds;
+  public final String exporterType;
 
-  public String otlpExporterEndpoint;
+  public final String otlpExporterEndpoint;
 
-  public String prometheusExporterHost;
-  public int prometheusExporterPort;
+  public final String prometheusExporterHost;
+  public final int prometheusExporterPort;
 
-  public String username;
-  public String password;
-  public String realm;
-  public String remoteProfiles;
+  public final String username;
+  public final String password;
+  public final String realm;
+  public final String remoteProfiles;
 
-  public Properties properties;
+  public final Properties properties;
 
-  public JmxConfig(final Properties properties) {
-    this.properties = new Properties(properties);
+  public JmxConfig(final Properties props) {
+    this.properties = new Properties(props);
     // command line takes precedence
     this.properties.putAll(System.getProperties());
 
     serviceUrl = getProperty(SERVICE_URL, "");
     groovyScript = getProperty(GROOVY_SCRIPT, "");
-    intervalMilliseconds = getProperty(INTERVAL_MILLISECONDS, 10000);
+
+    final int interval = getProperty(INTERVAL_MILLISECONDS, 10000);
+    intervalMilliseconds = interval == 0 ? 10000 : interval;
+
     exporterType = getProperty(EXPORTER_TYPE, "logging");
 
     otlpExporterEndpoint = getProperty(OTLP_ENDPOINT, "");
@@ -78,19 +81,19 @@ public class JmxConfig {
   }
 
   private String getProperty(final String key, final String dfault) {
-    final String propVal = properties.getProperty(PREFIX + key);
+    final String propVal = properties.getProperty(key);
     return (propVal == null) ? dfault : propVal;
   }
 
   private int getProperty(final String key, final int dfault) {
-    final String propVal = properties.getProperty(PREFIX + key);
+    final String propVal = properties.getProperty(key);
     if (propVal == null) {
       return dfault;
     }
     try {
       return Integer.parseInt(propVal);
     } catch (NumberFormatException e) {
-      throw new ConfigureError("Failed to parse " + PREFIX + key, e);
+      throw new ConfigureError("Failed to parse " + key, e);
     }
   }
 
@@ -101,23 +104,19 @@ public class JmxConfig {
    */
   public void validate() throws ConfigureError {
     if (isBlank(this.serviceUrl)) {
-      throw new ConfigureError(PREFIX + SERVICE_URL + " must be specified.");
+      throw new ConfigureError(SERVICE_URL + " must be specified.");
     }
 
     if (isBlank(this.groovyScript)) {
-      throw new ConfigureError(PREFIX + GROOVY_SCRIPT + " must be specified.");
+      throw new ConfigureError(GROOVY_SCRIPT + " must be specified.");
     }
 
     if (isBlank(this.otlpExporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
-      throw new ConfigureError(PREFIX + OTLP_ENDPOINT + " must be specified for otlp format.");
+      throw new ConfigureError(OTLP_ENDPOINT + " must be specified for otlp format.");
     }
 
     if (this.intervalMilliseconds < 0) {
-      throw new ConfigureError(PREFIX + INTERVAL_MILLISECONDS + " must be positive.");
-    }
-
-    if (this.intervalMilliseconds == 0) {
-      this.intervalMilliseconds = 10000;
+      throw new ConfigureError(INTERVAL_MILLISECONDS + " must be positive.");
     }
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -32,7 +32,7 @@ class JmxConfig {
 
   static final String JMX_USERNAME = PREFIX + "jmx.username";
   static final String JMX_PASSWORD = PREFIX + "jmx.password";
-  static final String JMX_REMOTE_PROFILES = PREFIX + "jmx.remote.profiles";
+  static final String JMX_REMOTE_PROFILE = PREFIX + "jmx.remote.profile";
   static final String JMX_REALM = PREFIX + "jmx.realm";
 
   final String serviceUrl;
@@ -48,7 +48,7 @@ class JmxConfig {
   final String username;
   final String password;
   final String realm;
-  final String remoteProfiles;
+  final String remoteProfile;
 
   final Properties properties;
 
@@ -72,7 +72,7 @@ class JmxConfig {
 
     username = properties.getProperty(JMX_USERNAME);
     password = properties.getProperty(JMX_PASSWORD);
-    remoteProfiles = properties.getProperty(JMX_REMOTE_PROFILES);
+    remoteProfile = properties.getProperty(JMX_REMOTE_PROFILE);
     realm = properties.getProperty(JMX_REALM);
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -18,75 +18,70 @@ package io.opentelemetry.contrib.jmxmetrics;
 
 import java.util.Properties;
 
-public class JmxConfig {
-  protected static final String PREFIX = "otel.";
-  protected static final String SERVICE_URL = PREFIX + "jmx.service.url";
-  protected static final String GROOVY_SCRIPT = PREFIX + "jmx.groovy.script";
-  protected static final String INTERVAL_MILLISECONDS = PREFIX + "jmx.interval.milliseconds";
-  protected static final String EXPORTER_TYPE = PREFIX + "exporter";
+class JmxConfig {
+  static final String PREFIX = "otel.";
+  static final String SERVICE_URL = PREFIX + "jmx.service.url";
+  static final String GROOVY_SCRIPT = PREFIX + "jmx.groovy.script";
+  static final String INTERVAL_MILLISECONDS = PREFIX + "jmx.interval.milliseconds";
+  static final String EXPORTER_TYPE = PREFIX + "exporter";
 
-  protected static final String OTLP_ENDPOINT = PREFIX + "otlp.endpoint";
+  static final String OTLP_ENDPOINT = PREFIX + "otlp.endpoint";
 
-  protected static final String PROMETHEUS_HOST = PREFIX + "prometheus.host";
-  protected static final String PROMETHEUS_PORT = PREFIX + "prometheus.port";
+  static final String PROMETHEUS_HOST = PREFIX + "prometheus.host";
+  static final String PROMETHEUS_PORT = PREFIX + "prometheus.port";
 
-  protected static final String JMX_USERNAME = PREFIX + "jmx.username";
-  protected static final String JMX_PASSWORD = PREFIX + "jmx.password";
-  protected static final String JMX_REMOTE_PROFILES = PREFIX + "jmx.remote.profiles";
-  protected static final String JMX_REALM = PREFIX + "jmx.realm";
+  static final String JMX_USERNAME = PREFIX + "jmx.username";
+  static final String JMX_PASSWORD = PREFIX + "jmx.password";
+  static final String JMX_REMOTE_PROFILES = PREFIX + "jmx.remote.profiles";
+  static final String JMX_REALM = PREFIX + "jmx.realm";
 
-  public final String serviceUrl;
-  public final String groovyScript;
-  public final int intervalMilliseconds;
-  public final String exporterType;
+  final String serviceUrl;
+  final String groovyScript;
+  final int intervalMilliseconds;
+  final String exporterType;
 
-  public final String otlpExporterEndpoint;
+  final String otlpExporterEndpoint;
 
-  public final String prometheusExporterHost;
-  public final int prometheusExporterPort;
+  final String prometheusExporterHost;
+  final int prometheusExporterPort;
 
-  public final String username;
-  public final String password;
-  public final String realm;
-  public final String remoteProfiles;
+  final String username;
+  final String password;
+  final String realm;
+  final String remoteProfiles;
 
-  public final Properties properties;
+  final Properties properties;
 
-  public JmxConfig(final Properties props) {
-    this.properties = new Properties(props);
+  JmxConfig(final Properties props) {
+    properties = new Properties(props);
     // command line takes precedence
-    this.properties.putAll(System.getProperties());
+    properties.putAll(System.getProperties());
 
-    serviceUrl = getProperty(SERVICE_URL, "");
-    groovyScript = getProperty(GROOVY_SCRIPT, "");
+    serviceUrl = properties.getProperty(SERVICE_URL);
+    groovyScript = properties.getProperty(GROOVY_SCRIPT);
 
-    final int interval = getProperty(INTERVAL_MILLISECONDS, 10000);
+    int interval = getProperty(INTERVAL_MILLISECONDS, 10000);
     intervalMilliseconds = interval == 0 ? 10000 : interval;
 
-    exporterType = getProperty(EXPORTER_TYPE, "logging");
+    exporterType = properties.getProperty(EXPORTER_TYPE, "logging");
 
-    otlpExporterEndpoint = getProperty(OTLP_ENDPOINT, "");
+    otlpExporterEndpoint = properties.getProperty(OTLP_ENDPOINT);
 
-    prometheusExporterHost = getProperty(PROMETHEUS_HOST, "localhost");
+    prometheusExporterHost = properties.getProperty(PROMETHEUS_HOST, "localhost");
     prometheusExporterPort = getProperty(PROMETHEUS_PORT, 9090);
 
-    username = getProperty(JMX_USERNAME, "");
-    password = getProperty(JMX_PASSWORD, "");
-    remoteProfiles = getProperty(JMX_REMOTE_PROFILES, "");
-    realm = getProperty(JMX_REALM, "");
+    username = properties.getProperty(JMX_USERNAME);
+    password = properties.getProperty(JMX_PASSWORD);
+    remoteProfiles = properties.getProperty(JMX_REMOTE_PROFILES);
+    realm = properties.getProperty(JMX_REALM);
   }
 
-  public JmxConfig() {
+  JmxConfig() {
     this(new Properties());
   }
 
-  private String getProperty(final String key, final String dfault) {
-    final String propVal = properties.getProperty(key);
-    return (propVal == null) ? dfault : propVal;
-  }
-
   private int getProperty(final String key, final int dfault) {
-    final String propVal = properties.getProperty(key);
+    String propVal = properties.getProperty(key);
     if (propVal == null) {
       return dfault;
     }
@@ -97,25 +92,22 @@ public class JmxConfig {
     }
   }
 
-  /**
-   * Will determine if parsed config is complete, setting any applicable defaults.
-   *
-   * @throws ConfigurationException - Thrown if a configuration value is missing or invalid.
-   */
-  public void validate() throws ConfigurationException {
-    if (isBlank(this.serviceUrl)) {
+  /** Will determine if parsed config is complete, setting any applicable defaults. */
+  void validate() {
+    if (isBlank(serviceUrl)) {
       throw new ConfigurationException(SERVICE_URL + " must be specified.");
     }
 
-    if (isBlank(this.groovyScript)) {
+    if (isBlank(groovyScript)) {
       throw new ConfigurationException(GROOVY_SCRIPT + " must be specified.");
     }
 
-    if (isBlank(this.otlpExporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
+    if (isBlank(otlpExporterEndpoint)
+        && (!isBlank(exporterType) && exporterType.equalsIgnoreCase("otlp"))) {
       throw new ConfigurationException(OTLP_ENDPOINT + " must be specified for otlp format.");
     }
 
-    if (this.intervalMilliseconds < 0) {
+    if (intervalMilliseconds < 0) {
       throw new ConfigurationException(INTERVAL_MILLISECONDS + " must be positive.");
     }
   }
@@ -126,7 +118,7 @@ public class JmxConfig {
    * @param s - {@link String} to evaluate
    * @return - if s is null or without non-whitespace chars.
    */
-  public static boolean isBlank(final String s) {
+  static boolean isBlank(final String s) {
     if (s == null) {
       return true;
     }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -101,19 +101,19 @@ public class JmxConfig {
    */
   public void validate() throws ConfigureError {
     if (isBlank(this.serviceUrl)) {
-      throw new ConfigureError(PREFIX + "service.url must be specified.");
+      throw new ConfigureError(PREFIX + SERVICE_URL + " must be specified.");
     }
 
     if (isBlank(this.groovyScript)) {
-      throw new ConfigureError(PREFIX + "groovy.script must be specified.");
+      throw new ConfigureError(PREFIX + GROOVY_SCRIPT + " must be specified.");
     }
 
     if (isBlank(this.otlpExporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
-      throw new ConfigureError(PREFIX + "exporter.endpoint must be specified for otlp format.");
+      throw new ConfigureError(PREFIX + OTLP_ENDPOINT + " must be specified for otlp format.");
     }
 
     if (this.intervalMilliseconds < 0) {
-      throw new ConfigureError(PREFIX + "interval.milliseconds must be positive.");
+      throw new ConfigureError(PREFIX + INTERVAL_MILLISECONDS + " must be positive.");
     }
 
     if (this.intervalMilliseconds == 0) {

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -93,30 +93,30 @@ public class JmxConfig {
     try {
       return Integer.parseInt(propVal);
     } catch (NumberFormatException e) {
-      throw new ConfigureError("Failed to parse " + key, e);
+      throw new ConfigurationException("Failed to parse " + key, e);
     }
   }
 
   /**
    * Will determine if parsed config is complete, setting any applicable defaults.
    *
-   * @throws ConfigureError - Thrown if a configuration value is missing or invalid.
+   * @throws ConfigurationException - Thrown if a configuration value is missing or invalid.
    */
-  public void validate() throws ConfigureError {
+  public void validate() throws ConfigurationException {
     if (isBlank(this.serviceUrl)) {
-      throw new ConfigureError(SERVICE_URL + " must be specified.");
+      throw new ConfigurationException(SERVICE_URL + " must be specified.");
     }
 
     if (isBlank(this.groovyScript)) {
-      throw new ConfigureError(GROOVY_SCRIPT + " must be specified.");
+      throw new ConfigurationException(GROOVY_SCRIPT + " must be specified.");
     }
 
     if (isBlank(this.otlpExporterEndpoint) && this.exporterType.equalsIgnoreCase("otlp")) {
-      throw new ConfigureError(OTLP_ENDPOINT + " must be specified for otlp format.");
+      throw new ConfigurationException(OTLP_ENDPOINT + " must be specified for otlp format.");
     }
 
     if (this.intervalMilliseconds < 0) {
-      throw new ConfigureError(INTERVAL_MILLISECONDS + " must be positive.");
+      throw new ConfigurationException(INTERVAL_MILLISECONDS + " must be positive.");
     }
   }
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -68,7 +68,7 @@ public class JmxMetrics {
   private void shutdown() {
     logger.info("Shutting down JmxMetrics Groovy runner and exporting final metrics.");
     exec.shutdown();
-    runner.flush();
+    runner.shutdown();
   }
 
   private static JmxConfig getConfigFromArgs(final String[] args) {

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JmxMetrics {
+  private static final Logger logger = Logger.getLogger(JmxMetrics.class.getName());
+
+  private final Timer timer = new Timer();
+  private GroovyRunner runner;
+
+  /**
+   * Begins the core metric scraping and reporting loop on configured interval after parsing and
+   * binding the configured groovy script and establishing the {@link JmxClient} connection.
+   *
+   * @param config - {@link JmxConfig} with Groovy script path, JMX connection info, and metric
+   *     export options.
+   */
+  public void start(final JmxConfig config) {
+    JmxClient jmxClient;
+    try {
+      jmxClient = new JmxClient(config);
+    } catch (MalformedURLException e) {
+      throw new ConfigureError("Malformed serviceUrl: ", e);
+    }
+
+    runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));
+
+    timer.scheduleAtFixedRate(
+        wrapTimerTask(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  runner.run();
+                } catch (Throwable e) {
+                  logger.log(Level.SEVERE, "Error gathering JMX metrics", e);
+                }
+              }
+            }),
+        0,
+        config.intervalMilliseconds);
+    logger.info("Started GroovyRunner.");
+  }
+
+  private static TimerTask wrapTimerTask(final Runnable r) {
+    return new TimerTask() {
+      @Override
+      public void run() {
+        r.run();
+      }
+    };
+  }
+
+  private void shutdown() {
+    logger.info("Shutting down JmxMetrics Groovy runner and exporting final metrics.");
+    timer.cancel();
+    runner.flush();
+  }
+
+  private static JmxConfig getConfigFromArgs(final String[] args) {
+    if (args.length != 0 && (args.length != 2 || !args[0].equalsIgnoreCase("-config"))) {
+      System.out.println(
+          "Usage: java io.opentelemetry.contrib.jmxmetrics.JmxMetrics "
+              + "-config <path_to_config.properties>");
+      System.exit(1);
+    }
+
+    Properties props = new Properties();
+    if (args.length == 2) {
+      try (InputStream is = new FileInputStream(args[1])) {
+        props.load(is);
+      } catch (IOException e) {
+        System.out.println(
+            "Failed to read config properties file at '" + args[1] + "': " + e.getMessage());
+        System.exit(1);
+      }
+    }
+
+    return new JmxConfig(props);
+  }
+
+  /**
+   * Main method to create and run a {@link JmxMetrics} instance.
+   *
+   * @param args - must be of the form "-config jmx_config_path"
+   */
+  public static void main(final String[] args) {
+    JmxConfig config = getConfigFromArgs(args);
+    config.validate();
+
+    final JmxMetrics jmxMetrics = new JmxMetrics();
+    try {
+      jmxMetrics.start(config);
+    } catch (ConfigureError e) {
+      logger.severe(e.getMessage());
+      System.exit(1);
+    }
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                jmxMetrics.shutdown();
+              }
+            });
+  }
+}

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -41,7 +41,7 @@ public class JmxMetrics {
     try {
       jmxClient = new JmxClient(config);
     } catch (MalformedURLException e) {
-      throw new ConfigureError("Malformed serviceUrl: ", e);
+      throw new ConfigurationException("Malformed serviceUrl: ", e);
     }
 
     runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -44,7 +44,7 @@ class JmxMetrics {
       throw new ConfigurationException("Malformed serviceUrl: ", e);
     }
 
-    runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));
+    runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyMetricEnvironment(config));
   }
 
   private void start() {

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -31,17 +31,12 @@ public class JmxMetrics {
   private static final Logger logger = Logger.getLogger(JmxMetrics.class.getName());
 
   private final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
-  private GroovyRunner runner;
+  private final GroovyRunner runner;
+  private final JmxConfig config;
 
-  /**
-   * Begins the core metric scraping and reporting loop on configured interval after parsing and
-   * binding the configured groovy script and establishing the {@link
-   * io.opentelemetry.contrib.jmxmetrics.JmxClient} connection.
-   *
-   * @param config - {@link JmxConfig} with Groovy script path, JMX connection info, and metric
-   *     export options.
-   */
-  public void start(final JmxConfig config) {
+  public JmxMetrics(final JmxConfig config) {
+    this.config = config;
+
     JmxClient jmxClient;
     try {
       jmxClient = new JmxClient(config);
@@ -50,7 +45,9 @@ public class JmxMetrics {
     }
 
     runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));
+  }
 
+  public void start() {
     exec.scheduleWithFixedDelay(
         new Runnable() {
           @Override
@@ -105,8 +102,8 @@ public class JmxMetrics {
     JmxConfig config = getConfigFromArgs(args);
     config.validate();
 
-    final JmxMetrics jmxMetrics = new JmxMetrics();
-    jmxMetrics.start(config);
+    final JmxMetrics jmxMetrics = new JmxMetrics(config);
+    jmxMetrics.start();
 
     Runtime.getRuntime()
         .addShutdownHook(

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -27,14 +27,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class JmxMetrics {
+class JmxMetrics {
   private static final Logger logger = Logger.getLogger(JmxMetrics.class.getName());
 
   private final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
   private final GroovyRunner runner;
   private final JmxConfig config;
 
-  public JmxMetrics(final JmxConfig config) {
+  JmxMetrics(final JmxConfig config) {
     this.config = config;
 
     JmxClient jmxClient;
@@ -47,7 +47,7 @@ public class JmxMetrics {
     runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyUtils(config));
   }
 
-  public void start() {
+  private void start() {
     exec.scheduleWithFixedDelay(
         new Runnable() {
           @Override

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -106,12 +106,7 @@ public class JmxMetrics {
     config.validate();
 
     final JmxMetrics jmxMetrics = new JmxMetrics();
-    try {
-      jmxMetrics.start(config);
-    } catch (ConfigureError e) {
-      logger.severe(e.getMessage());
-      System.exit(1);
-    }
+    jmxMetrics.start(config);
 
     Runtime.getRuntime()
         .addShutdownHook(

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import static org.junit.Assert.assertTrue
+
+import java.time.Duration
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import org.testcontainers.utility.MountableFile
+import spock.lang.Shared
+import spock.lang.Specification
+
+class IntegrationTest extends Specification{
+
+    @Shared
+    def cassandraContainer
+
+    @Shared
+    def jmxExtensionAppContainer
+
+    @Shared
+    def jmxExposedPort
+
+    void configureContainers(String configName, int exporterPort) {
+        def jarPath = System.getProperty("shadow.jar.path")
+
+        def scriptName = "script.groovy"
+        def scriptPath = ClassLoader.getSystemClassLoader().getResource(scriptName).path
+
+        def configPath = ClassLoader.getSystemClassLoader().getResource(configName).path
+
+        def cassandraDockerfile = ("FROM cassandra:3.11\n"
+                + "ENV LOCAL_JMX=no\n"
+                + "RUN echo 'cassandra cassandra' > /etc/cassandra/jmxremote.password\n"
+                + "RUN chmod 0400 /etc/cassandra/jmxremote.password\n")
+
+        def network = Network.SHARED
+
+        cassandraContainer =
+                new GenericContainer<>(
+                new ImageFromDockerfile().withFileFromString("Dockerfile", cassandraDockerfile))
+                .withNetwork(network)
+                .withNetworkAliases("cassandra")
+                .withExposedPorts(7199)
+                .withStartupTimeout(Duration.ofSeconds(120))
+                .waitingFor(Wait.forListeningPort())
+        cassandraContainer.start()
+
+        jmxExtensionAppContainer =
+                new GenericContainer<>("openjdk:7u111-jre-alpine")
+                .withNetwork(network)
+                .withCopyFileToContainer(MountableFile.forHostPath(jarPath), "/app/OpenTelemetryJava.jar")
+                .withCopyFileToContainer(
+                MountableFile.forHostPath(scriptPath), "/app/${scriptName}")
+                .withCopyFileToContainer(
+                MountableFile.forHostPath(configPath), "/app/${configName}")
+                .withCommand("java -cp /app/OpenTelemetryJava.jar "
+                + "-Dotel.jmx.metrics.username=cassandra "
+                + "-Dotel.jmx.metrics.password=cassandra "
+                + "io.opentelemetry.contrib.jmxmetrics.JmxMetrics "
+                + "-config /app/${configName}")
+                .withStartupTimeout(Duration.ofSeconds(120))
+                .waitingFor(Wait.forLogMessage(".*Started GroovyRunner.*", 1))
+                .dependsOn(cassandraContainer)
+        if (exporterPort != 0) {
+            jmxExtensionAppContainer.withExposedPorts(exporterPort)
+        }
+        jmxExtensionAppContainer.start()
+
+        assertTrue(cassandraContainer.running)
+        assertTrue(jmxExtensionAppContainer.running)
+
+        if (exporterPort != 0) {
+            jmxExposedPort = jmxExtensionAppContainer.getMappedPort(exporterPort)
+        }
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -72,8 +72,8 @@ class IntegrationTest extends Specification{
                 .withCopyFileToContainer(
                 MountableFile.forHostPath(configPath), "/app/${configName}")
                 .withCommand("java -cp /app/OpenTelemetryJava.jar "
-                + "-Dotel.jmx.metrics.username=cassandra "
-                + "-Dotel.jmx.metrics.password=cassandra "
+                + "-Dotel.jmx.username=cassandra "
+                + "-Dotel.jmx.password=cassandra "
                 + "io.opentelemetry.contrib.jmxmetrics.JmxMetrics "
                 + "-config /app/${configName}")
                 .withStartupTimeout(Duration.ofSeconds(120))

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -33,7 +33,7 @@ class JmxConfigTest extends Specification {
             "prometheus.port",
             "jmx.username",
             "jmx.password",
-            "jmx.remote.profiles",
+            "jmx.remote.profile",
             "jmx.realm"
         ]
         properties.each {System.clearProperty("otel.${it}")}
@@ -61,7 +61,7 @@ class JmxConfigTest extends Specification {
         config.prometheusExporterPort == 9090
         config.username == null
         config.password == null
-        config.remoteProfiles == null
+        config.remoteProfile == null
         config.realm == null
     }
 
@@ -77,7 +77,7 @@ class JmxConfigTest extends Specification {
             "prometheus.port": "234",
             "jmx.username": "myUsername",
             "jmx.password": "myPassword",
-            "jmx.remote.profiles": "myRemoteProfile",
+            "jmx.remote.profile": "myRemoteProfile",
             "jmx.realm": "myRealm"
         ]
         properties.each {System.setProperty("otel.${it.key}", it.value)}
@@ -93,7 +93,7 @@ class JmxConfigTest extends Specification {
         config.prometheusExporterPort == 234
         config.username == "myUsername"
         config.password == "myPassword"
-        config.remoteProfiles == "myRemoteProfile"
+        config.remoteProfile == "myRemoteProfile"
         config.realm == "myRealm"
     }
 

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import spock.lang.Specification
+
+
+class JmxConfigTest extends Specification {
+
+    void clearProperties() {
+        // ensure relevant properties aren't set
+        def properties = [
+            "jmx.service.url",
+            "jmx.groovy.script",
+            "jmx.interval.milliseconds",
+            "exporter",
+            "otlp.endpoint",
+            "prometheus.host",
+            "prometheus.port",
+            "jmx.username",
+            "jmx.password",
+            "jmx.remote.profiles",
+            "jmx.realm"
+        ]
+        properties.each {System.clearProperty("otel.${it}")}
+    }
+
+    def setup() {
+        clearProperties()
+    }
+
+    def cleanupSpec() {
+        clearProperties()
+    }
+
+    def 'default values'() {
+        when: 'config is without system properties'
+        def config = new JmxConfig()
+
+        then:
+        config.serviceUrl == ""
+        config.groovyScript == ""
+        config.intervalMilliseconds == 10000
+        config.exporterType == "logging"
+        config.otlpExporterEndpoint == ""
+        config.prometheusExporterHost == "localhost"
+        config.prometheusExporterPort == 9090
+        config.username == ""
+        config.password == ""
+        config.remoteProfiles == ""
+        config.realm == ""
+    }
+
+    def 'specified values'() {
+        when: 'config is set via system properties'
+        def properties = [
+            "jmx.service.url" : "myServiceUrl",
+            "jmx.groovy.script" : "myGroovyScript",
+            "jmx.interval.milliseconds": "123",
+            "exporter": "inmemory",
+            "otlp.endpoint": "myOtlpEndpoint",
+            "prometheus.host": "myPrometheusHost",
+            "prometheus.port": "234",
+            "jmx.username": "myUsername",
+            "jmx.password": "myPassword",
+            "jmx.remote.profiles": "myRemoteProfile",
+            "jmx.realm": "myRealm"
+        ]
+        properties.each {System.setProperty("otel.${it.key}", it.value)}
+        def config = new JmxConfig()
+
+        then:
+        config.serviceUrl == "myServiceUrl"
+        config.groovyScript == "myGroovyScript"
+        config.intervalMilliseconds == 123
+        config.exporterType == "inmemory"
+        config.otlpExporterEndpoint == "myOtlpEndpoint"
+        config.prometheusExporterHost == "myPrometheusHost"
+        config.prometheusExporterPort == 234
+        config.username == "myUsername"
+        config.password == "myPassword"
+        config.remoteProfiles == "myRemoteProfile"
+        config.realm == "myRealm"
+    }
+
+    def 'invalid values'() {
+        setup: 'config is set with invalid interval'
+        System.setProperty(prop, 'abc')
+        def raised = null
+        try {
+            new JmxConfig()
+        } catch (ConfigureError e) {
+            raised = e
+        }
+
+        expect: 'config fails to be created'
+        raised != null
+        raised.message ==  "Failed to parse ${prop}"
+        println "JmxConfigTest.invalid values: ${raised.message}"
+
+        where:
+        prop | _
+        'otel.jmx.interval.milliseconds' | _
+        'otel.prometheus.port' | _
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -103,7 +103,7 @@ class JmxConfigTest extends Specification {
         def raised = null
         try {
             new JmxConfig()
-        } catch (ConfigureError e) {
+        } catch (ConfigurationException e) {
             raised = e
         }
 

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -52,17 +52,17 @@ class JmxConfigTest extends Specification {
         def config = new JmxConfig()
 
         then:
-        config.serviceUrl == ""
-        config.groovyScript == ""
+        config.serviceUrl == null
+        config.groovyScript == null
         config.intervalMilliseconds == 10000
         config.exporterType == "logging"
-        config.otlpExporterEndpoint == ""
+        config.otlpExporterEndpoint == null
         config.prometheusExporterHost == "localhost"
         config.prometheusExporterPort == 9090
-        config.username == ""
-        config.password == ""
-        config.remoteProfiles == ""
-        config.realm == ""
+        config.username == null
+        config.password == null
+        config.remoteProfiles == null
+        config.realm == null
     }
 
     def 'specified values'() {

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+import javax.management.ObjectName
+import javax.management.remote.JMXConnectorServer
+import javax.management.remote.JMXConnectorServerFactory
+import javax.management.remote.JMXServiceURL
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class OtelHelperJmxTest extends Specification {
+
+    static String thingName = 'io.opentelemetry.extensions.metrics.jmx:type=OtelHelperJmxTest.Thing'
+
+    @Shared
+    JMXConnectorServer jmxServer
+
+    def setupSpec() {
+        def thing = new Thing()
+        def mbeanServer = getPlatformMBeanServer()
+        mbeanServer.registerMBean(thing, new ObjectName(thingName))
+    }
+
+    def cleanup() {
+        jmxServer.stop()
+    }
+
+    private JMXServiceURL setupServer(Map env) {
+        def serviceUrl = new JMXServiceURL('rmi', 'localhost', 0)
+        jmxServer = JMXConnectorServerFactory.newJMXConnectorServer(serviceUrl, env, getPlatformMBeanServer())
+        jmxServer.start()
+        return jmxServer.getAddress()
+    }
+
+    private OtelHelper setupHelper(JmxConfig config) {
+        return new OtelHelper(new JmxClient(config), new GroovyUtils(config))
+    }
+
+    private void verifyClient(JmxConfig config) {
+        config.groovyScript = "myscript.groovy"
+        config.validate()
+        def otel = setupHelper(config)
+        def mbeans = otel.queryJmx(thingName)
+
+        assertEquals(1, mbeans.size())
+        assertEquals('This is the attribute', mbeans[0].SomeAttribute)
+    }
+
+    def "no authentication"() {
+        when:
+        def serverAddr = setupServer([:])
+        def config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+        }
+        then:
+        verifyClient(config)
+    }
+
+    def "password authentication"() {
+        when:
+        def pwFile = ClassLoader.getSystemClassLoader().getResource('jmxremote.password').getPath()
+        def serverAddr = setupServer(['jmx.remote.x.password.file':pwFile])
+
+        def config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+            username = 'wrongUsername'
+            password = 'wrongPassword'
+        }
+        then:
+        try {
+            verifyClient(config)
+            assertTrue('Authentication should have failed.', false)
+        } catch (final SecurityException e) {
+            // desired
+        }
+
+        when:
+        config = new JmxConfig().tap {
+            serviceUrl = serverAddr
+            username = 'correctUsername'
+            password = 'correctPassword'
+        }
+        then:
+        verifyClient(config)
+    }
+
+    interface ThingMBean {
+
+        String getSomeAttribute()
+    }
+
+    static class Thing implements ThingMBean {
+
+        @Override
+        String getSomeAttribute() {
+            return 'This is the attribute'
+        }
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.groovy
@@ -53,7 +53,7 @@ class OtelHelperJmxTest extends Specification {
     }
 
     private OtelHelper setupHelper(JmxConfig config) {
-        return new OtelHelper(new JmxClient(config), new GroovyUtils(config))
+        return new OtelHelper(new JmxClient(config), new GroovyMetricEnvironment(config))
     }
 
     private void verifyClient(Properties props) {

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -1,0 +1,656 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.SUMMARY
+
+import io.opentelemetry.common.Labels
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import org.junit.Rule
+import org.junit.rules.TestName
+import org.junit.rules.TestRule
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class OtelHelperSynchronousMetricTest extends Specification{
+
+    @Shared
+    GroovyUtils gutil
+
+    @Shared
+    OtelHelper otel
+
+    @Rule public final TestRule name = new TestName()
+
+    def setup() {
+        // Set up a MeterSdk per test to be able to collect its metrics alone
+        gutil = new GroovyUtils(
+                new JmxConfig().tap {
+                    exporterType = 'inmemory'
+                },
+                name.methodName, ''
+                )
+        otel = new OtelHelper(null, gutil)
+    }
+
+    def exportMetrics() {
+        def provider = OpenTelemetrySdk.meterProvider.get(name.methodName, '')
+        return provider.collectAll().sort { md1, md2 ->
+            def p1 = md1.points[0]
+            def p2 = md2.points[0]
+            def s1 = p1.startEpochNanos
+            def s2 = p2.startEpochNanos
+            if (s1 == s2) {
+                if (md1.descriptor.type == SUMMARY) {
+                    return p1.percentileValues[0].value <=> p2.percentileValues[0].value
+                }
+                return p1.value <=> p2.value
+            }
+            s1 <=> s2
+        }
+    }
+
+    def "double counter"() {
+        when:
+        def dc = otel.doubleCounter(
+                'double-counter', 'a double counter',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        dc.add(123.456, Labels.of('key', 'value'))
+
+        dc = otel.doubleCounter('my-double-counter', 'another double counter', 'µs')
+        dc.add(234.567, Labels.of('myKey', 'myValue'))
+
+        dc = otel.doubleCounter('another-double-counter', 'double counter')
+        dc.add(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dc = otel.doubleCounter('yet-another-double-counter')
+        dc.add(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-counter'
+        assert first.descriptor.description == 'a double counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == MONOTONIC_DOUBLE
+        assert first.points.size() == 1
+        assert first.points[0].value == 123.456
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-counter'
+        assert second.descriptor.description == 'another double counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == MONOTONIC_DOUBLE
+        assert second.points.size() == 1
+        assert second.points[0].value == 234.567
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-counter'
+        assert third.descriptor.description == 'double counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == MONOTONIC_DOUBLE
+        assert third.points.size() == 1
+        assert third.points[0].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == MONOTONIC_DOUBLE
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "double counter memoization"() {
+        when:
+        def dcOne = otel.doubleCounter('dc', 'double')
+        dcOne.add(10.1, Labels.of('key', 'value'))
+        def dcTwo = otel.doubleCounter('dc', 'double')
+        dcTwo.add(10.1, Labels.of('key', 'value'))
+
+        then:
+        assert dcOne.is(dcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dc'
+        assert metric.descriptor.description == 'double'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == MONOTONIC_DOUBLE
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 20.2
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "long counter"() {
+        when:
+        def lc = otel.longCounter(
+                'long-counter', 'a long counter',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        lc.add(123, Labels.of('key', 'value'))
+
+        lc = otel.longCounter('my-long-counter', 'another long counter', 'µs')
+        lc.add(234, Labels.of('myKey', 'myValue'))
+
+        lc = otel.longCounter('another-long-counter', 'long counter')
+        lc.add(345, Labels.of('anotherKey', 'anotherValue'))
+
+        lc = otel.longCounter('yet-another-long-counter')
+        lc.add(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-counter'
+        assert first.descriptor.description == 'a long counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == MONOTONIC_LONG
+        assert first.points.size() == 1
+        assert first.points[0].value == 123
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-counter'
+        assert second.descriptor.description == 'another long counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == MONOTONIC_LONG
+        assert second.points.size() == 1
+        assert second.points[0].value == 234
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-counter'
+        assert third.descriptor.description == 'long counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == MONOTONIC_LONG
+        assert third.points.size() == 1
+        assert third.points[0].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == MONOTONIC_LONG
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "long counter memoization"() {
+        when:
+        def lcOne = otel.longCounter('lc', 'long')
+        lcOne.add(10, Labels.of('key', 'value'))
+        def lcTwo = otel.longCounter('lc', 'long')
+        lcTwo.add(10, Labels.of('key', 'value'))
+
+        then:
+        assert lcOne.is(lcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'lc'
+        assert metric.descriptor.description == 'long'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == MONOTONIC_LONG
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 20
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "double up down counter"() {
+        when:
+        def dudc = otel.doubleUpDownCounter(
+                'double-up-down-counter', 'a double up-down-counter',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        dudc.add(-234.567, Labels.of('key', 'value'))
+
+        dudc = otel.doubleUpDownCounter('my-double-up-down-counter', 'another double up-down-counter', 'µs')
+        dudc.add(-123.456, Labels.of('myKey', 'myValue'))
+
+        dudc = otel.doubleUpDownCounter('another-double-up-down-counter', 'double up-down-counter')
+        dudc.add(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dudc = otel.doubleUpDownCounter('yet-another-double-up-down-counter')
+        dudc.add(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-up-down-counter'
+        assert first.descriptor.description == 'a double up-down-counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert first.points.size() == 1
+        assert first.points[0].value == -234.567
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-up-down-counter'
+        assert second.descriptor.description == 'another double up-down-counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert second.points.size() == 1
+        assert second.points[0].value == -123.456
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-up-down-counter'
+        assert third.descriptor.description == 'double up-down-counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert third.points.size() == 1
+        assert third.points[0].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-up-down-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "double up down counter memoization"() {
+        when:
+        def dudcOne = otel.doubleUpDownCounter('dudc', 'double up down')
+        dudcOne.add(10.1, Labels.of('key', 'value'))
+        def dudcTwo = otel.doubleUpDownCounter('dudc', 'double up down')
+        dudcTwo.add(-10.1, Labels.of('key', 'value'))
+
+        then:
+        assert dudcOne.is(dudcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dudc'
+        assert metric.descriptor.description == 'double up down'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 0
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "long up down counter"() {
+        when:
+        def ludc = otel.longUpDownCounter(
+                'long-up-down-counter', 'a long up-down-counter',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        ludc.add(-234, Labels.of('key', 'value'))
+
+        ludc = otel.longUpDownCounter('my-long-up-down-counter', 'another long up-down-counter', 'µs')
+        ludc.add(-123, Labels.of('myKey', 'myValue'))
+
+        ludc = otel.longUpDownCounter('another-long-up-down-counter', 'long up-down-counter')
+        ludc.add(345, Labels.of('anotherKey', 'anotherValue'))
+
+        ludc = otel.longUpDownCounter('yet-another-long-up-down-counter')
+        ludc.add(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-up-down-counter'
+        assert first.descriptor.description == 'a long up-down-counter'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == NON_MONOTONIC_LONG
+        assert first.points.size() == 1
+        assert first.points[0].value == -234
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-up-down-counter'
+        assert second.descriptor.description == 'another long up-down-counter'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == NON_MONOTONIC_LONG
+        assert second.points.size() == 1
+        assert second.points[0].value == -123
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-up-down-counter'
+        assert third.descriptor.description == 'long up-down-counter'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == NON_MONOTONIC_LONG
+        assert third.points.size() == 1
+        assert third.points[0].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-up-down-counter'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == NON_MONOTONIC_LONG
+        assert fourth.points.size() == 1
+        assert fourth.points[0].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "long up down counter memoization"() {
+        when:
+        def ludcOne = otel.longUpDownCounter('ludc', 'long up down')
+        ludcOne.add(10, Labels.of('key', 'value'))
+        def ludcTwo = otel.longUpDownCounter('ludc', 'long up down')
+        ludcTwo.add(-10, Labels.of('key', 'value'))
+
+        then:
+        assert ludcOne.is(ludcTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'ludc'
+        assert metric.descriptor.description == 'long up down'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == NON_MONOTONIC_LONG
+        assert metric.points.size() == 1
+        assert metric.points[0].value == 0
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "double value recorder"() {
+        when:
+        def dvr = otel.doubleValueRecorder(
+                'double-value-recorder', 'a double value-recorder',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        dvr.record(-234.567, Labels.of('key', 'value'))
+
+        dvr = otel.doubleValueRecorder('my-double-value-recorder', 'another double value-recorder', 'µs')
+        dvr.record(-123.456, Labels.of('myKey', 'myValue'))
+
+        dvr = otel.doubleValueRecorder('another-double-value-recorder', 'double value-recorder')
+        dvr.record(345.678, Labels.of('anotherKey', 'anotherValue'))
+
+        dvr = otel.doubleValueRecorder('yet-another-double-value-recorder')
+        dvr.record(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'double-value-recorder'
+        assert first.descriptor.description == 'a double value-recorder'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == SUMMARY
+        assert first.points.size() == 1
+        assert first.points[0].count == 1
+        assert first.points[0].sum == -234.567
+        assert first.points[0].percentileValues[0].percentile == 0
+        assert first.points[0].percentileValues[0].value ==  -234.567
+        assert first.points[0].percentileValues[1].percentile == 100
+        assert first.points[0].percentileValues[1].value == -234.567
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-double-value-recorder'
+        assert second.descriptor.description == 'another double value-recorder'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == SUMMARY
+        assert second.points.size() == 1
+        assert second.points[0].count == 1
+        assert second.points[0].sum == -123.456
+        assert second.points[0].percentileValues[0].percentile == 0
+        assert second.points[0].percentileValues[0].value == -123.456
+        assert second.points[0].percentileValues[1].percentile == 100
+        assert second.points[0].percentileValues[1].value == -123.456
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-double-value-recorder'
+        assert third.descriptor.description == 'double value-recorder'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == SUMMARY
+        assert third.points.size() == 1
+        assert third.points[0].count == 1
+        assert third.points[0].sum == 345.678
+        assert third.points[0].percentileValues[0].percentile == 0
+        assert third.points[0].percentileValues[0].value == 345.678
+        assert third.points[0].percentileValues[1].percentile == 100
+        assert third.points[0].percentileValues[1].value == 345.678
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-double-value-recorder'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == SUMMARY
+        assert fourth.points.size() == 1
+        assert fourth.points[0].count == 1
+        assert fourth.points[0].sum == 456.789
+        assert fourth.points[0].percentileValues[0].percentile == 0
+        assert fourth.points[0].percentileValues[0].value == 456.789
+        assert fourth.points[0].percentileValues[1].percentile == 100
+        assert fourth.points[0].percentileValues[1].value == 456.789
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "double value recorder memoization"() {
+        when:
+        def dvrOne = otel.doubleValueRecorder('dvr', 'double value')
+        dvrOne.record(10.1, Labels.of('key', 'value'))
+        def dvrTwo = otel.doubleValueRecorder('dvr', 'double value')
+        dvrTwo.record(-10.1, Labels.of('key', 'value'))
+
+        then:
+        assert dvrOne.is(dvrTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'dvr'
+        assert metric.descriptor.description == 'double value'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == SUMMARY
+        assert metric.points.size() == 1
+        assert metric.points[0].count == 2
+        assert metric.points[0].sum == 0
+        assert metric.points[0].percentileValues[0].percentile == 0
+        assert metric.points[0].percentileValues[0].value == -10.1
+        assert metric.points[0].percentileValues[1].percentile == 100
+        assert metric.points[0].percentileValues[1].value == 10.1
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+    def "long value recorder"() {
+        when:
+        def lvr = otel.longValueRecorder(
+                'long-value-recorder', 'a long value-recorder',
+                'ms', [key1:'value1', key2:'value2']
+                )
+        lvr.record(-234, Labels.of('key', 'value'))
+
+        lvr = otel.longValueRecorder('my-long-value-recorder', 'another long value-recorder', 'µs')
+        lvr.record(-123, Labels.of('myKey', 'myValue'))
+
+        lvr = otel.longValueRecorder('another-long-value-recorder', 'long value-recorder')
+        lvr.record(345, Labels.of('anotherKey', 'anotherValue'))
+
+        lvr = otel.longValueRecorder('yet-another-long-value-recorder')
+        lvr.record(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
+
+        def metrics = exportMetrics()
+        then:
+        assert metrics.size() == 4
+
+        def first = metrics[0]
+        def second = metrics[1]
+        def third = metrics[2]
+        def fourth = metrics[3]
+
+        assert first.descriptor.name == 'long-value-recorder'
+        assert first.descriptor.description == 'a long value-recorder'
+        assert first.descriptor.unit == 'ms'
+        assert first.descriptor.constantLabels == Labels.of(
+        'key1', 'value1', 'key2', 'value2'
+        )
+        assert first.descriptor.type == SUMMARY
+        assert first.points.size() == 1
+        assert first.points[0].count == 1
+        assert first.points[0].sum == -234
+        assert first.points[0].percentileValues[0].percentile == 0
+        assert first.points[0].percentileValues[0].value == -234
+        assert first.points[0].percentileValues[1].percentile == 100
+        assert first.points[0].percentileValues[1].value == -234
+        assert first.points[0].labels == Labels.of('key', 'value')
+
+        assert second.descriptor.name == 'my-long-value-recorder'
+        assert second.descriptor.description == 'another long value-recorder'
+        assert second.descriptor.unit == 'µs'
+        assert second.descriptor.constantLabels == Labels.empty()
+        assert second.descriptor.type == SUMMARY
+        assert second.points.size() == 1
+        assert second.points[0].count == 1
+        assert second.points[0].sum == -123
+        assert second.points[0].percentileValues[0].percentile == 0
+        assert second.points[0].percentileValues[0].value == -123
+        assert second.points[0].percentileValues[1].percentile == 100
+        assert second.points[0].percentileValues[1].value == -123
+        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+
+        assert third.descriptor.name == 'another-long-value-recorder'
+        assert third.descriptor.description == 'long value-recorder'
+        assert third.descriptor.unit == '1'
+        assert third.descriptor.constantLabels == Labels.empty()
+        assert third.descriptor.type == SUMMARY
+        assert third.points.size() == 1
+        assert third.points[0].count == 1
+        assert third.points[0].sum == 345
+        assert third.points[0].percentileValues[0].percentile == 0
+        assert third.points[0].percentileValues[0].value == 345
+        assert third.points[0].percentileValues[1].percentile == 100
+        assert third.points[0].percentileValues[1].value == 345
+        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+
+        assert fourth.descriptor.name == 'yet-another-long-value-recorder'
+        assert fourth.descriptor.description == ''
+        assert fourth.descriptor.unit == '1'
+        assert fourth.descriptor.constantLabels == Labels.empty()
+        assert fourth.descriptor.type == SUMMARY
+        assert fourth.points.size() == 1
+        assert fourth.points[0].count == 1
+        assert fourth.points[0].sum == 456
+        assert fourth.points[0].percentileValues[0].percentile == 0
+        assert fourth.points[0].percentileValues[0].value == 456
+        assert fourth.points[0].percentileValues[1].percentile == 100
+        assert fourth.points[0].percentileValues[1].value == 456
+        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+    }
+
+    def "long value recorder memoization"() {
+        when:
+        def lvrOne = otel.longValueRecorder('lvr', 'long value')
+        lvrOne.record(10, Labels.of('key', 'value'))
+        def lvrTwo = otel.longValueRecorder('lvr', 'long value')
+        lvrTwo.record(-10, Labels.of('key', 'value'))
+
+        then:
+        assert lvrOne.is(lvrTwo)
+
+        def metrics = exportMetrics()
+        assert metrics.size() == 1
+        def metric = metrics[0]
+
+        assert metric.descriptor.name == 'lvr'
+        assert metric.descriptor.description == 'long value'
+        assert metric.descriptor.unit == '1'
+        assert metric.descriptor.constantLabels == Labels.empty()
+        assert metric.descriptor.type == SUMMARY
+        assert metric.points.size() == 1
+        assert metric.points[0].count == 2
+        assert metric.points[0].sum == 0
+        assert metric.points[0].percentileValues[0].percentile == 0
+        assert metric.points[0].percentileValues[0].value == -10
+        assert metric.points[0].percentileValues[1].percentile == 100
+        assert metric.points[0].percentileValues[1].value == 10
+        assert metric.points[0].labels == Labels.of('key', 'value')
+    }
+
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -34,7 +34,7 @@ import spock.lang.Specification
 class OtelHelperSynchronousMetricTest extends Specification{
 
     @Shared
-    GroovyUtils gutil
+    GroovyMetricEnvironment gme
 
     @Shared
     OtelHelper otel
@@ -43,13 +43,13 @@ class OtelHelperSynchronousMetricTest extends Specification{
 
     def setup() {
         // Set up a MeterSdk per test to be able to collect its metrics alone
-        gutil = new GroovyUtils(
+        gme = new GroovyMetricEnvironment(
                 new JmxConfig(new Properties().tap {
                     it.setProperty(JmxConfig.EXPORTER_TYPE, 'inmemory')
                 }),
                 name.methodName, ''
                 )
-        otel = new OtelHelper(null, gutil)
+        otel = new OtelHelper(null, gme)
     }
 
     def exportMetrics() {

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -44,9 +44,9 @@ class OtelHelperSynchronousMetricTest extends Specification{
     def setup() {
         // Set up a MeterSdk per test to be able to collect its metrics alone
         gutil = new GroovyUtils(
-                new JmxConfig().tap {
-                    exporterType = 'inmemory'
-                },
+                new JmxConfig(new Properties().tap {
+                    it.setProperty(JmxConfig.EXPORTER_TYPE, 'inmemory')
+                }),
                 name.methodName, ''
                 )
         otel = new OtelHelper(null, gutil)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -78,7 +78,7 @@ class OtlpIntegrationTests extends IntegrationTest  {
         InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
-        il.name  == 'jmx-metrics'
+        il.name  == 'io.opentelemetry.contrib.jmxmetrics'
         il.version == '0.0.1'
 
         when: 'we examine the instrumentation library metric metrics list'

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -16,7 +16,6 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import spock.lang.Requires
 
 import static io.opentelemetry.proto.metrics.v1.MetricDescriptor.Type.SUMMARY
 import static org.junit.Assert.assertTrue
@@ -34,11 +33,14 @@ import io.opentelemetry.proto.metrics.v1.MetricDescriptor
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics
 import io.opentelemetry.proto.metrics.v1.SummaryDataPoint
 import org.testcontainers.Testcontainers
+import spock.lang.Requires
 import spock.lang.Shared
+import spock.lang.Timeout
 
 @Requires({
     System.getProperty('ojc.integration.tests') == 'true'
 })
+@Timeout(60)
 class OtlpIntegrationTests extends IntegrationTest  {
 
     @Shared

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import spock.lang.Requires
+
+import static io.opentelemetry.proto.metrics.v1.MetricDescriptor.Type.SUMMARY
+import static org.junit.Assert.assertTrue
+
+import io.grpc.ServerBuilder
+import io.grpc.stub.StreamObserver
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceResponse
+import io.opentelemetry.proto.collector.metrics.v1.MetricsServiceGrpc
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.MetricDescriptor
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import io.opentelemetry.proto.metrics.v1.SummaryDataPoint
+import org.testcontainers.Testcontainers
+import spock.lang.Shared
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+class OtlpIntegrationTests extends IntegrationTest  {
+
+    @Shared
+    def collector = new Collector()
+    @Shared
+    def collectorServer = ServerBuilder.forPort(55680).addService(collector).build()
+
+    def setupSpec() {
+        Testcontainers.exposeHostPorts(55680)
+        configureContainers('otlp_config.properties', 0)
+    }
+
+    def setup() {
+        collectorServer.start()
+    }
+
+    def cleanupSpec() {
+        collectorServer.shutdown()
+    }
+
+    def 'end to end'() {
+        when: 'we receive metrics from the JMX metrics gatherer'
+        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+        then: 'they are of the expected size'
+        receivedMetrics.size() == 1
+
+        when: "we examine the received metric's instrumentation library metrics lists"
+        ResourceMetrics receivedMetric = receivedMetrics.get(0)
+        List<InstrumentationLibraryMetrics> ilMetrics =
+                receivedMetric.instrumentationLibraryMetricsList
+        then: 'they of the expected size'
+        ilMetrics.size() == 1
+
+        when: 'we examine the instrumentation library'
+        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+        InstrumentationLibrary il = ilMetric.instrumentationLibrary
+        then: 'it is of the expected content'
+        il.name  == 'jmx-metrics'
+        il.version == '0.0.1'
+
+        when: 'we examine the instrumentation library metric metrics list'
+        List<Metric> metrics = ilMetric.metricsList
+        then: 'it is of the expected size'
+        metrics.size() == 1
+
+        when: 'we examine the metric descriptor'
+        Metric metric = metrics.get(0)
+        MetricDescriptor md = metric.metricDescriptor
+        then: 'it is of the expected content'
+        md.name == 'cassandra.storage.load'
+        md.description == 'Size, in bytes, of the on disk data size this node manages'
+        md.unit == 'By'
+        md.type == SUMMARY
+
+        when: 'we examine the datapoints'
+        List<SummaryDataPoint> datapoints = metric.summaryDataPointsList
+        then: 'they are of the expected size'
+        datapoints.size() == 1
+
+        when: 'we example the datapoint labels and sum'
+        SummaryDataPoint datapoint = datapoints.get(0)
+        List<StringKeyValue> labels = datapoint.labelsList
+        def sum = datapoint.sum
+        then: 'they are of the expected content'
+        labels.size() == 1
+        labels.get(0) == StringKeyValue.newBuilder().setKey("myKey").setValue("myVal").build()
+        datapoint.count == 1
+        datapoint.getPercentileValues(0).value == sum
+        datapoint.getPercentileValues(1).value == sum
+    }
+
+    static final class Collector extends MetricsServiceGrpc.MetricsServiceImplBase {
+        private final List<ResourceMetrics> receivedMetrics = new ArrayList<>()
+        private final Object monitor = new Object()
+
+        @Override
+        void export(
+                ExportMetricsServiceRequest request,
+                StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+            synchronized (receivedMetrics) {
+                receivedMetrics.addAll(request.resourceMetricsList)
+            }
+            synchronized (monitor) {
+                monitor.notify()
+            }
+            responseObserver.onNext(ExportMetricsServiceResponse.newBuilder().build())
+            responseObserver.onCompleted()
+        }
+
+        List<ResourceMetrics> getReceivedMetrics() {
+            List<ResourceMetrics> received
+            try {
+                synchronized (monitor) {
+                    monitor.wait(15000)
+                }
+            } catch (final InterruptedException e) {
+                assertTrue(e.message, false)
+            }
+
+            synchronized (receivedMetrics) {
+                received = new ArrayList<>(receivedMetrics)
+                receivedMetrics.clear()
+            }
+            return received
+        }
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
@@ -52,17 +52,17 @@ class PrometheusIntegrationTests extends IntegrationTest {
         then: 'they are of the expected format'
         scraped.size() == 6
         scraped[0].contains(
-                '# HELP jmx_metrics_cassandra_storage_load Size, in bytes, of the on disk data size this node manages')
+                '# HELP io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load Size, in bytes, of the on disk data size this node manages')
         scraped[1].contains(
-                '# TYPE jmx_metrics_cassandra_storage_load summary')
+                '# TYPE io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load summary')
         scraped[2].contains(
-                'jmx_metrics_cassandra_storage_load_count{myKey="myVal",} ')
+                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load_count{myKey="myVal",} ')
         scraped[3].contains(
-                'jmx_metrics_cassandra_storage_load_sum{myKey="myVal",} ')
+                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load_sum{myKey="myVal",} ')
         scraped[4].contains(
-                'jmx_metrics_cassandra_storage_load{myKey="myVal",quantile="0.0",} ')
+                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load{myKey="myVal",quantile="0.0",} ')
 
         scraped[5].contains(
-                'jmx_metrics_cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
+                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import org.apache.hc.client5.http.fluent.Request
+import spock.lang.Requires;
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+class PrometheusIntegrationTests extends IntegrationTest {
+
+    def setupSpec() {
+        configureContainers('prometheus_config.properties', 9123)
+    }
+
+    def receivedMetrics() {
+        def received = ''
+        while (received == '' || received.charAt(0) != '#') {
+            Thread.sleep(500)
+            received = Request.get("http://localhost:${jmxExposedPort}/metrics").execute().returnContent().asString()
+        }
+        return received
+    }
+
+    def 'end to end'() {
+        when: 'we receive metrics from the prometheus endpoint'
+        def scraped = receivedMetrics().split('\n')
+
+        then: 'they are of the expected format'
+        scraped.size() == 6
+        scraped[0].contains(
+                '# HELP jmx_metrics_cassandra_storage_load Size, in bytes, of the on disk data size this node manages')
+        scraped[1].contains(
+                '# TYPE jmx_metrics_cassandra_storage_load summary')
+        scraped[2].contains(
+                'jmx_metrics_cassandra_storage_load_count{myKey="myVal",} ')
+        scraped[3].contains(
+                'jmx_metrics_cassandra_storage_load_sum{myKey="myVal",} ')
+        scraped[4].contains(
+                'jmx_metrics_cassandra_storage_load{myKey="myVal",quantile="0.0",} ')
+
+        scraped[5].contains(
+                'jmx_metrics_cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/jmxremote.password
+++ b/contrib/jmx-metrics/src/test/resources/jmxremote.password
@@ -1,0 +1,1 @@
+correctUsername   correctPassword

--- a/contrib/jmx-metrics/src/test/resources/otlp_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/otlp_config.properties
@@ -1,0 +1,9 @@
+otel.jmx.metrics.interval.milliseconds = 3000
+otel.jmx.metrics.exporter.type = otlp
+otel.jmx.metrics.exporter.otlp.endpoint = host.testcontainers.internal:55680
+otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.metrics.groovy.script = /app/script.groovy
+
+# these will be overridden by cmd line
+otel.jmx.metrics.username = wrong_username
+otel.jmx.metrics.password = wrong_password

--- a/contrib/jmx-metrics/src/test/resources/otlp_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/otlp_config.properties
@@ -1,9 +1,9 @@
-otel.jmx.metrics.interval.milliseconds = 3000
-otel.jmx.metrics.exporter.type = otlp
-otel.jmx.metrics.exporter.otlp.endpoint = host.testcontainers.internal:55680
-otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
-otel.jmx.metrics.groovy.script = /app/script.groovy
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = otlp
+otel.otlp.endpoint = host.testcontainers.internal:55680
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.groovy.script = /app/script.groovy
 
 # these will be overridden by cmd line
-otel.jmx.metrics.username = wrong_username
-otel.jmx.metrics.password = wrong_password
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password

--- a/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
@@ -1,0 +1,10 @@
+otel.jmx.metrics.interval.milliseconds = 3000
+otel.jmx.metrics.exporter.type = prometheus
+otel.jmx.metrics.exporter.prometheus.host = 0.0.0.0
+otel.jmx.metrics.exporter.prometheus.port = 9123
+otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.metrics.groovy.script = /app/script.groovy
+
+# these will be overridden by cmd line
+otel.jmx.metrics.username = wrong_username
+otel.jmx.metrics.password = wrong_password

--- a/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
@@ -1,10 +1,10 @@
-otel.jmx.metrics.interval.milliseconds = 3000
-otel.jmx.metrics.exporter.type = prometheus
-otel.jmx.metrics.exporter.prometheus.host = 0.0.0.0
-otel.jmx.metrics.exporter.prometheus.port = 9123
-otel.jmx.metrics.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
-otel.jmx.metrics.groovy.script = /app/script.groovy
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = prometheus
+otel.prometheus.host = 0.0.0.0
+otel.prometheus.port = 9123
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.groovy.script = /app/script.groovy
 
 # these will be overridden by cmd line
-otel.jmx.metrics.username = wrong_username
-otel.jmx.metrics.password = wrong_password
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password

--- a/contrib/jmx-metrics/src/test/resources/script.groovy
+++ b/contrib/jmx-metrics/src/test/resources/script.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.opentelemetry.common.Labels
+
+def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
+def load = loadMatches.first()
+
+def lvr = otel.longValueRecorder(
+        "cassandra.storage.load",
+        "Size, in bytes, of the on disk data size this node manages",
+        "By"
+        )
+lvr.record(load.Count, Labels.of("myKey", "myVal"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
 
-ojc.integration.test=false
+ojc.integration.tests=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
+
+ojc.integration.test=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'opentelemetry-java-contrib'
 
 include ':example'
+include ':jmx-metrics'
 
 rootProject.children.each {
     it.projectDir = "${rootDir}/contrib/" + it.name as File


### PR DESCRIPTION
**Description:**
Feature addition - Provides a new utility for running groovy scripts for the creation of custom, JMX attribute-based metrics.  It currently supports otlp, prometheus, logging, and inmemory (testing) exporters.

**Testing:**
Added basic unit and integration tests w/ associated make target and properties and circleci job.

**Documentation:**
Library has own documentation and link provided in project readme.

**Outstanding items:**
This addition doesn't provided asynchronous instrument support, and this will need to be added in a subsequent PR.
Publishing isn't included, and neither are report or ci artifacts.  These will be addressed in another PR, potentially w/ github actions adoption.
There is also a likely a need to be able to read configuration from stdin when this is used by an upcoming Collector extension.
