### PR TITLE
Adopt otel-java 0.8.0

### DIFF
--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
@@ -52,17 +52,16 @@ class PrometheusIntegrationTests extends IntegrationTest {
         then: 'they are of the expected format'
         scraped.size() == 6
         scraped[0].contains(
-                '# HELP io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load Size, in bytes, of the on disk data size this node manages')
+                '# HELP cassandra_storage_load Size, in bytes, of the on disk data size this node manages')
         scraped[1].contains(
-                '# TYPE io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load summary')
+                '# TYPE cassandra_storage_load summary')
         scraped[2].contains(
-                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load_count{myKey="myVal",} ')
+                'cassandra_storage_load_count{myKey="myVal",} ')
         scraped[3].contains(
-                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load_sum{myKey="myVal",} ')
+                'cassandra_storage_load_sum{myKey="myVal",} ')
         scraped[4].contains(
-                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load{myKey="myVal",quantile="0.0",} ')
-
+                'cassandra_storage_load{myKey="myVal",quantile="0.0",} ')
         scraped[5].contains(
-                'io_opentelemetry_contrib_jmxmetrics_cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
+                'cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     versions = [
-        otelStable : '0.7.1'
+        otelStable : '0.8.0'
     ]
 
     libraries = [


### PR DESCRIPTION
**Description:**
Bumps the opentelemetry-java deps to 0.8.0.  Also updates proto usage in jmx metric gatherer integration tests.

**Testing:**

Required test updates only.

**Outstanding items:**

We will need to establish an approach to versioning and support as more functionality is adopted so that these updates aren't necessarily breaking changes. (edit, opened https://github.com/open-telemetry/opentelemetry-java-contrib/issues/8)
