### PR TITLE
jmx metrics: Allow properties file contents from stdin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
       - image: circleci/openjdk:8-jdk
   integration:
     machine:
+      resource_class: large
       image: ubuntu-1604:201903-01
 jobs:
   build:

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -7,7 +7,7 @@ object with methods for obtaining MBeans and constructing synchronous OpenTeleme
 ### Usage
 
 ```bash
-$ java -D<otel.jmx.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config ./optional_config.properties]
+$ java -D<otel.jmx.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config {optional_config.properties, '-'}]
 ```
 
 ##### `optional_config.properties` example
@@ -90,7 +90,8 @@ This metric extension supports Java 7+, though SASL is only supported where
 ### Configuration
 
 The following properties are supported via the command line or specified config properties file `(-config)`.
-Those provided as command line properties take priority of those contained in a properties file.
+Those provided as command line properties take priority of those contained in a properties file.  Properties
+file contents can also be provided via stdin on startup when using `-config -` as an option.
 
 | Property | Required | Description |
 | ------------- | -------- | ----------- |

--- a/contrib/jmx-metrics/src/test/resources/otlp_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/otlp_config.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
 otel.exporter = otlp
-otel.otlp.endpoint = host.testcontainers.internal:55680
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
 otel.jmx.groovy.script = /app/script.groovy
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
+otel.otlp.endpoint = host.testcontainers.internal:80


### PR DESCRIPTION
**Description:**
Feature addition - These changes introduce the ability to provide jmx metric gatherer configuration properties over stdin when using `-` as the file identifier.

**Testing:**

Parameterized jmx integration tests to use properties file directly and piped.

**Documentation:**

Updated jmx metric gatherer readme.

**Outstanding items:**

These changes don't introduce any dynamic property configuration mechanism and the functionality of the utility is still determined wholly at startup.
