### PR TITLE
Add local maven and oss-snapshot-local artifactory publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,11 @@ test:
 .PHONY: integration-test
 integration-test:
 	./gradlew -Pojc.integration.tests=true test
+
+.PHONY: maven-publish
+maven-publish:
+	./gradlew publish
+
+.PHONY: oss-snapshot
+oss-snapshot:
+	./gradlew artifactoryPublish

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+# Releasing OpenTelemetry Java Contrib Artifacts
+
+This project currently has two make targets capable of preparing and releasing artifacts: `maven-publish`
+and `oss-snapshot`.  In order for you to register your contributed project to be published by these commands,
+you must apply the provided publish script plugin in your subproject's gradle file:
+
+```groovy
+apply from: project.publish
+```
+
+To set the desired library name and description for your artifact's pom file, you can set the `libraryName`
+project property and project description:
+
+```groovy
+ext.libraryName = 'An OpenTelemetry Java Contrib Library'
+description = 'An OpenTelemetry-based library for improving the observability of your application'
+```
+
+If you are using the [shadow gradle plugin](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow)
+and would like your `shadowJar` task-produced artifact published, please set the `shadowPublish` project
+property to `true` in your subproject's gradle file:
+
+```groovy
+apply plugin: 'com.github.johnrengelman.shadow'
+ext.shadowPublish = true
+```
+
+## `make maven-publish`
+
+This make target will invoke the [Maven Publish](https://docs.gradle.org/current/userguide/publishing_maven.html) task
+and publish all applicable artifacts to a `build/repo` directory in the root OpenTelemetry Java Contrib project path of
+your machine. The ability to publish to a stable remote repository like Maven Central is not provided at this time.
+
+## `make oss-snapshot`
+
+This make target will invoke the [Artifactory Plugin](https://www.jfrog.com/confluence/display/JFROG/Gradle+Artifactory+Plugin)
+and publish all applicable snapshot artifacts to https://oss.jfrog.org/artifactory/oss-snapshot-local.  It's important
+to note that these snapshot releases are often from unstable development states and should generally not be used in
+production environments.
+
+This task requires an account and API key for the OpenTelemetry Bintray organization.  If you have been provided access
+and configured your key, please set the required environment variables detailed in the publish script plugin.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.diffplug.spotless' version '5.1.1'
+    id "com.github.johnrengelman.shadow" version "6.0.0" apply false
     id "com.jfrog.artifactory" version "4.17.2" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.diffplug.spotless' version '5.1.1'
+    id "com.jfrog.artifactory" version "4.17.2" apply false
 }
 
 description = 'OpenTelemetry Contrib libraries and utilities for the JVM'
@@ -12,6 +13,7 @@ allprojects {
     apply from: "$rootDir/gradle/dependencies.gradle"
 
     it.ext.contrib = "$rootDir/gradle/contrib.gradle"
+    it.ext.publish = "$rootDir/gradle/publish.gradle"
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ description = 'OpenTelemetry Contrib libraries and utilities for the JVM'
 
 allprojects {
     group = 'io.opentelemetry.contrib'
-    version = '0.0.1'
+    version = '0.0.1-SNAPSHOT'
 
     apply from: "$rootDir/gradle/spotless.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"

--- a/contrib/example/example.gradle
+++ b/contrib/example/example.gradle
@@ -1,5 +1,6 @@
 apply from: project.contrib
 
+ext.libraryName = 'OpenTelemetry Java Contrib Example'
 description = 'An example OpenTelemetry Java Contrib library'
 
 jar {

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -7,7 +7,7 @@ object with methods for obtaining MBeans and constructing synchronous OpenTeleme
 ### Usage
 
 ```bash
-$ java -D<otel.jmx.property=value> -jar io.opentelemetry.contrib.jmx-metrics-<version>-all.jar [-config {optional_config.properties, '-'}]
+$ java -D<otel.jmx.property=value> -jar opentelemetry-java-contrib-jmx-metrics-<version>.jar [-config {optional_config.properties, '-'}]
 ```
 
 ##### `optional_config.properties` example

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -1,13 +1,14 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "6.0.0"
     id "application"
 }
 
 apply from: project.contrib
 apply plugin: 'com.github.johnrengelman.shadow'
+apply from: project.publish
 
-archivesBaseName = 'io.opentelemetry.contrib.jmx-metrics'
+ext.shadowPublish = true
 
+ext.libraryName = 'OpenTelemetry Java Contrib JMX Metric Gatherer'
 description = 'JMX metrics gathering Groovy script runner'
 
 // we are joint compiling so rely on groovy plugin entirely
@@ -64,6 +65,11 @@ dependencies {
             'org.apache.httpcomponents.client5:httpclient5-fluent:5.0.1',
             deps.testcontainers,
             libraries.otelProto
+}
+
+shadowJar {
+    // This should always be standalone, so remove '-all' to prevent unnecessary artifact.
+    archiveClassifier.set('')
 }
 
 tasks.withType(Test) {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,0 +1,82 @@
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.artifactory'
+
+publishing {
+    repositories {
+        maven {
+            url = "$rootDir/build/repo"
+        }
+    }
+
+    publications {
+        maven(MavenPublication) {
+            if (project.tasks.findByName('shadowJar') != null && findProperty('shadowPublish')) {
+                project.shadow.component(it)
+            } else {
+                from components.java
+            }
+
+            afterEvaluate {
+                artifactId = artifactPrefix(archivesBaseName) + archivesBaseName
+            }
+
+            pom {
+                name = 'OpenTelemetry Java Contrib'
+                packaging = 'jar'
+                url = 'https://github.com/open-telemetry/opentelemetry-java-contrib'
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'opentelemetry'
+                        name = 'OpenTelemetry Gitter'
+                        url = 'https://gitter.im/open-telemetry/community'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git@github.com:open-telemetry/opentelemetry-java-contrib.git'
+                    developerConnection = 'scm:git:git@github.com:open-telemetry/opentelemetry-java-contrib.git'
+                    url = 'git@github.com:open-telemetry/opentelemetry-java-contrib.git'
+                }
+
+                afterEvaluate {
+                    // these properties aren't available until evaluated
+                    if (project.findProperty('libraryName') != null) {
+                        name = project.getProperty('libraryName')
+                    }
+                    description = project.description
+                }
+            }
+        }
+    }
+}
+
+def artifactPrefix(archivesBaseName) {
+    if (archivesBaseName.startsWith(rootProject.name)) {
+        return ''
+    }
+    return rootProject.name
+}
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = System.getenv('BINTRAY_USER')
+            password = System.getenv('BINTRAY_API_KEY')
+        }
+    }
+}
+
+artifactoryPublish {
+    enabled = version.toString().contains('SNAPSHOT')
+    publications('maven')
+}


### PR DESCRIPTION
**Description:**

Feature addition - These changes add maven and artifactory publishing task configurations for contrib projects, and source them in the jmx-metrics project.  They are based on current otel java and java-instrumentation publishing and include:

* Setting 0.0.1-SNAPSHOT version
* Local maven publishing via `gradle publish`, which publishes artifacts to `build/repo` directory.
* Artifactory snapshot publishing via `gradle artifactoryPublish`, which publishes to https://oss.jfrog.org/artifactory.

**Testing:**

Manually tested: https://oss.jfrog.org/artifactory/oss-snapshot-local/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/0.0.1-SNAPSHOT/

**Documentation:**

Added a RELEASE.md file w/ details.

**Outstanding items:**

No automation has been added to use these tasks, and I plan on moving to gh actions before this is implemented.  Also does not resolve versioning approach - https://github.com/open-telemetry/opentelemetry-java-contrib/issues/8.
