### PR TITLE
JMX Metrics: add target system script support

### DIFF
--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -45,7 +45,7 @@ class JmxMetrics {
       throw new ConfigurationException("Malformed serviceUrl: ", e);
     }
 
-    runner = new GroovyRunner(config.groovyScript, jmxClient, new GroovyMetricEnvironment(config));
+    runner = new GroovyRunner(config, jmxClient, new GroovyMetricEnvironment(config));
   }
 
   private void start() {

--- a/contrib/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+++ b/contrib/jmx-metrics/src/main/resources/target-systems/jvm.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+// This is a placeholder for default metric functionality
+// per https://github.com/open-telemetry/opentelemetry-java-contrib/issues/12
+
+def counter = otel.longCounter("placeholder.metric", "For testing purposes")
+counter.add(1)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+class GroovyRunnerTest extends UnitTest {
+
+    def 'target system scripts are loaded from resources'() {
+        when: 'available target system script is used'
+        System.setProperty('otel.jmx.service.url', 'requiredValue')
+        System.setProperty('otel.jmx.target.system', 'jvm')
+        def config = new JmxConfig()
+        config.validate()
+
+        def exportCalled = false
+
+        def groovyRunner = new GroovyRunner(config, null, new GroovyMetricEnvironment(config) {
+                    @Override
+                    void exportMetrics() {
+                        exportCalled = true
+                    }
+                })
+
+        then: 'it is successfully loaded and runnable'
+        groovyRunner.script != null
+        groovyRunner.run()
+        exportCalled
+    }
+
+    def 'unavailable target system scripts are attempted to be loaded'() {
+        when: 'unavailable target system script is used'
+        System.setProperty('otel.jmx.service.url', 'requiredValue')
+        System.setProperty('otel.jmx.target.system', 'notAProvidededTargetSystem')
+        def config = new JmxConfig()
+
+        then: 'it fails to successfully load'
+        def raised = null
+        try {
+            def groovyRunner = new GroovyRunner(config, null, null)
+        } catch (ConfigurationException e) {
+            raised = e
+        }
+        raised != null
+        raised.message == 'Failed to load target-systems/notaprovidededtargetsystem.groovy'
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -16,35 +16,12 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import spock.lang.Specification
 
+class JmxConfigTest extends UnitTest {
 
-class JmxConfigTest extends Specification {
-
-    void clearProperties() {
-        // ensure relevant properties aren't set
-        def properties = [
-            "jmx.service.url",
-            "jmx.groovy.script",
-            "jmx.interval.milliseconds",
-            "exporter",
-            "otlp.endpoint",
-            "prometheus.host",
-            "prometheus.port",
-            "jmx.username",
-            "jmx.password",
-            "jmx.remote.profile",
-            "jmx.realm"
-        ]
-        properties.each {System.clearProperty("otel.${it}")}
-    }
-
-    def setup() {
-        clearProperties()
-    }
-
-    def cleanupSpec() {
-        clearProperties()
+    def 'static values'() {
+        expect: 'static values to be expected'
+        JmxConfig.AVAILABLE_TARGET_SYSTEMS == ["jvm"]
     }
 
     def 'default values'() {
@@ -54,6 +31,7 @@ class JmxConfigTest extends Specification {
         then:
         config.serviceUrl == null
         config.groovyScript == null
+        config.targetSystem == ""
         config.intervalMilliseconds == 10000
         config.exporterType == "logging"
         config.otlpExporterEndpoint == null
@@ -70,6 +48,7 @@ class JmxConfigTest extends Specification {
         def properties = [
             "jmx.service.url" : "myServiceUrl",
             "jmx.groovy.script" : "myGroovyScript",
+            "jmx.target.system" : "mytargetsystem",
             "jmx.interval.milliseconds": "123",
             "exporter": "inmemory",
             "otlp.endpoint": "myOtlpEndpoint",
@@ -86,6 +65,7 @@ class JmxConfigTest extends Specification {
         then:
         config.serviceUrl == "myServiceUrl"
         config.groovyScript == "myGroovyScript"
+        config.targetSystem == "mytargetsystem"
         config.intervalMilliseconds == 123
         config.exporterType == "inmemory"
         config.otlpExporterEndpoint == "myOtlpEndpoint"
@@ -110,11 +90,55 @@ class JmxConfigTest extends Specification {
         expect: 'config fails to be created'
         raised != null
         raised.message ==  "Failed to parse ${prop}"
-        println "JmxConfigTest.invalid values: ${raised.message}"
 
         where:
         prop | _
         'otel.jmx.interval.milliseconds' | _
         'otel.prometheus.port' | _
+    }
+
+    def 'conflicting groovy script and target system'() {
+        setup: 'config is set with both groovy script and target system'
+        [
+            "service.url" : "requiredValue",
+            "groovy.script": "myGroovyScript",
+            "target.system": "myTargetSystem"
+        ].each {
+            System.setProperty("otel.jmx.${it.key}", it.value)
+        }
+        def config = new JmxConfig()
+
+        def raised = null
+        try {
+            config.validate()
+        } catch (ConfigurationException e) {
+            raised = e
+        }
+
+        expect: 'config fails to validate'
+        raised != null
+        raised.message ==  "Only one of otel.jmx.groovy.script or otel.jmx.target.system can be specified."
+    }
+
+    def "invalid target system"() {
+        setup: "config is set with nonexistant target system"
+        [
+            "service.url" : "requiredValue",
+            "target.system": "unavailableTargetSystem"
+        ].each {
+            System.setProperty("otel.jmx.${it.key}", it.value)
+        }
+        def config = new JmxConfig()
+
+        def raised = null
+        try {
+            config.validate()
+        } catch (ConfigurationException e) {
+            raised = e
+        }
+
+        expect: 'config fails to validate'
+        raised != null
+        raised.message ==  "unavailabletargetsystem must be one of [jvm]"
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import spock.lang.Specification
+
+
+class UnitTest extends Specification {
+
+    void clearProperties() {
+        // ensure relevant properties aren't set
+        def properties = [
+            "jmx.service.url",
+            "jmx.groovy.script",
+            "jmx.target.system",
+            "jmx.interval.milliseconds",
+            "exporter",
+            "otlp.endpoint",
+            "prometheus.host",
+            "prometheus.port",
+            "jmx.username",
+            "jmx.password",
+            "jmx.remote.profile",
+            "jmx.realm"
+        ]
+        properties.each {System.clearProperty("otel.${it}")}
+    }
+
+    def setup() {
+        clearProperties()
+    }
+
+    def cleanupSpec() {
+        clearProperties()
+    }
+}

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import org.apache.hc.client5.http.fluent.Request
+import spock.lang.Requires
+import spock.lang.Timeout
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+@Timeout(60)
+class JVMTargetSystemIntegrationTests extends IntegrationTest {
+
+    def receivedMetrics() {
+        def scraped = []
+        for (int i = 0; i < 120; i++) {
+            def resp = Request.get("http://localhost:${jmxExposedPort}/metrics").execute()
+            def received = resp.returnContent().asString()
+            if (received != '') {
+                scraped = received.split('\n')
+                if (scraped.size() > 2) {
+                    break
+                }
+            }
+            Thread.sleep(500)
+        }
+        return scraped
+    }
+
+    def 'end to end'() {
+        setup: 'we configure JMX metrics gatherer and target server to use default JVM target system script'
+        configureContainers('jvm_config.properties', 0, 9123, false)
+
+        expect:
+        when: 'we receive metrics from the prometheus endpoint'
+        def scraped = receivedMetrics()
+
+        then: 'they are of the expected format'
+        scraped.size() == 3
+        scraped[0].contains(
+                '# HELP placeholder_metric For testing purposes')
+        scraped[1].contains(
+                '# TYPE placeholder_metric counter')
+        scraped[2].contains(
+                'placeholder_metric 1.0')
+
+        cleanup:
+        cassandraContainer.stop()
+        jmxExtensionAppContainer.stop()
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/jvm_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/jvm_config.properties
@@ -1,0 +1,10 @@
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = prometheus
+otel.prometheus.host = 0.0.0.0
+otel.prometheus.port = 9123
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
+otel.jmx.target.system = jvm
+
+# these will be overridden by cmd line
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password


### PR DESCRIPTION
**Description:**
Feature addition - Adds a new "target system" feature to the jmx metric gatherer that will allow built in metric gathering capabilities via a new `otel.jmx.target.system` property in lieu of `otel.jmx.groovy.script`.  The intention is that built in content will be distributed as resources.

`otel.jmx.target.system = jvm`

Also includes breaking out* test helpers to reuse cleanup logic*.

Feedback/suggestions for naming could be helpful as "target system" can connote the address over application sense.

**Existing Issue(s):**

Will help provide the mechanism to satisfy https://github.com/open-telemetry/opentelemetry-java-contrib/issues/12 without the actual default metric generation.

**Testing:**

Added unit and integration test suites.

**Documentation:**

I'm not sure any documentation should be added until we provide the first default metric gathering script.

**Outstanding items:**

Aforementioned default script aside from its testable placeholder. 
