### PR TITLE
Add Kafka Broker JMX Metrics

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -125,6 +125,7 @@ The currently available target systems are:
 | ------------------------ |
 | [`jvm`](./docs/target-systems/jvm.md) |
 | [`cassandra`](./docs/target-systems/cassandra.md) |
+| [`kafka`](./docs/target-systems/kafka.md) |
 
 ### Configuration
 

--- a/contrib/jmx-metrics/docs/target-systems/kafka.md
+++ b/contrib/jmx-metrics/docs/target-systems/kafka.md
@@ -1,0 +1,130 @@
+# Kafka Metrics
+
+The JMX Metric Gatherer provides built in Kafka metric gathering capabilities for versions v0.8.2.x and above.
+These metrics are sourced from Kafka's exposed Yammer metrics for each instance: https://kafka.apache.org/documentation/#monitoring
+
+## Metrics
+
+### Broker Metrics
+
+* Name: `kafka.messages.in`
+* Description: Number of messages in per second
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.bytes.in`
+* Description: Bytes in per second from clients
+* Unit: `by`
+* Instrument Type: LongCounter
+
+* Name: `kafka.bytes.out`
+* Description: Bytes out per second to clients
+* Unit: `by`
+* Instrument Type: LongCounter
+
+* Name: `kafka.isr.shrinks`
+* Description: In-sync replica shrinks per second
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.isr.expands`
+* Description: In-sync replica expands per second
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.max.lag`
+* Description: Max lag in messages between follower and leader replicas
+* Unit: `1`
+* Instrument Type: LongUpDownCounter
+
+* Name: `kafka.controller.active.count`
+* Description: Controller is active on broker
+* Unit: `1`
+* Instrument Type: LongUpDownCounter
+
+* Name: `kafka.partitions.offline.count`
+* Description: Number of partitions without an active leader
+* Unit: `1`
+* Instrument Type: LongUpDownCounter
+
+* Name: `kafka.partitions.underreplicated.count`
+* Description: Number of under replicated partitions
+* Unit: `1`
+* Instrument Type: LongUpDownCounter
+
+* Name: `kafka.leader.election.rate`
+* Description: Leader election rate - non-zero indicates broker failures
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.unclean.election.rate`
+* Description: Unclean leader election rate - non-zero indicates broker failures
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.request.queue`
+* Description: Size of the request queue
+* Unit: `1`
+* Instrument Type: LongUpDownCounter
+
+* Name: `kafka.fetch.consumer.total.time.count`
+* Description: Fetch consumer request count
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.fetch.consumer.total.time.median`
+* Description: Fetch consumer request time - 50th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.fetch.consumer.total.time.99p`
+* Description: Fetch consumer request time - 99th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.fetch.follower.total.time.count`
+* Description: Fetch follower request count
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.fetch.follower.total.time.median`
+* Description: Fetch follower request time - 50th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.fetch.follower.total.time.99p`
+* Description: Fetch follower request time - 99th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.produce.total.time.count`
+* Description: Produce request count
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.produce.total.time.median`
+* Description: Produce request time - 50th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.produce.total.time.99p`
+* Description: Produce request time - 99th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+### Log metrics
+
+* Name: `kafka.logs.flush.time.count`
+* Description: Log flush count
+* Unit: `1`
+* Instrument Type: LongCounter
+
+* Name: `kafka.logs.flush.time.median`
+* Description: Log flush time - 50th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter
+
+* Name: `kafka.logs.flush.time.99p`
+* Description: Log flush time - 99th percentile
+* Unit: `ms`
+* Instrument Type: DoubleUpDownCounter

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -38,7 +38,7 @@ class JmxConfig {
   static final String JMX_REMOTE_PROFILE = PREFIX + "jmx.remote.profile";
   static final String JMX_REALM = PREFIX + "jmx.realm";
 
-  static final List<String> AVAILABLE_TARGET_SYSTEMS = Arrays.asList("jvm", "cassandra");
+  static final List<String> AVAILABLE_TARGET_SYSTEMS = Arrays.asList("jvm", "kafka", "cassandra");
 
   final String serviceUrl;
   final String groovyScript;

--- a/contrib/jmx-metrics/src/main/resources/target-systems/kafka.groovy
+++ b/contrib/jmx-metrics/src/main/resources/target-systems/kafka.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def messagesInPerSec = otel.mbean("kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec")
+otel.instrument(messagesInPerSec, "kafka.messages.in", "number of messages in per second",
+        "1", "Count", otel.&longCounter)
+
+def bytesInPerSec = otel.mbean("kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec")
+otel.instrument(bytesInPerSec, "kafka.bytes.in", "bytes in per second from clients",
+        "by", "Count", otel.&longCounter)
+
+def bytesOutPerSec = otel.mbean("kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec")
+otel.instrument(bytesOutPerSec, "kafka.bytes.out", "bytes out per second to clients",
+        "by", "Count", otel.&longCounter)
+
+def isrShrinksPerSec = otel.mbean("kafka.server:type=ReplicaManager,name=IsrShrinksPerSec")
+otel.instrument(isrShrinksPerSec, "kafka.isr.shrinks", "in-sync replica shrinks per second",
+        "1", "Count", otel.&longCounter)
+
+def isrExpandsPerSec = otel.mbean("kafka.server:type=ReplicaManager,name=IsrExpandsPerSec")
+otel.instrument(isrExpandsPerSec, "kafka.isr.expands", "in-sync replica expands per second",
+        "1", "Count", otel.&longCounter)
+
+def maxLag = otel.mbean("kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica")
+otel.instrument(maxLag, "kafka.max.lag", "max lag in messages between follower and leader replicas",
+        "1", "Value", otel.&longUpDownCounter)
+
+def activeControllerCount = otel.mbean("kafka.controller:type=KafkaController,name=ActiveControllerCount")
+otel.instrument(activeControllerCount, "kafka.controller.active.count", "controller is active on broker",
+        "1", "Value", otel.&longUpDownCounter)
+
+def offlinePartitionsCount = otel.mbean("kafka.controller:type=KafkaController,name=OfflinePartitionsCount")
+otel.instrument(offlinePartitionsCount, "kafka.partitions.offline.count", "number of partitions without an active leader",
+        "1", "Value", otel.&longUpDownCounter)
+
+def underReplicatedPartitionsCount = otel.mbean("kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions")
+otel.instrument(underReplicatedPartitionsCount, "kafka.partitions.underreplicated.count", "number of under replicated partitions",
+        "1", "Value", otel.&longUpDownCounter)
+
+def leaderElectionRate = otel.mbean("kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs")
+otel.instrument(leaderElectionRate, "kafka.leader.election.rate", "leader election rate - non-zero indicates broker failures",
+        "1", "Count", otel.&longCounter)
+
+def uncleanLeaderElections = otel.mbean("kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec")
+otel.instrument(uncleanLeaderElections, "kafka.unclean.election.rate", "unclean leader election rate - non-zero indicates broker failures",
+        "1", "Count", otel.&longCounter)
+
+def requestQueueSize = otel.mbean("kafka.network:type=RequestChannel,name=RequestQueueSize")
+otel.instrument(requestQueueSize, "kafka.request.queue", "size of the request queue",
+        "1", "Value", otel.&longUpDownCounter)
+
+def fetchConsumer = otel.mbean("kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchConsumer")
+otel.instrument(fetchConsumer, "kafka.fetch.consumer.total.time.count", "fetch consumer request count",
+        "1", "Count", otel.&longCounter)
+otel.instrument(fetchConsumer, "kafka.fetch.consumer.total.time.median", "fetch consumer request time - 50th percentile",
+        "ms", "50thPercentile", otel.&doubleUpDownCounter)
+otel.instrument(fetchConsumer, "kafka.fetch.consumer.total.time.99p", "fetch consumer request time - 99th percentile",
+        "ms", "99thPercentile", otel.&doubleUpDownCounter)
+
+def fetchFollower = otel.mbean("kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchFollower")
+otel.instrument(fetchFollower, "kafka.fetch.follower.total.time.count", "fetch follower request count",
+        "1", "Count", otel.&longCounter)
+otel.instrument(fetchFollower, "kafka.fetch.follower.total.time.median", "fetch follower request time - 50th percentile",
+        "ms", "50thPercentile", otel.&doubleUpDownCounter)
+otel.instrument(fetchFollower, "kafka.fetch.follower.total.time.99p", "fetch follower request time - 99th percentile",
+        "ms", "99thPercentile", otel.&doubleUpDownCounter)
+
+def produce = otel.mbean("kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce")
+otel.instrument(produce, "kafka.produce.total.time.count", "produce request count",
+        "1", "Count", otel.&longCounter)
+otel.instrument(produce, "kafka.produce.total.time.median", "produce request time - 50th percentile",
+        "ms", "50thPercentile", otel.&doubleUpDownCounter)
+otel.instrument(produce, "kafka.produce.total.time.99p", "produce request time - 99th percentile",
+        "ms", "99thPercentile", otel.&doubleUpDownCounter)
+
+def logFlushRate = otel.mbean("kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs")
+otel.instrument(logFlushRate, "kafka.logs.flush.time.count", "log flush count",
+        "1", "Count", otel.&longCounter)
+otel.instrument(logFlushRate, "kafka.logs.flush.time.median", "log flush time - 50th percentile",
+        "ms", "50thPercentile", otel.&doubleUpDownCounter)
+otel.instrument(logFlushRate, "kafka.logs.flush.time.99p", "log flush time - 99th percentile",
+        "ms", "99thPercentile", otel.&doubleUpDownCounter)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -40,7 +40,10 @@ import spock.lang.Unroll
 class IntegrationTest extends Specification{
 
     @Shared
-    def cassandraContainer
+    def targets
+
+    @Shared
+    def targetContainers = []
 
     @Shared
     def jmxExtensionAppContainer
@@ -53,14 +56,7 @@ class IntegrationTest extends Specification{
 
         def scriptName = "script.groovy"
         def scriptPath = ClassLoader.getSystemClassLoader().getResource(scriptName).path
-
         def configPath = ClassLoader.getSystemClassLoader().getResource(configName).path
-
-        def cassandraDockerfile = ("FROM cassandra:3.11\n"
-                + "ENV LOCAL_JMX=no\n"
-                + "RUN echo 'cassandra cassandra' > /etc/cassandra/jmxremote.password\n"
-                + "RUN chmod 0400 /etc/cassandra/jmxremote.password\n")
-
         def network = Network.SHARED
 
         def jvmCommand = [
@@ -85,15 +81,26 @@ class IntegrationTest extends Specification{
             jvmCommand.add("/app/${configName}")
         }
 
-        cassandraContainer =
-                new GenericContainer<>(
-                new ImageFromDockerfile().withFileFromString("Dockerfile", cassandraDockerfile))
-                .withNetwork(network)
-                .withNetworkAliases("cassandra")
-                .withExposedPorts(7199)
-                .withStartupTimeout(Duration.ofSeconds(120))
-                .waitingFor(Wait.forListeningPort())
-        cassandraContainer.start()
+        if ("cassandra" in targets) {
+            targetContainers.add(
+                    new GenericContainer<>(
+                    new ImageFromDockerfile().withFileFromString("Dockerfile",
+                    ("FROM cassandra:3.11\n"
+                    + "ENV LOCAL_JMX=no\n"
+                    + "RUN echo 'cassandra cassandra' > /etc/cassandra/jmxremote.password\n"
+                    + "RUN chmod 0400 /etc/cassandra/jmxremote.password\n")
+                    )
+                    )
+                    .withNetwork(network)
+                    .withNetworkAliases("cassandra")
+                    .withExposedPorts(7199)
+                    .withStartupTimeout(Duration.ofSeconds(120))
+                    .waitingFor(Wait.forListeningPort())
+                    )
+        }
+        targetContainers.each {
+            it.start()
+        }
 
         jmxExtensionAppContainer =
                 new GenericContainer<>("openjdk:7u111-jre-alpine")
@@ -106,13 +113,15 @@ class IntegrationTest extends Specification{
                 .withCommand(jvmCommand as String[])
                 .withStartupTimeout(Duration.ofSeconds(120))
                 .waitingFor(Wait.forLogMessage(".*Started GroovyRunner.*", 1))
-                .dependsOn(cassandraContainer)
+                .dependsOn(targetContainers)
         if (prometheusPort != 0) {
             jmxExtensionAppContainer.withExposedPorts(prometheusPort)
         }
         jmxExtensionAppContainer.start()
 
-        assertTrue(cassandraContainer.running)
+        targetContainers.each {
+            assertTrue(it.running)
+        }
         assertTrue(jmxExtensionAppContainer.running)
 
         if (prometheusPort != 0) {

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -21,7 +21,7 @@ class JmxConfigTest extends UnitTest {
 
     def 'static values'() {
         expect: 'static values to be expected'
-        JmxConfig.AVAILABLE_TARGET_SYSTEMS == ["jvm", "cassandra"]
+        JmxConfig.AVAILABLE_TARGET_SYSTEMS == ["jvm", "kafka", "cassandra"]
     }
 
     def 'default values'() {
@@ -139,6 +139,6 @@ class JmxConfigTest extends UnitTest {
 
         expect: 'config fails to validate'
         raised != null
-        raised.message ==  "unavailabletargetsystem must be one of [jvm, cassandra]"
+        raised.message ==  "unavailabletargetsystem must be one of [jvm, kafka, cassandra]"
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -37,6 +37,7 @@ class OtlpIntegrationTests extends OtlpIntegrationTest {
     @Unroll
     def 'end to end with stdin config: #useStdin'() {
         setup: 'we configure JMX metrics gatherer and target server'
+        targets = ["cassandra"]
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('otlp_config.properties',  otlpPort, 0, useStdin)
 
@@ -91,7 +92,7 @@ class OtlpIntegrationTests extends OtlpIntegrationTest {
         datapoint.getBucketCounts(1).value == sum
 
         cleanup:
-        cassandraContainer.stop()
+        targetContainers.each { it.stop() }
         jmxExtensionAppContainer.stop()
 
         where:

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/PrometheusIntegrationTests.groovy
@@ -45,6 +45,7 @@ class PrometheusIntegrationTests extends IntegrationTest {
     @Unroll
     def 'end to end with stdin config: #useStdin'() {
         setup: 'we configure JMX metrics gatherer and target server'
+        targets = ["cassandra"]
         configureContainers('prometheus_config.properties', 0, 9123, useStdin)
 
         expect:
@@ -67,7 +68,7 @@ class PrometheusIntegrationTests extends IntegrationTest {
                 'cassandra_storage_load{myKey="myVal",quantile="100.0",} ')
 
         cleanup:
-        cassandraContainer.stop()
+        targetContainers.each { it.stop() }
         jmxExtensionAppContainer.stop()
 
         where:

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
@@ -36,6 +36,7 @@ class CassandraIntegrationTests extends OtlpIntegrationTest  {
 
     def 'end to end'() {
         setup: 'we configure JMX metrics gatherer and target server to use Cassandra as target system'
+        targets = ["cassandra"]
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/cassandra.properties',  otlpPort, 0, false)
 
@@ -231,7 +232,7 @@ class CassandraIntegrationTests extends OtlpIntegrationTest  {
         }
 
         cleanup:
-        cassandraContainer.stop()
+        targetContainers.each { it.stop() }
         jmxExtensionAppContainer.stop()
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -35,6 +35,7 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
 
     def 'end to end'() {
         setup: 'we configure JMX metrics gatherer and target server to use JVM as target system'
+        targets = ["cassandra"]
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/jvm.properties',  otlpPort, 0, false)
 
@@ -219,7 +220,7 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
         }
 
         cleanup:
-        cassandraContainer.stop()
+        targetContainers.each { it.stop() }
         jmxExtensionAppContainer.stop()
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.DoubleSum
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.IntSum
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import org.testcontainers.Testcontainers
+import spock.lang.Requires
+import spock.lang.Timeout
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+@Timeout(60)
+class KafkaTargetSystemIntegrationTests extends OtlpIntegrationTest {
+
+    def 'end to end'() {
+        setup: 'we configure JMX metrics gatherer and target server to use Kafka as target system'
+        targets = ["kafka"]
+        Testcontainers.exposeHostPorts(otlpPort)
+        configureContainers('target-systems/kafka.properties',  otlpPort, 0, false)
+
+        expect:
+        when: 'we receive metrics from the JMX metric gatherer'
+        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+        then: 'they are of the expected size'
+        receivedMetrics.size() == 1
+
+        when: "we examine the received metric's instrumentation library metrics lists"
+        ResourceMetrics receivedMetric = receivedMetrics.get(0)
+        List<InstrumentationLibraryMetrics> ilMetrics =
+                receivedMetric.instrumentationLibraryMetricsList
+        then: 'they of the expected size'
+        ilMetrics.size() == 1
+
+        when: 'we examine the instrumentation library metric metrics list'
+        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+        metrics.sort{ a, b -> a.name <=> b.name}
+        then: 'they are of the expected size and content'
+        metrics.size() == 21
+
+        def expectedMetrics = [
+            [
+                'kafka.bytes.in',
+                'bytes in per second from clients',
+                'by',
+                'int',
+            ],
+            [
+                'kafka.bytes.out',
+                'bytes out per second to clients',
+                'by',
+                'int',
+            ],
+            [
+                'kafka.controller.active.count',
+                'controller is active on broker',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.fetch.consumer.total.time.99p',
+                'fetch consumer request time - 99th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.fetch.consumer.total.time.count',
+                'fetch consumer request count',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.fetch.consumer.total.time.median',
+                'fetch consumer request time - 50th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.fetch.follower.total.time.99p',
+                'fetch follower request time - 99th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.fetch.follower.total.time.count',
+                'fetch follower request count',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.fetch.follower.total.time.median',
+                'fetch follower request time - 50th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.isr.expands',
+                'in-sync replica expands per second',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.isr.shrinks',
+                'in-sync replica shrinks per second',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.leader.election.rate',
+                'leader election rate - non-zero indicates broker failures',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.max.lag',
+                'max lag in messages between follower and leader replicas',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.messages.in',
+                'number of messages in per second',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.partitions.offline.count',
+                'number of partitions without an active leader',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.partitions.underreplicated.count',
+                'number of under replicated partitions',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.produce.total.time.99p',
+                'produce request time - 99th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.produce.total.time.count',
+                'produce request count',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.produce.total.time.median',
+                'produce request time - 50th percentile',
+                'ms',
+                'double',
+            ],
+            [
+                'kafka.request.queue',
+                'size of the request queue',
+                '1',
+                'int',
+            ],
+            [
+                'kafka.unclean.election.rate',
+                'unclean leader election rate - non-zero indicates broker failures',
+                '1',
+                'int',
+            ],
+        ].eachWithIndex{ item, index ->
+            Metric metric = metrics.get(index)
+            assert metric.name == item[0]
+            assert metric.description == item[1]
+            assert metric.unit == item[2]
+            def datapoint
+            switch(item[3]) {
+                case 'double':
+                    assert metric.hasDoubleSum()
+                    DoubleSum datapoints = metric.doubleSum
+                    assert datapoints.dataPointsCount == 1
+                    datapoint = datapoints.getDataPoints(0)
+                    break
+                case 'int':
+                    assert metric.hasIntSum()
+                    IntSum datapoints = metric.intSum
+                    assert datapoints.dataPointsCount == 1
+                    datapoint = datapoints.getDataPoints(0)
+                    break
+                default:
+                    assert false, "Invalid expected data type: ${item[3]}"
+            }
+            List<StringKeyValue> labels = datapoint.labelsList
+            assert labels.size() == 0
+        }
+
+        cleanup:
+        targetContainers.each { it.stop() }
+        jmxExtensionAppContainer.stop()
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka.properties
@@ -1,0 +1,9 @@
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = otlp
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka:7199/jmxrmi
+otel.jmx.target.system = kafka
+
+# these will be overridden by cmd line
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password
+otel.otlp.endpoint = host.testcontainers.internal:80


### PR DESCRIPTION
**Description:**

Feature addition - These changes add a new Kafka target system to the JMX Metric Gatherer.

**Testing:**

Added integration test, and included minor fixture updates to provide kafka and zookeeper containers.

**Documentation:**

Added target system metric readme.

**Outstanding items:**

These changes demonstrate that a more flexible test container fixture system is required when adding new features.  I'm going to give this a shot in the near future.

I'll also be trying to add consumer and producer target system scripts shortly.