### PR TITLE
Adopt Otel 0.9.1

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -88,51 +88,47 @@ via `otel.jmx.groovy.script`, it will then run the script on the specified
 
 ### OpenTelemetry Synchronous Instrument Helpers
 
-- `otel.doubleCounter(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleCounter(String name, String description, String unit)`
 
-- `otel.longCounter(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longCounter(String name, String description, String unit)`
 
-- `otel.doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleUpDownCounter(String name, String description, String unit)`
 
-- `otel.longUpDownCounter(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longUpDownCounter(String name, String description, String unit)`
 
-- `otel.doubleValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleValueRecorder(String name, String description, String unit)`
 
-- `otel.longValueRecorder(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longValueRecorder(String name, String description, String unit)`
 
 These methods will return a new or previously registered instance of the applicable metric
-instruments.  Each one provides three additional signatures where labels, unit, and description
+instruments.  Each one provides three additional signatures where unit and description
 aren't desired upon invocation.
 
-- `otel.<meterMethod>(String name, String description, String unit)` - `labels` are empty map.
+- `otel.<meterMethod>(String name, String description)` - `unit` is "1".
 
-- `otel.<meterMethod>(String name, String description)` - `unit` is "1" and `labels` are empty map.
-
-- `otel.<meterMethod>(String name)` - `description` is empty string, `unit` is "1" and `labels` are empty map.
+- `otel.<meterMethod>(String name)` - `description` is empty string and `unit` is "1".
 
 ### OpenTelemetry Asynchronous Instrument Helpers
 
-- `otel.doubleSumObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleSumObserver(String name, String description, String unit)`
 
-- `otel.longSumObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longSumObserver(String name, String description, String unit)`
 
-- `otel.doubleUpDownSumObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleUpDownSumObserver(String name, String description, String unit)`
 
-- `otel.longUpDownSumObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longUpDownSumObserver(String name, String description, String unit)`
 
-- `otel.doubleValueObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.doubleValueObserver(String name, String description, String unit)`
 
-- `otel.longValueObserver(String name, String description, String unit, Map<String, String> labels)`
+- `otel.longValueObserver(String name, String description, String unit)`
 
 These methods will return a new or previously registered instance of the applicable metric
-instruments.  Each one provides three additional signatures where labels, unit, and description
-aren't desired upon invocation.
+instruments.  Each one provides two additional signatures where unit and description aren't
+desired upon invocation.
 
-- `otel.<meterMethod>(String name, String description, String unit)` - `labels` are empty map.
+- `otel.<meterMethod>(String name, String description)` - `unit` is "1".
 
-- `otel.<meterMethod>(String name, String description)` - `unit` is "1" and `labels` are empty map.
-
-- `otel.<meterMethod>(String name)` - `description` is empty string, `unit` is "1" and `labels` are empty map.
+- `otel.<meterMethod>(String name)` - `description` is empty string and `unit` is "1".
 
 ### Compatibility
 

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -160,12 +160,12 @@ file contents can also be provided via stdin on startup when using `-config -` a
 | `otel.jmx.target.system` | if not using `otel.jmx.groovy.script` | The supported target application with built in Groovy script. |
 | `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10000 by default. |
 | `otel.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
-| `otel.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
-| `otel.otlp.metric.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |
-| `otel.otlp.use.tls` | no | Whether to use TLS for otlp channel.  Setting any value evaluates to `true`. |
-| `otel.otlp.metadata` | no | Any headers to include in otlp exporter metric submissions.  Of the form `'header1=value1;header2=value2'` |
-| `otel.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
-| `otel.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
+| `otel.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
+| `otel.exporter.otlp.metric.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |
+| `otel.exporter.otlp.use.tls` | no | Whether to use TLS for otlp channel.  Setting any value evaluates to `true`. |
+| `otel.exporter.otlp.metadata` | no | Any headers to include in otlp exporter metric submissions.  Of the form `'header1=value1;header2=value2'` |
+| `otel.exporter.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
+| `otel.exporter.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
 | `otel.jmx.username` | no | Username for JMX authentication, if applicable. |
 | `otel.jmx.password` | no | Password for JMX authentication, if applicable. |
 | `javax.net.ssl.keyStore` | no | The key store path is required if client authentication is enabled on the target JVM. |

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -107,12 +107,8 @@ class OtelHelper {
         return instrument(mBeanHelper, instrumentName, "", OtelHelper.SCALAR, [:] as Map<String, Closure>, attribute, otelInstrument)
     }
 
-    DoubleCounter doubleCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleCounter(name, description, unit, labels)
-    }
-
     DoubleCounter doubleCounter(String name, String description, String unit) {
-        return doubleCounter(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleCounter(name, description, unit)
     }
 
     DoubleCounter doubleCounter(String name, String description) {
@@ -123,12 +119,8 @@ class OtelHelper {
         return doubleCounter(name, '')
     }
 
-    LongCounter longCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongCounter(name, description, unit, labels)
-    }
-
     LongCounter longCounter(String name, String description, String unit) {
-        return longCounter(name, description, unit, null)
+        return groovyMetricEnvironment.getLongCounter(name, description, unit)
     }
 
     LongCounter longCounter(String name, String description) {
@@ -139,12 +131,8 @@ class OtelHelper {
         return longCounter(name, '')
     }
 
-    DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleUpDownCounter(name, description, unit, labels)
-    }
-
     DoubleUpDownCounter doubleUpDownCounter(String name, String description, String unit) {
-        return doubleUpDownCounter(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleUpDownCounter(name, description, unit)
     }
 
     DoubleUpDownCounter doubleUpDownCounter(String name, String description) {
@@ -155,12 +143,8 @@ class OtelHelper {
         return doubleUpDownCounter(name, '')
     }
 
-    LongUpDownCounter longUpDownCounter(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongUpDownCounter(name, description, unit, labels)
-    }
-
     LongUpDownCounter longUpDownCounter(String name, String description, String unit) {
-        return longUpDownCounter(name, description, unit, null)
+        return groovyMetricEnvironment.getLongUpDownCounter(name, description, unit)
     }
 
     LongUpDownCounter longUpDownCounter(String name, String description) {
@@ -171,12 +155,8 @@ class OtelHelper {
         return longUpDownCounter(name, '')
     }
 
-    DoubleValueRecorder doubleValueRecorder(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleValueRecorder(name, description, unit, labels)
-    }
-
     DoubleValueRecorder doubleValueRecorder(String name, String description, String unit) {
-        return doubleValueRecorder(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleValueRecorder(name, description, unit)
     }
 
     DoubleValueRecorder doubleValueRecorder(String name, String description) {
@@ -187,12 +167,8 @@ class OtelHelper {
         return doubleValueRecorder(name, '')
     }
 
-    LongValueRecorder longValueRecorder(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongValueRecorder(name, description, unit, labels)
-    }
-
     LongValueRecorder longValueRecorder(String name, String description, String unit) {
-        return longValueRecorder(name, description, unit, null)
+        return groovyMetricEnvironment.getLongValueRecorder(name, description, unit)
     }
 
     LongValueRecorder longValueRecorder(String name, String description) {
@@ -203,12 +179,8 @@ class OtelHelper {
         return longValueRecorder(name, '')
     }
 
-    DoubleSumObserver doubleSumObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleSumObserver(name, description, unit, labels)
-    }
-
     DoubleSumObserver doubleSumObserver(String name, String description, String unit) {
-        return doubleSumObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleSumObserver(name, description, unit)
     }
 
     DoubleSumObserver doubleSumObserver(String name, String description) {
@@ -219,12 +191,8 @@ class OtelHelper {
         return doubleSumObserver(name, '')
     }
 
-    LongSumObserver longSumObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongSumObserver(name, description, unit, labels)
-    }
-
     LongSumObserver longSumObserver(String name, String description, String unit) {
-        return longSumObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getLongSumObserver(name, description, unit)
     }
 
     LongSumObserver longSumObserver(String name, String description) {
@@ -235,12 +203,8 @@ class OtelHelper {
         return longSumObserver(name, '')
     }
 
-    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleUpDownSumObserver(name, description, unit, labels)
-    }
-
     DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description, String unit) {
-        return doubleUpDownSumObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleUpDownSumObserver(name, description, unit)
     }
 
     DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description) {
@@ -251,12 +215,8 @@ class OtelHelper {
         return doubleUpDownSumObserver(name, '')
     }
 
-    LongUpDownSumObserver longUpDownSumObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongUpDownSumObserver(name, description, unit, labels)
-    }
-
     LongUpDownSumObserver longUpDownSumObserver(String name, String description, String unit) {
-        return longUpDownSumObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getLongUpDownSumObserver(name, description, unit)
     }
 
     LongUpDownSumObserver longUpDownSumObserver(String name, String description) {
@@ -267,12 +227,8 @@ class OtelHelper {
         return longUpDownSumObserver(name, '')
     }
 
-    DoubleValueObserver doubleValueObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getDoubleValueObserver(name, description, unit, labels)
-    }
-
     DoubleValueObserver doubleValueObserver(String name, String description, String unit) {
-        return doubleValueObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getDoubleValueObserver(name, description, unit)
     }
 
     DoubleValueObserver doubleValueObserver(String name, String description) {
@@ -283,12 +239,8 @@ class OtelHelper {
         return doubleValueObserver(name, '')
     }
 
-    LongValueObserver longValueObserver(String name, String description, String unit, Map<String, String> labels) {
-        return groovyMetricEnvironment.getLongValueObserver(name, description, unit, labels)
-    }
-
     LongValueObserver longValueObserver(String name, String description, String unit) {
-        return longValueObserver(name, description, unit, null)
+        return groovyMetricEnvironment.getLongValueObserver(name, description, unit)
     }
 
     LongValueObserver longValueObserver(String name, String description) {

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -133,21 +133,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleCounter}
    */
   public DoubleCounter getDoubleCounter(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .doubleCounterBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.doubleCounterBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -156,21 +146,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongCounter}
    */
   public LongCounter getLongCounter(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .longCounterBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.longCounterBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -179,21 +159,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleUpDownCounter}
    */
   public DoubleUpDownCounter getDoubleUpDownCounter(
-      final String name,
-      final String description,
-      final String unit,
-      Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .doubleUpDownCounterBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.doubleUpDownCounterBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -202,21 +172,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongUpDownCounter}
    */
   public LongUpDownCounter getLongUpDownCounter(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .longUpDownCounterBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.longUpDownCounterBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -225,21 +185,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleValueRecorder}
    */
   public DoubleValueRecorder getDoubleValueRecorder(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .doubleValueRecorderBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.doubleValueRecorderBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -248,21 +198,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongValueRecorder}
    */
   public LongValueRecorder getLongValueRecorder(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .longValueRecorderBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.longValueRecorderBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -271,21 +211,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleSumObserver}
    */
   public DoubleSumObserver getDoubleSumObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .doubleSumObserverBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.doubleSumObserverBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -294,21 +224,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongSumObserver}
    */
   public LongSumObserver getLongSumObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .longSumObserverBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.longSumObserverBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -317,20 +237,14 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleUpDownSumObserver}
    */
   public DoubleUpDownSumObserver getDoubleUpDownSumObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
+      final String name, final String description, final String unit) {
     return meter
         .doubleUpDownSumObserverBuilder(name)
         .setDescription(description)
         .setUnit(unit)
-        .setConstantLabels(labels)
         .build();
   }
 
@@ -340,20 +254,14 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongUpDownSumObserver}
    */
   public LongUpDownSumObserver getLongUpDownSumObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
+      final String name, final String description, final String unit) {
     return meter
         .longUpDownSumObserverBuilder(name)
         .setDescription(description)
         .setUnit(unit)
-        .setConstantLabels(labels)
         .build();
   }
 
@@ -363,21 +271,11 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link DoubleValueObserver}
    */
   public DoubleValueObserver getDoubleValueObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .doubleValueObserverBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.doubleValueObserverBuilder(name).setDescription(description).setUnit(unit).build();
   }
 
   /**
@@ -386,20 +284,10 @@ public class GroovyMetricEnvironment {
    * @param name - metric name
    * @param description metric description
    * @param unit - metric unit
-   * @param constantLabels - metric descriptor's constant labels
    * @return new or memoized {@link LongValueObserver}
    */
   public LongValueObserver getLongValueObserver(
-      final String name,
-      final String description,
-      final String unit,
-      final Map<String, String> constantLabels) {
-    Labels labels = mapToLabels(constantLabels);
-    return meter
-        .longValueObserverBuilder(name)
-        .setDescription(description)
-        .setUnit(unit)
-        .setConstantLabels(labels)
-        .build();
+      final String name, final String description, final String unit) {
+    return meter.longValueObserverBuilder(name).setDescription(description).setUnit(unit).build();
   }
 }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -27,11 +27,12 @@ class JmxConfig {
   static final String TARGET_SYSTEM = PREFIX + "jmx.target.system";
   static final String INTERVAL_MILLISECONDS = PREFIX + "jmx.interval.milliseconds";
   static final String EXPORTER_TYPE = PREFIX + "exporter";
+  static final String EXPORTER = EXPORTER_TYPE + ".";
 
-  static final String OTLP_ENDPOINT = PREFIX + "otlp.endpoint";
+  static final String OTLP_ENDPOINT = EXPORTER + "otlp.endpoint";
 
-  static final String PROMETHEUS_HOST = PREFIX + "prometheus.host";
-  static final String PROMETHEUS_PORT = PREFIX + "prometheus.port";
+  static final String PROMETHEUS_HOST = EXPORTER + "prometheus.host";
+  static final String PROMETHEUS_PORT = EXPORTER + "prometheus.port";
 
   static final String JMX_USERNAME = PREFIX + "jmx.username";
   static final String JMX_PASSWORD = PREFIX + "jmx.password";

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
@@ -102,7 +102,7 @@ class InstrumentHelperTest extends Specification {
             def s1 = p1.startEpochNanos
             def s2 = p2.startEpochNanos
             if (s1 == s2) {
-                if (md1.descriptor.type == SUMMARY) {
+                if (md1.type == SUMMARY) {
                     return p1.percentileValues[0].value <=> p2.percentileValues[0].value
                 }
                 return p1.value <=> p2.value
@@ -139,15 +139,15 @@ class InstrumentHelperTest extends Specification {
         metrics.size() == 1
 
         metrics.each { metric ->
-            assert metric.descriptor.name == instrumentName
-            assert metric.descriptor.description == description
-            assert metric.descriptor.unit == "1"
-            assert metric.descriptor.type ==  descriptorType
+            assert metric.name == instrumentName
+            assert metric.description == description
+            assert metric.unit == "1"
+            assert metric.type ==  metricType
             assert metric.points.size() == isSingle ? 1 : 4
             metric.points.eachWithIndex { point, i ->
                 assert point.labels == Labels.of("labelOne", "labelOneValue", "labelTwo", "${i}")
 
-                if (descriptorType == SUMMARY) {
+                if (metricType == SUMMARY) {
                     assert point.count == 1
                     assert point.sum == value
                     assert point.percentileValues[0].percentile == 0
@@ -161,7 +161,7 @@ class InstrumentHelperTest extends Specification {
         }
 
         where:
-        isSingle | quantity | attribute | instrumentMethod | descriptorType | value
+        isSingle | quantity | attribute | instrumentMethod | metricType | value
         true | "single" | "Double" | "doubleCounter" | MONOTONIC_DOUBLE | 123.456
         false | "multiple" | "Double" | "doubleCounter" | MONOTONIC_DOUBLE | 123.456
         true | "single" | "Double" | "doubleUpDownCounter" | NON_MONOTONIC_DOUBLE | 123.456

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.SUMMARY
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer
 
 import io.opentelemetry.common.Labels
@@ -142,7 +142,6 @@ class InstrumentHelperTest extends Specification {
             assert metric.descriptor.name == instrumentName
             assert metric.descriptor.description == description
             assert metric.descriptor.unit == "1"
-            assert metric.descriptor.constantLabels == Labels.empty()
             assert metric.descriptor.type ==  descriptorType
             assert metric.points.size() == isSingle ? 1 : 4
             metric.points.eachWithIndex { point, i ->

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -65,7 +65,7 @@ class IntegrationTest extends Specification{
             "/app/OpenTelemetryJava.jar",
             "-Dotel.jmx.username=cassandra",
             "-Dotel.jmx.password=cassandra",
-            "-Dotel.otlp.endpoint=host.testcontainers.internal:${otlpPort}",
+            "-Dotel.exporter.otlp.endpoint=host.testcontainers.internal:${otlpPort}",
             "io.opentelemetry.contrib.jmxmetrics.JmxMetrics",
             "-config",
         ]

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -120,7 +120,7 @@ class IntegrationTest extends Specification{
         }
 
         jmxExtensionAppContainer =
-                new GenericContainer<>("openjdk:7u111-jre-alpine")
+                new GenericContainer<>("openjdk:8u272-jre-slim")
                 .withNetwork(network)
                 .withCopyFileToContainer(MountableFile.forHostPath(jarPath), "/app/OpenTelemetryJava.jar")
                 .withCopyFileToContainer(

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -51,9 +51,9 @@ class JmxConfigTest extends UnitTest {
             "jmx.target.system" : "mytargetsystem",
             "jmx.interval.milliseconds": "123",
             "exporter": "inmemory",
-            "otlp.endpoint": "myOtlpEndpoint",
-            "prometheus.host": "myPrometheusHost",
-            "prometheus.port": "234",
+            "exporter.otlp.endpoint": "myOtlpEndpoint",
+            "exporter.prometheus.host": "myPrometheusHost",
+            "exporter.prometheus.port": "234",
             "jmx.username": "myUsername",
             "jmx.password": "myPassword",
             "jmx.remote.profile": "myRemoteProfile",
@@ -94,7 +94,7 @@ class JmxConfigTest extends UnitTest {
         where:
         prop | _
         'otel.jmx.interval.milliseconds' | _
-        'otel.prometheus.port' | _
+        'otel.exporter.prometheus.port' | _
     }
 
     def 'conflicting groovy script and target system'() {

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.SUMMARY
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 
 import io.opentelemetry.common.Labels
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -74,8 +74,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.doubleSumObserver(
                 'double-sum', 'a double sum',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({doubleResult ->
             doubleResult.observe(123.456, Labels.of('key', 'value'))
         })
@@ -107,9 +106,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-sum'
         assert first.descriptor.description == 'a double sum'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
@@ -118,7 +114,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-sum'
         assert second.descriptor.description == 'another double sum'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
@@ -127,7 +122,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-sum'
         assert third.descriptor.description == 'double sum'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
@@ -136,7 +130,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-sum'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
@@ -177,7 +170,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'double'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == MONOTONIC_DOUBLE
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20.2
@@ -187,7 +179,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'double'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == MONOTONIC_DOUBLE
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20.2
@@ -200,8 +191,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.longSumObserver(
                 'long-sum', 'a long sum',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({longResult ->
             longResult.observe(123, Labels.of('key', 'value'))
         })
@@ -233,9 +223,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-sum'
         assert first.descriptor.description == 'a long sum'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
@@ -244,7 +231,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-sum'
         assert second.descriptor.description == 'another long sum'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
@@ -253,7 +239,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-sum'
         assert third.descriptor.description == 'long sum'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
@@ -262,7 +247,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-sum'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
@@ -303,7 +287,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'long'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == MONOTONIC_LONG
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20
@@ -313,7 +296,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'long'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == MONOTONIC_LONG
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20
@@ -326,8 +308,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.doubleUpDownSumObserver(
                 'double-up-down-sum', 'a double up down sum',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({doubleResult ->
             doubleResult.observe(123.456, Labels.of('key', 'value'))
         })
@@ -359,9 +340,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-up-down-sum'
         assert first.descriptor.description == 'a double up down sum'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == NON_MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
@@ -370,7 +348,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-up-down-sum'
         assert second.descriptor.description == 'another double up down sum'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == NON_MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
@@ -379,7 +356,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-up-down-sum'
         assert third.descriptor.description == 'double up down sum'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == NON_MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
@@ -388,7 +364,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-up-down-sum'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
@@ -429,7 +404,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'double'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == NON_MONOTONIC_DOUBLE
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20.2
@@ -439,7 +413,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'double'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == NON_MONOTONIC_DOUBLE
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20.2
@@ -452,8 +425,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.longUpDownSumObserver(
                 'long-up-down-sum', 'a long up down sum',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({longResult ->
             longResult.observe(123, Labels.of('key', 'value'))
         })
@@ -485,9 +457,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-up-down-sum'
         assert first.descriptor.description == 'a long up down sum'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == NON_MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
@@ -496,7 +465,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-up-down-sum'
         assert second.descriptor.description == 'another long up down sum'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == NON_MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
@@ -505,7 +473,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-up-down-sum'
         assert third.descriptor.description == 'long up down sum'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == NON_MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
@@ -514,7 +481,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-up-down-sum'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == NON_MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
@@ -555,7 +521,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'long'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == NON_MONOTONIC_LONG
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20
@@ -565,7 +530,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'long'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == NON_MONOTONIC_LONG
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20
@@ -578,8 +542,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.doubleValueObserver(
                 'double-value', 'a double value',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({doubleResult ->
             doubleResult.observe(123.456, Labels.of('key', 'value'))
         })
@@ -611,9 +574,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-value'
         assert first.descriptor.description == 'a double value'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
@@ -627,7 +587,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-value'
         assert second.descriptor.description == 'another double value'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == SUMMARY
         assert second.points[0].count == 1
         assert second.points[0].sum == 234.567
@@ -640,7 +599,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-value'
         assert third.descriptor.description == 'double value'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
@@ -654,7 +612,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-value'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
@@ -701,7 +658,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'double'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == SUMMARY
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].count == 1
@@ -716,7 +672,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'double'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == SUMMARY
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].count == 1
@@ -739,8 +694,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.longValueObserver(
                 'long-value', 'a long value',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dso.setCallback({longResult ->
             longResult.observe(123, Labels.of('key', 'value'))
         })
@@ -772,9 +726,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-value'
         assert first.descriptor.description == 'a long value'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
@@ -788,7 +739,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-value'
         assert second.descriptor.description == 'another long value'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
@@ -802,7 +752,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-value'
         assert third.descriptor.description == 'long value'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
@@ -816,7 +765,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-value'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
@@ -863,7 +811,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.descriptor.name == 'dc'
         assert firstMetric.descriptor.description == 'long'
         assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.constantLabels == Labels.empty()
         assert firstMetric.descriptor.type == SUMMARY
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].sum == 20
@@ -877,7 +824,6 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetric.descriptor.name == 'dc'
         assert secondMetric.descriptor.description == 'long'
         assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.constantLabels == Labels.empty()
         assert secondMetric.descriptor.type == SUMMARY
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].sum == 40

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
@@ -61,7 +61,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
             def s1 = p1.startEpochNanos
             def s2 = p2.startEpochNanos
             if (s1 == s2) {
-                if (md1.descriptor.type == SUMMARY) {
+                if (md1.type == SUMMARY) {
                     return p1.percentileValues[0].value <=> p2.percentileValues[0].value
                 }
                 return p1.value <=> p2.value
@@ -103,34 +103,34 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-sum'
-        assert first.descriptor.description == 'a double sum'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == MONOTONIC_DOUBLE
+        assert first.name == 'double-sum'
+        assert first.description == 'a double sum'
+        assert first.unit == 'ms'
+        assert first.type == MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-sum'
-        assert second.descriptor.description == 'another double sum'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == MONOTONIC_DOUBLE
+        assert second.name == 'my-double-sum'
+        assert second.description == 'another double sum'
+        assert second.unit == 'µs'
+        assert second.type == MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-sum'
-        assert third.descriptor.description == 'double sum'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == MONOTONIC_DOUBLE
+        assert third.name == 'another-double-sum'
+        assert third.description == 'double sum'
+        assert third.unit == '1'
+        assert third.type == MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-sum'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == MONOTONIC_DOUBLE
+        assert fourth.name == 'yet-another-double-sum'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -167,19 +167,19 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'double'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == MONOTONIC_DOUBLE
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'double'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == MONOTONIC_DOUBLE
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20.2
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'double'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == MONOTONIC_DOUBLE
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'double'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == MONOTONIC_DOUBLE
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20.2
         assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
@@ -220,34 +220,34 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-sum'
-        assert first.descriptor.description == 'a long sum'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == MONOTONIC_LONG
+        assert first.name == 'long-sum'
+        assert first.description == 'a long sum'
+        assert first.unit == 'ms'
+        assert first.type == MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-sum'
-        assert second.descriptor.description == 'another long sum'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == MONOTONIC_LONG
+        assert second.name == 'my-long-sum'
+        assert second.description == 'another long sum'
+        assert second.unit == 'µs'
+        assert second.type == MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-sum'
-        assert third.descriptor.description == 'long sum'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == MONOTONIC_LONG
+        assert third.name == 'another-long-sum'
+        assert third.description == 'long sum'
+        assert third.unit == '1'
+        assert third.type == MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-sum'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == MONOTONIC_LONG
+        assert fourth.name == 'yet-another-long-sum'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -284,19 +284,19 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'long'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == MONOTONIC_LONG
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'long'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == MONOTONIC_LONG
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'long'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == MONOTONIC_LONG
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'long'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == MONOTONIC_LONG
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20
         assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
@@ -337,34 +337,34 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-up-down-sum'
-        assert first.descriptor.description == 'a double up down sum'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert first.name == 'double-up-down-sum'
+        assert first.description == 'a double up down sum'
+        assert first.unit == 'ms'
+        assert first.type == NON_MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-up-down-sum'
-        assert second.descriptor.description == 'another double up down sum'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert second.name == 'my-double-up-down-sum'
+        assert second.description == 'another double up down sum'
+        assert second.unit == 'µs'
+        assert second.type == NON_MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-up-down-sum'
-        assert third.descriptor.description == 'double up down sum'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert third.name == 'another-double-up-down-sum'
+        assert third.description == 'double up down sum'
+        assert third.unit == '1'
+        assert third.type == NON_MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-up-down-sum'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert fourth.name == 'yet-another-double-up-down-sum'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == NON_MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -401,19 +401,19 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'double'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'double'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == NON_MONOTONIC_DOUBLE
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20.2
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'double'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'double'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == NON_MONOTONIC_DOUBLE
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20.2
         assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
@@ -454,34 +454,34 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-up-down-sum'
-        assert first.descriptor.description == 'a long up down sum'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == NON_MONOTONIC_LONG
+        assert first.name == 'long-up-down-sum'
+        assert first.description == 'a long up down sum'
+        assert first.unit == 'ms'
+        assert first.type == NON_MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-up-down-sum'
-        assert second.descriptor.description == 'another long up down sum'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == NON_MONOTONIC_LONG
+        assert second.name == 'my-long-up-down-sum'
+        assert second.description == 'another long up down sum'
+        assert second.unit == 'µs'
+        assert second.type == NON_MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-up-down-sum'
-        assert third.descriptor.description == 'long up down sum'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == NON_MONOTONIC_LONG
+        assert third.name == 'another-long-up-down-sum'
+        assert third.description == 'long up down sum'
+        assert third.unit == '1'
+        assert third.type == NON_MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-up-down-sum'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == NON_MONOTONIC_LONG
+        assert fourth.name == 'yet-another-long-up-down-sum'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == NON_MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -518,19 +518,19 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'long'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == NON_MONOTONIC_LONG
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'long'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == NON_MONOTONIC_LONG
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].value == 20
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'long'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == NON_MONOTONIC_LONG
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'long'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == NON_MONOTONIC_LONG
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].value == 20
         assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
@@ -571,10 +571,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-value'
-        assert first.descriptor.description == 'a double value'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == SUMMARY
+        assert first.name == 'double-value'
+        assert first.description == 'a double value'
+        assert first.unit == 'ms'
+        assert first.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
         assert first.points[0].sum == 123.456
@@ -584,10 +584,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.points[0].percentileValues[1].value == 123.456
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-value'
-        assert second.descriptor.description == 'another double value'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == SUMMARY
+        assert second.name == 'my-double-value'
+        assert second.description == 'another double value'
+        assert second.unit == 'µs'
+        assert second.type == SUMMARY
         assert second.points[0].count == 1
         assert second.points[0].sum == 234.567
         assert second.points[0].percentileValues[0].percentile == 0
@@ -596,10 +596,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.points[0].percentileValues[1].value == 234.567
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-value'
-        assert third.descriptor.description == 'double value'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == SUMMARY
+        assert third.name == 'another-double-value'
+        assert third.description == 'double value'
+        assert third.unit == '1'
+        assert third.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
         assert third.points[0].sum == 345.678
@@ -609,10 +609,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.points[0].percentileValues[1].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-value'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == SUMMARY
+        assert fourth.name == 'yet-another-double-value'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
         assert fourth.points[0].sum == 456.789
@@ -655,10 +655,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'double'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == SUMMARY
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'double'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == SUMMARY
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].count == 1
         assert firstMetric.points[0].sum == 20.2
@@ -669,10 +669,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'double'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == SUMMARY
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'double'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == SUMMARY
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].count == 1
         assert secondMetric.points[0].sum == 40.4
@@ -723,10 +723,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-value'
-        assert first.descriptor.description == 'a long value'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == SUMMARY
+        assert first.name == 'long-value'
+        assert first.description == 'a long value'
+        assert first.unit == 'ms'
+        assert first.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
         assert first.points[0].sum == 123
@@ -736,10 +736,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.points[0].percentileValues[1].value == 123
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-value'
-        assert second.descriptor.description == 'another long value'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == SUMMARY
+        assert second.name == 'my-long-value'
+        assert second.description == 'another long value'
+        assert second.unit == 'µs'
+        assert second.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
         assert second.points[0].sum == 234
@@ -749,10 +749,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert second.points[0].percentileValues[1].value == 234
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-value'
-        assert third.descriptor.description == 'long value'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == SUMMARY
+        assert third.name == 'another-long-value'
+        assert third.description == 'long value'
+        assert third.unit == '1'
+        assert third.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
         assert third.points[0].sum == 345
@@ -762,10 +762,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert third.points[0].percentileValues[1].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-value'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == SUMMARY
+        assert fourth.name == 'yet-another-long-value'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
         assert fourth.points[0].sum == 456
@@ -808,10 +808,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert secondMetrics.size() == 1
 
         def firstMetric = firstMetrics[0]
-        assert firstMetric.descriptor.name == 'dc'
-        assert firstMetric.descriptor.description == 'long'
-        assert firstMetric.descriptor.unit == '1'
-        assert firstMetric.descriptor.type == SUMMARY
+        assert firstMetric.name == 'dc'
+        assert firstMetric.description == 'long'
+        assert firstMetric.unit == '1'
+        assert firstMetric.type == SUMMARY
         assert firstMetric.points.size() == 1
         assert firstMetric.points[0].sum == 20
         assert firstMetric.points[0].percentileValues[0].percentile == 0
@@ -821,10 +821,10 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
-        assert secondMetric.descriptor.name == 'dc'
-        assert secondMetric.descriptor.description == 'long'
-        assert secondMetric.descriptor.unit == '1'
-        assert secondMetric.descriptor.type == SUMMARY
+        assert secondMetric.name == 'dc'
+        assert secondMetric.description == 'long'
+        assert secondMetric.unit == '1'
+        assert secondMetric.type == SUMMARY
         assert secondMetric.points.size() == 2
         assert secondMetric.points[0].sum == 40
         assert secondMetric.points[0].percentileValues[0].percentile == 0

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -60,7 +60,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
             def s1 = p1.startEpochNanos
             def s2 = p2.startEpochNanos
             if (s1 == s2) {
-                if (md1.descriptor.type == SUMMARY) {
+                if (md1.type == SUMMARY) {
                     return p1.percentileValues[0].value <=> p2.percentileValues[0].value
                 }
                 return p1.value <=> p2.value
@@ -94,34 +94,34 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-counter'
-        assert first.descriptor.description == 'a double counter'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == MONOTONIC_DOUBLE
+        assert first.name == 'double-counter'
+        assert first.description == 'a double counter'
+        assert first.unit == 'ms'
+        assert first.type == MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-counter'
-        assert second.descriptor.description == 'another double counter'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == MONOTONIC_DOUBLE
+        assert second.name == 'my-double-counter'
+        assert second.description == 'another double counter'
+        assert second.unit == 'µs'
+        assert second.type == MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-counter'
-        assert third.descriptor.description == 'double counter'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == MONOTONIC_DOUBLE
+        assert third.name == 'another-double-counter'
+        assert third.description == 'double counter'
+        assert third.unit == '1'
+        assert third.type == MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-counter'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == MONOTONIC_DOUBLE
+        assert fourth.name == 'yet-another-double-counter'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -141,10 +141,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'dc'
-        assert metric.descriptor.description == 'double'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == MONOTONIC_DOUBLE
+        assert metric.name == 'dc'
+        assert metric.description == 'double'
+        assert metric.unit == '1'
+        assert metric.type == MONOTONIC_DOUBLE
         assert metric.points.size() == 1
         assert metric.points[0].value == 20.2
         assert metric.points[0].labels == Labels.of('key', 'value')
@@ -175,34 +175,34 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-counter'
-        assert first.descriptor.description == 'a long counter'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == MONOTONIC_LONG
+        assert first.name == 'long-counter'
+        assert first.description == 'a long counter'
+        assert first.unit == 'ms'
+        assert first.type == MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-counter'
-        assert second.descriptor.description == 'another long counter'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == MONOTONIC_LONG
+        assert second.name == 'my-long-counter'
+        assert second.description == 'another long counter'
+        assert second.unit == 'µs'
+        assert second.type == MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-counter'
-        assert third.descriptor.description == 'long counter'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == MONOTONIC_LONG
+        assert third.name == 'another-long-counter'
+        assert third.description == 'long counter'
+        assert third.unit == '1'
+        assert third.type == MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-counter'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == MONOTONIC_LONG
+        assert fourth.name == 'yet-another-long-counter'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -222,10 +222,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'lc'
-        assert metric.descriptor.description == 'long'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == MONOTONIC_LONG
+        assert metric.name == 'lc'
+        assert metric.description == 'long'
+        assert metric.unit == '1'
+        assert metric.type == MONOTONIC_LONG
         assert metric.points.size() == 1
         assert metric.points[0].value == 20
         assert metric.points[0].labels == Labels.of('key', 'value')
@@ -256,34 +256,34 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-up-down-counter'
-        assert first.descriptor.description == 'a double up-down-counter'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert first.name == 'double-up-down-counter'
+        assert first.description == 'a double up-down-counter'
+        assert first.unit == 'ms'
+        assert first.type == NON_MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == -234.567
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-up-down-counter'
-        assert second.descriptor.description == 'another double up-down-counter'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert second.name == 'my-double-up-down-counter'
+        assert second.description == 'another double up-down-counter'
+        assert second.unit == 'µs'
+        assert second.type == NON_MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == -123.456
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-up-down-counter'
-        assert third.descriptor.description == 'double up-down-counter'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert third.name == 'another-double-up-down-counter'
+        assert third.description == 'double up-down-counter'
+        assert third.unit == '1'
+        assert third.type == NON_MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-up-down-counter'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert fourth.name == 'yet-another-double-up-down-counter'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == NON_MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -303,10 +303,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'dudc'
-        assert metric.descriptor.description == 'double up down'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == NON_MONOTONIC_DOUBLE
+        assert metric.name == 'dudc'
+        assert metric.description == 'double up down'
+        assert metric.unit == '1'
+        assert metric.type == NON_MONOTONIC_DOUBLE
         assert metric.points.size() == 1
         assert metric.points[0].value == 0
         assert metric.points[0].labels == Labels.of('key', 'value')
@@ -337,34 +337,34 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-up-down-counter'
-        assert first.descriptor.description == 'a long up-down-counter'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == NON_MONOTONIC_LONG
+        assert first.name == 'long-up-down-counter'
+        assert first.description == 'a long up-down-counter'
+        assert first.unit == 'ms'
+        assert first.type == NON_MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == -234
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-up-down-counter'
-        assert second.descriptor.description == 'another long up-down-counter'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == NON_MONOTONIC_LONG
+        assert second.name == 'my-long-up-down-counter'
+        assert second.description == 'another long up-down-counter'
+        assert second.unit == 'µs'
+        assert second.type == NON_MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == -123
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-up-down-counter'
-        assert third.descriptor.description == 'long up-down-counter'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == NON_MONOTONIC_LONG
+        assert third.name == 'another-long-up-down-counter'
+        assert third.description == 'long up-down-counter'
+        assert third.unit == '1'
+        assert third.type == NON_MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-up-down-counter'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == NON_MONOTONIC_LONG
+        assert fourth.name == 'yet-another-long-up-down-counter'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == NON_MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
@@ -384,10 +384,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'ludc'
-        assert metric.descriptor.description == 'long up down'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == NON_MONOTONIC_LONG
+        assert metric.name == 'ludc'
+        assert metric.description == 'long up down'
+        assert metric.unit == '1'
+        assert metric.type == NON_MONOTONIC_LONG
         assert metric.points.size() == 1
         assert metric.points[0].value == 0
         assert metric.points[0].labels == Labels.of('key', 'value')
@@ -418,10 +418,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'double-value-recorder'
-        assert first.descriptor.description == 'a double value-recorder'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == SUMMARY
+        assert first.name == 'double-value-recorder'
+        assert first.description == 'a double value-recorder'
+        assert first.unit == 'ms'
+        assert first.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
         assert first.points[0].sum == -234.567
@@ -431,10 +431,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.points[0].percentileValues[1].value == -234.567
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-double-value-recorder'
-        assert second.descriptor.description == 'another double value-recorder'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == SUMMARY
+        assert second.name == 'my-double-value-recorder'
+        assert second.description == 'another double value-recorder'
+        assert second.unit == 'µs'
+        assert second.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
         assert second.points[0].sum == -123.456
@@ -444,10 +444,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.points[0].percentileValues[1].value == -123.456
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-double-value-recorder'
-        assert third.descriptor.description == 'double value-recorder'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == SUMMARY
+        assert third.name == 'another-double-value-recorder'
+        assert third.description == 'double value-recorder'
+        assert third.unit == '1'
+        assert third.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
         assert third.points[0].sum == 345.678
@@ -457,10 +457,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.points[0].percentileValues[1].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-double-value-recorder'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == SUMMARY
+        assert fourth.name == 'yet-another-double-value-recorder'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
         assert fourth.points[0].sum == 456.789
@@ -485,10 +485,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'dvr'
-        assert metric.descriptor.description == 'double value'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == SUMMARY
+        assert metric.name == 'dvr'
+        assert metric.description == 'double value'
+        assert metric.unit == '1'
+        assert metric.type == SUMMARY
         assert metric.points.size() == 1
         assert metric.points[0].count == 2
         assert metric.points[0].sum == 0
@@ -524,10 +524,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         def third = metrics[2]
         def fourth = metrics[3]
 
-        assert first.descriptor.name == 'long-value-recorder'
-        assert first.descriptor.description == 'a long value-recorder'
-        assert first.descriptor.unit == 'ms'
-        assert first.descriptor.type == SUMMARY
+        assert first.name == 'long-value-recorder'
+        assert first.description == 'a long value-recorder'
+        assert first.unit == 'ms'
+        assert first.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
         assert first.points[0].sum == -234
@@ -537,10 +537,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.points[0].percentileValues[1].value == -234
         assert first.points[0].labels == Labels.of('key', 'value')
 
-        assert second.descriptor.name == 'my-long-value-recorder'
-        assert second.descriptor.description == 'another long value-recorder'
-        assert second.descriptor.unit == 'µs'
-        assert second.descriptor.type == SUMMARY
+        assert second.name == 'my-long-value-recorder'
+        assert second.description == 'another long value-recorder'
+        assert second.unit == 'µs'
+        assert second.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
         assert second.points[0].sum == -123
@@ -550,10 +550,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.points[0].percentileValues[1].value == -123
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
-        assert third.descriptor.name == 'another-long-value-recorder'
-        assert third.descriptor.description == 'long value-recorder'
-        assert third.descriptor.unit == '1'
-        assert third.descriptor.type == SUMMARY
+        assert third.name == 'another-long-value-recorder'
+        assert third.description == 'long value-recorder'
+        assert third.unit == '1'
+        assert third.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
         assert third.points[0].sum == 345
@@ -563,10 +563,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.points[0].percentileValues[1].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
-        assert fourth.descriptor.name == 'yet-another-long-value-recorder'
-        assert fourth.descriptor.description == ''
-        assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.type == SUMMARY
+        assert fourth.name == 'yet-another-long-value-recorder'
+        assert fourth.description == ''
+        assert fourth.unit == '1'
+        assert fourth.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
         assert fourth.points[0].sum == 456
@@ -591,10 +591,10 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metrics.size() == 1
         def metric = metrics[0]
 
-        assert metric.descriptor.name == 'lvr'
-        assert metric.descriptor.description == 'long value'
-        assert metric.descriptor.unit == '1'
-        assert metric.descriptor.type == SUMMARY
+        assert metric.name == 'lvr'
+        assert metric.description == 'long value'
+        assert metric.unit == '1'
+        assert metric.type == SUMMARY
         assert metric.points.size() == 1
         assert metric.points[0].count == 2
         assert metric.points[0].sum == 0

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -16,11 +16,11 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.NON_MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type.SUMMARY
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 
 import io.opentelemetry.common.Labels
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -73,8 +73,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def dc = otel.doubleCounter(
                 'double-counter', 'a double counter',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dc.add(123.456, Labels.of('key', 'value'))
 
         dc = otel.doubleCounter('my-double-counter', 'another double counter', 'µs')
@@ -98,9 +97,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-counter'
         assert first.descriptor.description == 'a double counter'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == 123.456
@@ -109,7 +105,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-counter'
         assert second.descriptor.description == 'another double counter'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == 234.567
@@ -118,7 +113,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-counter'
         assert third.descriptor.description == 'double counter'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
@@ -127,7 +121,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-counter'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
@@ -151,7 +144,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'dc'
         assert metric.descriptor.description == 'double'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == MONOTONIC_DOUBLE
         assert metric.points.size() == 1
         assert metric.points[0].value == 20.2
@@ -162,8 +154,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def lc = otel.longCounter(
                 'long-counter', 'a long counter',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         lc.add(123, Labels.of('key', 'value'))
 
         lc = otel.longCounter('my-long-counter', 'another long counter', 'µs')
@@ -187,9 +178,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-counter'
         assert first.descriptor.description == 'a long counter'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == 123
@@ -198,7 +186,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-counter'
         assert second.descriptor.description == 'another long counter'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == 234
@@ -207,7 +194,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-counter'
         assert third.descriptor.description == 'long counter'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
@@ -216,7 +202,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-counter'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
@@ -240,7 +225,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'lc'
         assert metric.descriptor.description == 'long'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == MONOTONIC_LONG
         assert metric.points.size() == 1
         assert metric.points[0].value == 20
@@ -251,8 +235,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def dudc = otel.doubleUpDownCounter(
                 'double-up-down-counter', 'a double up-down-counter',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dudc.add(-234.567, Labels.of('key', 'value'))
 
         dudc = otel.doubleUpDownCounter('my-double-up-down-counter', 'another double up-down-counter', 'µs')
@@ -276,9 +259,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-up-down-counter'
         assert first.descriptor.description == 'a double up-down-counter'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == NON_MONOTONIC_DOUBLE
         assert first.points.size() == 1
         assert first.points[0].value == -234.567
@@ -287,7 +267,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-up-down-counter'
         assert second.descriptor.description == 'another double up-down-counter'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == NON_MONOTONIC_DOUBLE
         assert second.points.size() == 1
         assert second.points[0].value == -123.456
@@ -296,7 +275,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-up-down-counter'
         assert third.descriptor.description == 'double up-down-counter'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == NON_MONOTONIC_DOUBLE
         assert third.points.size() == 1
         assert third.points[0].value == 345.678
@@ -305,7 +283,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-up-down-counter'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == NON_MONOTONIC_DOUBLE
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456.789
@@ -329,7 +306,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'dudc'
         assert metric.descriptor.description == 'double up down'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == NON_MONOTONIC_DOUBLE
         assert metric.points.size() == 1
         assert metric.points[0].value == 0
@@ -340,8 +316,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def ludc = otel.longUpDownCounter(
                 'long-up-down-counter', 'a long up-down-counter',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         ludc.add(-234, Labels.of('key', 'value'))
 
         ludc = otel.longUpDownCounter('my-long-up-down-counter', 'another long up-down-counter', 'µs')
@@ -365,9 +340,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-up-down-counter'
         assert first.descriptor.description == 'a long up-down-counter'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == NON_MONOTONIC_LONG
         assert first.points.size() == 1
         assert first.points[0].value == -234
@@ -376,7 +348,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-up-down-counter'
         assert second.descriptor.description == 'another long up-down-counter'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == NON_MONOTONIC_LONG
         assert second.points.size() == 1
         assert second.points[0].value == -123
@@ -385,7 +356,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-up-down-counter'
         assert third.descriptor.description == 'long up-down-counter'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == NON_MONOTONIC_LONG
         assert third.points.size() == 1
         assert third.points[0].value == 345
@@ -394,7 +364,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-up-down-counter'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == NON_MONOTONIC_LONG
         assert fourth.points.size() == 1
         assert fourth.points[0].value == 456
@@ -418,7 +387,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'ludc'
         assert metric.descriptor.description == 'long up down'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == NON_MONOTONIC_LONG
         assert metric.points.size() == 1
         assert metric.points[0].value == 0
@@ -429,8 +397,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def dvr = otel.doubleValueRecorder(
                 'double-value-recorder', 'a double value-recorder',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         dvr.record(-234.567, Labels.of('key', 'value'))
 
         dvr = otel.doubleValueRecorder('my-double-value-recorder', 'another double value-recorder', 'µs')
@@ -454,9 +421,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'double-value-recorder'
         assert first.descriptor.description == 'a double value-recorder'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
@@ -470,7 +434,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-double-value-recorder'
         assert second.descriptor.description == 'another double value-recorder'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
@@ -484,7 +447,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-double-value-recorder'
         assert third.descriptor.description == 'double value-recorder'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
@@ -498,7 +460,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-double-value-recorder'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
@@ -527,7 +488,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'dvr'
         assert metric.descriptor.description == 'double value'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == SUMMARY
         assert metric.points.size() == 1
         assert metric.points[0].count == 2
@@ -543,8 +503,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
         when:
         def lvr = otel.longValueRecorder(
                 'long-value-recorder', 'a long value-recorder',
-                'ms', [key1:'value1', key2:'value2']
-                )
+                'ms')
         lvr.record(-234, Labels.of('key', 'value'))
 
         lvr = otel.longValueRecorder('my-long-value-recorder', 'another long value-recorder', 'µs')
@@ -568,9 +527,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert first.descriptor.name == 'long-value-recorder'
         assert first.descriptor.description == 'a long value-recorder'
         assert first.descriptor.unit == 'ms'
-        assert first.descriptor.constantLabels == Labels.of(
-        'key1', 'value1', 'key2', 'value2'
-        )
         assert first.descriptor.type == SUMMARY
         assert first.points.size() == 1
         assert first.points[0].count == 1
@@ -584,7 +540,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert second.descriptor.name == 'my-long-value-recorder'
         assert second.descriptor.description == 'another long value-recorder'
         assert second.descriptor.unit == 'µs'
-        assert second.descriptor.constantLabels == Labels.empty()
         assert second.descriptor.type == SUMMARY
         assert second.points.size() == 1
         assert second.points[0].count == 1
@@ -598,7 +553,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert third.descriptor.name == 'another-long-value-recorder'
         assert third.descriptor.description == 'long value-recorder'
         assert third.descriptor.unit == '1'
-        assert third.descriptor.constantLabels == Labels.empty()
         assert third.descriptor.type == SUMMARY
         assert third.points.size() == 1
         assert third.points[0].count == 1
@@ -612,7 +566,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert fourth.descriptor.name == 'yet-another-long-value-recorder'
         assert fourth.descriptor.description == ''
         assert fourth.descriptor.unit == '1'
-        assert fourth.descriptor.constantLabels == Labels.empty()
         assert fourth.descriptor.type == SUMMARY
         assert fourth.points.size() == 1
         assert fourth.points[0].count == 1
@@ -641,7 +594,6 @@ class OtelHelperSynchronousMetricTest extends Specification{
         assert metric.descriptor.name == 'lvr'
         assert metric.descriptor.description == 'long value'
         assert metric.descriptor.unit == '1'
-        assert metric.descriptor.constantLabels == Labels.empty()
         assert metric.descriptor.type == SUMMARY
         assert metric.points.size() == 1
         assert metric.points[0].count == 2

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
@@ -24,20 +24,20 @@ class UnitTest extends Specification {
     void clearProperties() {
         // ensure relevant properties aren't set
         def properties = [
-            "jmx.service.url",
-            "jmx.groovy.script",
-            "jmx.target.system",
-            "jmx.interval.milliseconds",
-            "exporter",
-            "otlp.endpoint",
-            "prometheus.host",
-            "prometheus.port",
-            "jmx.username",
-            "jmx.password",
-            "jmx.remote.profile",
-            "jmx.realm"
+            JmxConfig.SERVICE_URL,
+            JmxConfig.GROOVY_SCRIPT,
+            JmxConfig.TARGET_SYSTEM,
+            JmxConfig.INTERVAL_MILLISECONDS,
+            JmxConfig.EXPORTER_TYPE,
+            JmxConfig.OTLP_ENDPOINT,
+            JmxConfig.PROMETHEUS_HOST,
+            JmxConfig.PROMETHEUS_PORT,
+            JmxConfig.JMX_USERNAME,
+            JmxConfig.JMX_PASSWORD,
+            JmxConfig.JMX_REMOTE_PROFILE,
+            JmxConfig.JMX_REALM
         ]
-        properties.each {System.clearProperty("otel.${it}")}
+        properties.each {System.clearProperty(it)}
     }
 
     def setup() {

--- a/contrib/jmx-metrics/src/test/resources/otlp_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/otlp_config.properties
@@ -6,4 +6,4 @@ otel.jmx.groovy.script = /app/script.groovy
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = host.testcontainers.internal:80

--- a/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
@@ -1,7 +1,7 @@
 otel.jmx.interval.milliseconds = 3000
 otel.exporter = prometheus
-otel.prometheus.host = 0.0.0.0
-otel.prometheus.port = 9123
+otel.exporter.prometheus.host = 0.0.0.0
+otel.exporter.prometheus.port = 9123
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
 otel.jmx.groovy.script = /app/script.groovy
 

--- a/contrib/jmx-metrics/src/test/resources/target-systems/cassandra.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/cassandra.properties
@@ -6,4 +6,4 @@ otel.jmx.target.system = cassandra
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = host.testcontainers.internal:80

--- a/contrib/jmx-metrics/src/test/resources/target-systems/jvm.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/jvm.properties
@@ -6,4 +6,4 @@ otel.jmx.target.system = jvm
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = host.testcontainers.internal:80

--- a/gradle/contrib.gradle
+++ b/gradle/contrib.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'groovy'
 
-ext.releaseJavaVersion = JavaVersion.VERSION_1_7
+ext.releaseJavaVersion = JavaVersion.VERSION_1_8
 ext.testJavaVersion = JavaVersion.VERSION_1_8
 
 java {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     versions = [
-        otelStable : '0.8.0'
+        otelStable : '0.9.1'
     ]
 
     libraries = [


### PR DESCRIPTION
**Description:**
These changes update all applicable otel dependencies to 0.9.1.  There were a number of [breaking changes](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v0.9.1) addressed:

1. Removed constant labels from the instrument helpers since they are no longer supported in the api.
1. Collapse/remove descriptors from MetricData.
1. Update all applicable `otel.exporter` properties.
1. End Java 7 release support.

**Testing:**

Updates existing tests and jre test container.

**Documentation:**

Updates existing readme

**Outstanding items:**

I will open a subsequent PR to move to 0.10.0 as soon as these changes land.
