### PR TITLE
Adopt Otel 0.10.0

### DIFF
--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -48,8 +48,8 @@ dependencies {
             libraries.otelExporterLogging,
             libraries.otelExporterOtlp,
             libraries.otelExporterPrometheus,
-            libraries.otelExporterInMemory,
             libraries.otelSdk,
+            libraries.otelSdkTesting,
             deps.slf4j,
             dependencies.create(group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j)
 

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -16,16 +16,16 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import io.opentelemetry.metrics.DoubleCounter
-import io.opentelemetry.metrics.DoubleSumObserver
-import io.opentelemetry.metrics.DoubleUpDownCounter
-import io.opentelemetry.metrics.DoubleUpDownSumObserver
-import io.opentelemetry.metrics.DoubleValueObserver
-import io.opentelemetry.metrics.LongCounter
-import io.opentelemetry.metrics.LongSumObserver
-import io.opentelemetry.metrics.LongUpDownCounter
-import io.opentelemetry.metrics.LongUpDownSumObserver
-import io.opentelemetry.metrics.LongValueObserver
+import io.opentelemetry.api.metrics.DoubleCounter
+import io.opentelemetry.api.metrics.DoubleSumObserver
+import io.opentelemetry.api.metrics.DoubleUpDownCounter
+import io.opentelemetry.api.metrics.DoubleUpDownSumObserver
+import io.opentelemetry.api.metrics.DoubleValueObserver
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongSumObserver
+import io.opentelemetry.api.metrics.LongUpDownCounter
+import io.opentelemetry.api.metrics.LongUpDownSumObserver
+import io.opentelemetry.api.metrics.LongValueObserver
 
 import java.util.logging.Logger
 import javax.management.openmbean.CompositeData
@@ -63,7 +63,7 @@ class InstrumentHelper {
     private final Closure instrument
 
     /**
-     * An InstrumentHelper provides the ability to easily create and update {@link io.opentelemetry.metrics.Instrument}
+     * An InstrumentHelper provides the ability to easily create and update {@link io.opentelemetry.api.metrics.Instrument}
      * instances from an MBeanHelper's underlying {@link GroovyMBean} instances via an {@link OtelHelper}'s instrument
      * method pointer.
      *
@@ -75,7 +75,7 @@ class InstrumentHelper {
      *        {@link GroovyMBean}-provided Closures: (e.g. [ "myLabelName" : { mbean -> "myLabelValue"} ]). The
      *        resulting Label instances will be used for each individual update.
      * @param attribute - The {@link GroovyMBean} attribute for which to use as the instrument value.
-     * @param instrument - The {@link io.opentelemetry.metrics.Instrument}-producing {@link OtelHelper} method pointer:
+     * @param instrument - The {@link io.opentelemetry.api.metrics.Instrument}-producing {@link OtelHelper} method pointer:
      *        (e.g. new OtelHelper().&doubleValueRecorder)
      */
     InstrumentHelper(MBeanHelper mBeanHelper, String instrumentName, String description, String unit, Map<String, Closure> labelFuncs, String attribute, Closure instrument) {

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -16,18 +16,18 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import io.opentelemetry.metrics.DoubleCounter
-import io.opentelemetry.metrics.DoubleSumObserver
-import io.opentelemetry.metrics.DoubleUpDownCounter
-import io.opentelemetry.metrics.DoubleUpDownSumObserver
-import io.opentelemetry.metrics.DoubleValueObserver
-import io.opentelemetry.metrics.DoubleValueRecorder
-import io.opentelemetry.metrics.LongCounter
-import io.opentelemetry.metrics.LongSumObserver
-import io.opentelemetry.metrics.LongUpDownCounter
-import io.opentelemetry.metrics.LongUpDownSumObserver
-import io.opentelemetry.metrics.LongValueObserver
-import io.opentelemetry.metrics.LongValueRecorder
+import io.opentelemetry.api.metrics.DoubleCounter
+import io.opentelemetry.api.metrics.DoubleSumObserver
+import io.opentelemetry.api.metrics.DoubleUpDownCounter
+import io.opentelemetry.api.metrics.DoubleUpDownSumObserver
+import io.opentelemetry.api.metrics.DoubleValueObserver
+import io.opentelemetry.api.metrics.DoubleValueRecorder
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongSumObserver
+import io.opentelemetry.api.metrics.LongUpDownCounter
+import io.opentelemetry.api.metrics.LongUpDownSumObserver
+import io.opentelemetry.api.metrics.LongValueObserver
+import io.opentelemetry.api.metrics.LongValueRecorder
 
 import javax.management.ObjectName
 

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -16,24 +16,24 @@
 
 package io.opentelemetry.contrib.jmxmetrics;
 
-import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.common.Labels;
-import io.opentelemetry.exporters.logging.LoggingMetricExporter;
-import io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter;
-import io.opentelemetry.exporters.prometheus.PrometheusCollector;
-import io.opentelemetry.metrics.DoubleCounter;
-import io.opentelemetry.metrics.DoubleSumObserver;
-import io.opentelemetry.metrics.DoubleUpDownCounter;
-import io.opentelemetry.metrics.DoubleUpDownSumObserver;
-import io.opentelemetry.metrics.DoubleValueObserver;
-import io.opentelemetry.metrics.DoubleValueRecorder;
-import io.opentelemetry.metrics.LongCounter;
-import io.opentelemetry.metrics.LongSumObserver;
-import io.opentelemetry.metrics.LongUpDownCounter;
-import io.opentelemetry.metrics.LongUpDownSumObserver;
-import io.opentelemetry.metrics.LongValueObserver;
-import io.opentelemetry.metrics.LongValueRecorder;
-import io.opentelemetry.metrics.Meter;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Labels;
+import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleSumObserver;
+import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownSumObserver;
+import io.opentelemetry.api.metrics.DoubleValueObserver;
+import io.opentelemetry.api.metrics.DoubleValueRecorder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongSumObserver;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownSumObserver;
+import io.opentelemetry.api.metrics.LongValueObserver;
+import io.opentelemetry.api.metrics.LongValueRecorder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
+import io.opentelemetry.exporter.otlp.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.prometheus.PrometheusCollector;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
@@ -62,11 +62,11 @@ public class GroovyMetricEnvironment {
       final JmxConfig config,
       final String instrumentationName,
       final String instrumentationVersion) {
-    meter = OpenTelemetry.getMeter(instrumentationName, instrumentationVersion);
+    meter = OpenTelemetry.getGlobalMeter(instrumentationName, instrumentationVersion);
 
     switch (config.exporterType.toLowerCase()) {
       case "otlp":
-        exporter = OtlpGrpcMetricExporter.newBuilder().readProperties(config.properties).build();
+        exporter = OtlpGrpcMetricExporter.builder().readProperties(config.properties).build();
         break;
       case "prometheus":
         configurePrometheus(config);
@@ -90,11 +90,11 @@ public class GroovyMetricEnvironment {
   }
 
   private static MetricProducer getMetricProducer() {
-    return OpenTelemetrySdk.getMeterProvider().getMetricProducer();
+    return OpenTelemetrySdk.getGlobalMeterProvider().getMetricProducer();
   }
 
   private void configurePrometheus(final JmxConfig config) {
-    PrometheusCollector.newBuilder().setMetricProducer(getMetricProducer()).buildAndRegister();
+    PrometheusCollector.builder().setMetricProducer(getMetricProducer()).buildAndRegister();
     try {
       prometheusServer =
           new HTTPServer(config.prometheusExporterHost, config.prometheusExporterPort);
@@ -121,7 +121,7 @@ public class GroovyMetricEnvironment {
     Labels.Builder labels = new Labels.Builder();
     if (labelMap != null) {
       for (Map.Entry<String, String> kv : labelMap.entrySet()) {
-        labels.setLabel(kv.getKey(), kv.getValue());
+        labels.put(kv.getKey(), kv.getValue());
       }
     }
     return labels.build();

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -18,7 +18,6 @@ package io.opentelemetry.contrib.jmxmetrics;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.common.Labels;
-import io.opentelemetry.exporters.inmemory.InMemoryMetricExporter;
 import io.opentelemetry.exporters.logging.LoggingMetricExporter;
 import io.opentelemetry.exporters.otlp.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporters.prometheus.PrometheusCollector;
@@ -39,6 +38,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricProducer;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
 import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
 import java.util.Collection;

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelperTest.groovy
@@ -16,6 +16,8 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
@@ -23,7 +25,7 @@ import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LO
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer
 
-import io.opentelemetry.common.Labels
+import io.opentelemetry.api.common.Labels
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import javax.management.MBeanServer
 import javax.management.ObjectName
@@ -95,7 +97,7 @@ class InstrumentHelperTest extends Specification {
     }
 
     def exportMetrics() {
-        def provider = OpenTelemetrySdk.meterProvider.get(name.methodName, '')
+        def provider = OpenTelemetrySdk.globalMeterProvider.get(name.methodName, '')
         return provider.collectAll().sort { md1, md2 ->
             def p1 = md1.points[0]
             def p2 = md2.points[0]
@@ -182,9 +184,9 @@ class InstrumentHelperTest extends Specification {
         false | "multiple" | "Long" | "longSumObserver" | MONOTONIC_LONG | 234
         true | "single" | "Long" | "longUpDownSumObserver" | NON_MONOTONIC_LONG | 234
         false | "multiple" | "Long" | "longUpDownSumObserver" | NON_MONOTONIC_LONG | 234
-        true | "single" | "Double" | "doubleValueObserver" | SUMMARY | 123.456
-        false | "multiple" | "Double" | "doubleValueObserver" | SUMMARY | 123.456
-        true | "single" | "Long" | "longValueObserver" | SUMMARY | 234
-        false | "multiple" | "Long" | "longValueObserver" | SUMMARY | 234
+        true | "single" | "Double" | "doubleValueObserver" | GAUGE_DOUBLE | 123.456
+        false | "multiple" | "Double" | "doubleValueObserver" | GAUGE_DOUBLE | 123.456
+        true | "single" | "Long" | "longValueObserver" | GAUGE_LONG | 234
+        false | "multiple" | "Long" | "longValueObserver" | GAUGE_LONG | 234
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
@@ -16,13 +16,15 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_DOUBLE
+import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 
-import io.opentelemetry.common.Labels
+import io.opentelemetry.api.common.Labels
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.junit.Rule
 import org.junit.rules.TestName
@@ -54,7 +56,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
     }
 
     def exportMetrics() {
-        def provider = OpenTelemetrySdk.meterProvider.get(name.methodName, '')
+        def provider = OpenTelemetrySdk.globalMeterProvider.get(name.methodName, '')
         return provider.collectAll().sort { md1, md2 ->
             def p1 = md1.points[0]
             def p2 = md2.points[0]
@@ -574,52 +576,32 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'double-value'
         assert first.description == 'a double value'
         assert first.unit == 'ms'
-        assert first.type == SUMMARY
+        assert first.type == GAUGE_DOUBLE
         assert first.points.size() == 1
-        assert first.points[0].count == 1
-        assert first.points[0].sum == 123.456
-        assert first.points[0].percentileValues[0].percentile == 0
-        assert first.points[0].percentileValues[0].value ==  123.456
-        assert first.points[0].percentileValues[1].percentile == 100
-        assert first.points[0].percentileValues[1].value == 123.456
+        assert first.points[0].value == 123.456
         assert first.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-double-value'
         assert second.description == 'another double value'
         assert second.unit == 'µs'
-        assert second.type == SUMMARY
-        assert second.points[0].count == 1
-        assert second.points[0].sum == 234.567
-        assert second.points[0].percentileValues[0].percentile == 0
-        assert second.points[0].percentileValues[0].value ==  234.567
-        assert second.points[0].percentileValues[1].percentile == 100
-        assert second.points[0].percentileValues[1].value == 234.567
+        assert second.type == GAUGE_DOUBLE
+        assert second.points[0].value == 234.567
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-double-value'
         assert third.description == 'double value'
         assert third.unit == '1'
-        assert third.type == SUMMARY
+        assert third.type == GAUGE_DOUBLE
         assert third.points.size() == 1
-        assert third.points[0].count == 1
-        assert third.points[0].sum == 345.678
-        assert third.points[0].percentileValues[0].percentile == 0
-        assert third.points[0].percentileValues[0].value ==  345.678
-        assert third.points[0].percentileValues[1].percentile == 100
-        assert third.points[0].percentileValues[1].value == 345.678
+        assert third.points[0].value == 345.678
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-double-value'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == SUMMARY
+        assert fourth.type == GAUGE_DOUBLE
         assert fourth.points.size() == 1
-        assert fourth.points[0].count == 1
-        assert fourth.points[0].sum == 456.789
-        assert fourth.points[0].percentileValues[0].percentile == 0
-        assert fourth.points[0].percentileValues[0].value ==  456.789
-        assert fourth.points[0].percentileValues[1].percentile == 100
-        assert fourth.points[0].percentileValues[1].value == 456.789
+        assert fourth.points[0].value == 456.789
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
@@ -658,35 +640,20 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'double'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == SUMMARY
+        assert firstMetric.type == GAUGE_DOUBLE
         assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].count == 1
-        assert firstMetric.points[0].sum == 20.2
-        assert firstMetric.points[0].percentileValues[0].percentile == 0
-        assert firstMetric.points[0].percentileValues[0].value ==  20.2
-        assert firstMetric.points[0].percentileValues[1].percentile == 100
-        assert firstMetric.points[0].percentileValues[1].value == 20.2
+        assert firstMetric.points[0].value == 20.2
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'double'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == SUMMARY
+        assert secondMetric.type == GAUGE_DOUBLE
         assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].count == 1
-        assert secondMetric.points[0].sum == 40.4
-        assert secondMetric.points[0].percentileValues[0].percentile == 0
-        assert secondMetric.points[0].percentileValues[0].value ==  40.4
-        assert secondMetric.points[0].percentileValues[1].percentile == 100
-        assert secondMetric.points[0].percentileValues[1].value == 40.4
+        assert secondMetric.points[0].value == 40.4
         assert secondMetric.points[0].labels == Labels.of('key4', 'value4')
-        assert secondMetric.points[1].count == 1
-        assert secondMetric.points[1].sum == 50.5
-        assert secondMetric.points[1].percentileValues[0].percentile == 0
-        assert secondMetric.points[1].percentileValues[0].value ==  50.5
-        assert secondMetric.points[1].percentileValues[1].percentile == 100
-        assert secondMetric.points[1].percentileValues[1].value == 50.5
+        assert secondMetric.points[1].value == 50.5
         assert secondMetric.points[1].labels == Labels.of('key2', 'value2')
     }
 
@@ -726,53 +693,33 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'long-value'
         assert first.description == 'a long value'
         assert first.unit == 'ms'
-        assert first.type == SUMMARY
+        assert first.type == GAUGE_LONG
         assert first.points.size() == 1
-        assert first.points[0].count == 1
-        assert first.points[0].sum == 123
-        assert first.points[0].percentileValues[0].percentile == 0
-        assert first.points[0].percentileValues[0].value == 123
-        assert first.points[0].percentileValues[1].percentile == 100
-        assert first.points[0].percentileValues[1].value == 123
+        assert first.points[0].value == 123
         assert first.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-long-value'
         assert second.description == 'another long value'
         assert second.unit == 'µs'
-        assert second.type == SUMMARY
+        assert second.type == GAUGE_LONG
         assert second.points.size() == 1
-        assert second.points[0].count == 1
-        assert second.points[0].sum == 234
-        assert second.points[0].percentileValues[0].percentile == 0
-        assert second.points[0].percentileValues[0].value == 234
-        assert second.points[0].percentileValues[1].percentile == 100
-        assert second.points[0].percentileValues[1].value == 234
+        assert second.points[0].value == 234
         assert second.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-long-value'
         assert third.description == 'long value'
         assert third.unit == '1'
-        assert third.type == SUMMARY
+        assert third.type == GAUGE_LONG
         assert third.points.size() == 1
-        assert third.points[0].count == 1
-        assert third.points[0].sum == 345
-        assert third.points[0].percentileValues[0].percentile == 0
-        assert third.points[0].percentileValues[0].value == 345
-        assert third.points[0].percentileValues[1].percentile == 100
-        assert third.points[0].percentileValues[1].value == 345
+        assert third.points[0].value == 345
         assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-long-value'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == SUMMARY
+        assert fourth.type == GAUGE_LONG
         assert fourth.points.size() == 1
-        assert fourth.points[0].count == 1
-        assert fourth.points[0].sum == 456
-        assert fourth.points[0].percentileValues[0].percentile == 0
-        assert fourth.points[0].percentileValues[0].value == 456
-        assert fourth.points[0].percentileValues[1].percentile == 100
-        assert fourth.points[0].percentileValues[1].value == 456
+        assert fourth.points[0].value == 456
         assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
@@ -811,32 +758,20 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'long'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == SUMMARY
+        assert firstMetric.type == GAUGE_LONG
         assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].sum == 20
-        assert firstMetric.points[0].percentileValues[0].percentile == 0
-        assert firstMetric.points[0].percentileValues[0].value == 20
-        assert firstMetric.points[0].percentileValues[1].percentile == 100
-        assert firstMetric.points[0].percentileValues[1].value == 20
+        assert firstMetric.points[0].value == 20
         assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'long'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == SUMMARY
+        assert secondMetric.type == GAUGE_LONG
         assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].sum == 40
-        assert secondMetric.points[0].percentileValues[0].percentile == 0
-        assert secondMetric.points[0].percentileValues[0].value == 40
-        assert secondMetric.points[0].percentileValues[1].percentile == 100
-        assert secondMetric.points[0].percentileValues[1].value == 40
+        assert secondMetric.points[0].value == 40
         assert secondMetric.points[0].labels == Labels.of('key4', 'value4')
-        assert secondMetric.points[1].sum == 50
-        assert secondMetric.points[1].percentileValues[0].percentile == 0
-        assert secondMetric.points[1].percentileValues[0].value == 50
-        assert secondMetric.points[1].percentileValues[1].percentile == 100
-        assert secondMetric.points[1].percentileValues[1].value == 50
+        assert secondMetric.points[1].value == 50
         assert secondMetric.points[1].labels == Labels.of('key2', 'value2')
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.groovy
@@ -22,7 +22,7 @@ import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DO
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
 import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 
-import io.opentelemetry.common.Labels
+import io.opentelemetry.api.common.Labels
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.junit.Rule
 import org.junit.rules.TestName
@@ -53,7 +53,7 @@ class OtelHelperSynchronousMetricTest extends Specification{
     }
 
     def exportMetrics() {
-        def provider = OpenTelemetrySdk.meterProvider.get(name.methodName, '')
+        def provider = OpenTelemetrySdk.globalMeterProvider.get(name.methodName, '')
         return provider.collectAll().sort { md1, md2 ->
             def p1 = md1.points[0]
             def p2 = md2.points[0]

--- a/contrib/jmx-metrics/src/test/resources/script.groovy
+++ b/contrib/jmx-metrics/src/test/resources/script.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import io.opentelemetry.common.Labels
+import io.opentelemetry.api.common.Labels
 
 def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
 def load = loadMatches.first()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,18 +1,18 @@
 ext {
     versions = [
-        otelStable : '0.9.1'
+        otelStable : '0.10.0'
     ]
 
     libraries = [
         // otel
         otelApi            : "io.opentelemetry:opentelemetry-api:${versions.otelStable}",
         otelSdk            : "io.opentelemetry:opentelemetry-sdk:${versions.otelStable}",
-        otelExporterInMemory       : "io.opentelemetry:opentelemetry-exporters-inmemory:${versions.otelStable}",
-        otelExporterJaeger         : "io.opentelemetry:opentelemetry-exporters-jaeger:${versions.otelStable}",
-        otelExporterLogging        : "io.opentelemetry:opentelemetry-exporters-logging:${versions.otelStable}",
-        otelExporterOtlp           : "io.opentelemetry:opentelemetry-exporters-otlp:${versions.otelStable}",
-        otelExporterPrometheus     : "io.opentelemetry:opentelemetry-exporters-prometheus:${versions.otelStable}",
-        otelExporterZipkin         : "io.opentelemetry:opentelemetry-exporters-zipkin:${versions.otelStable}",
+        otelSdkTesting       : "io.opentelemetry:opentelemetry-sdk-testing:${versions.otelStable}",
+        otelExporterJaeger         : "io.opentelemetry:opentelemetry-exporter-jaeger:${versions.otelStable}",
+        otelExporterLogging        : "io.opentelemetry:opentelemetry-exporter-logging:${versions.otelStable}",
+        otelExporterOtlp           : "io.opentelemetry:opentelemetry-exporter-otlp:${versions.otelStable}",
+        otelExporterPrometheus     : "io.opentelemetry:opentelemetry-exporter-prometheus:${versions.otelStable}",
+        otelExporterZipkin         : "io.opentelemetry:opentelemetry-exporter-zipkin:${versions.otelStable}",
         otelProto          : "io.opentelemetry:opentelemetry-proto:${versions.otelStable}",
 
         // testing


### PR DESCRIPTION
**Description:**

These changes update all applicable otel dependencies to 0.10.0. There were a number of [breaking changes](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v0.10.0) addressed:

1. Update all applicable imports to `io.opentelemetry.api` and `io.opentelemetry.exporter`.
1. Update dependency targets including new `opentelemety-sdk-testing` to continue support for in-memory exporter.
1. Update applicable `getGlobal<...>()` and label methods.
1. Update value observer tests to expect new gauge datapoints.

**Testing:**

Updated existing tests only.

**Documentation:**

No updates required at this time.

**Outstanding items:**

These changes don't update any existing target systems to use gauges where applicable.  I will open another PR to do after this one.