### PR TITLE
Adopt async instruments in JVM target script

### DIFF
--- a/contrib/jmx-metrics/docs/target-systems/jvm.md
+++ b/contrib/jmx-metrics/docs/target-systems/jvm.md
@@ -10,79 +10,79 @@ These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each n
 * Name: `jvm.classes.loaded`
 * Description: The number of loaded classes
 * Unit: `1`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.gc.collections.count`
 * Description: The total number of garbage collections that have occurred
 * Unit: `1`
-* Instrument Type: LongCounter
+* Instrument Type: LongSumObserver
 
 * Name: `jvm.gc.collections.elapsed`
 * Description: The approximate accumulated collection elapsed time
 * Unit: `ms`
-* Instrument Type: LongCounter
+* Instrument Type: LongSumObserver
 
 * Name: `jvm.memory.heap.init`
 * Description: The initial amount of memory that the JVM requests from the operating system for the heap
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.heap.max`
 * Description: The maximum amount of memory can be used for the heap
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.heap.used`
 * Description: The current heap memory usage
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.heap.committed`
 * Description: The amount of memory that is guaranteed to be available for the heap
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.nonheap.init`
 * Description: The initial amount of memory that the JVM requests from the operating system for non-heap purposes
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.nonheap.max`
 * Description: The maximum amount of memory can be used for non-heap purposes
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.nonheap.used`
 * Description: The current non-heap memory usage
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.nonheap.committed`
 * Description: The amount of memory that is guaranteed to be available for non-heap purposes
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.pool.init`
 * Description: The initial amount of memory that the JVM requests from the operating system for the memory pool
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.pool.max`
 * Description: The maximum amount of memory can be used for the memory pool
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.pool.used`
 * Description: The current memory pool memory usage
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.memory.pool.committed`
 * Description: The amount of memory that is guaranteed to be available for the memory pool
 * Unit: `by`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver
 
 * Name: `jvm.threads.count`
 * Description: The current number of threads
 * Unit: `1`
-* Instrument Type: LongUpDownCounter
+* Instrument Type: LongValueObserver

--- a/contrib/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+++ b/contrib/jmx-metrics/src/main/resources/target-systems/jvm.groovy
@@ -16,28 +16,28 @@
 
 def classLoading = otel.mbean("java.lang:type=ClassLoading")
 otel.instrument(classLoading, "jvm.classes.loaded", "number of loaded classes",
-        "1", "LoadedClassCount", otel.&longUpDownCounter)
+        "1", "LoadedClassCount", otel.&longValueObserver)
 
 def garbageCollector = otel.mbeans("java.lang:type=GarbageCollector,*")
 otel.instrument(garbageCollector, "jvm.gc.collections.count", "total number of collections that have occurred",
         "1", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
-        "CollectionCount", otel.&longCounter)
+        "CollectionCount", otel.&longSumObserver)
 otel.instrument(garbageCollector, "jvm.gc.collections.elapsed",
         "the approximate accumulated collection elapsed time in milliseconds", "ms",
         ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
-        "CollectionTime", otel.&longCounter)
+        "CollectionTime", otel.&longSumObserver)
 
 def memory = otel.mbean("java.lang:type=Memory")
 otel.instrument(memory, "jvm.memory.heap", "current heap usage",
-        "by", "HeapMemoryUsage", otel.&longUpDownCounter)
+        "by", "HeapMemoryUsage", otel.&longValueObserver)
 otel.instrument(memory, "jvm.memory.nonheap", "current non-heap usage",
-        "by", "NonHeapMemoryUsage", otel.&longUpDownCounter)
+        "by", "NonHeapMemoryUsage", otel.&longValueObserver)
 
 def memoryPool = otel.mbeans("java.lang:type=MemoryPool,*")
 otel.instrument(memoryPool, "jvm.memory.pool", "current memory pool usage",
         "by", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
-        "Usage", otel.&longUpDownCounter)
+        "Usage", otel.&longValueObserver)
 
 def threading = otel.mbean("java.lang:type=Threading")
 otel.instrument(threading, "jvm.threads.count", "number of threads",
-        "1", "ThreadCount", otel.&longUpDownCounter)
+        "1", "ThreadCount", otel.&longValueObserver)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -16,6 +16,7 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
+import io.opentelemetry.proto.metrics.v1.IntGauge
 import io.opentelemetry.proto.metrics.v1.IntSum
 
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary
@@ -70,7 +71,8 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                 'jvm.classes.loaded',
                 'number of loaded classes',
                 '1',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.gc.collections.count',
@@ -78,7 +80,9 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                 '1',
                 [
                     "ConcurrentMarkSweep",
-                    "ParNew"]
+                    "ParNew"
+                ],
+                IntSum
             ],
             [
                 'jvm.gc.collections.elapsed',
@@ -86,55 +90,65 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                 'ms',
                 [
                     "ConcurrentMarkSweep",
-                    "ParNew"]
+                    "ParNew"
+                ],
+                IntSum
             ],
             [
                 'jvm.memory.heap.committed',
                 'current heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.heap.init',
                 'current heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.heap.max',
                 'current heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.heap.used',
                 'current heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.nonheap.committed',
                 'current non-heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.nonheap.init',
                 'current non-heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.nonheap.max',
                 'current non-heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.nonheap.used',
                 'current non-heap usage',
                 'by',
-                []
+                [],
+                IntGauge
             ],
             [
                 'jvm.memory.pool.committed',
@@ -146,7 +160,9 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                     "CMS Old Gen",
                     "Compressed Class Space",
                     "Metaspace",
-                    "Par Survivor Space"]
+                    "Par Survivor Space"
+                ],
+                IntGauge
             ],
             [
                 'jvm.memory.pool.init',
@@ -158,7 +174,9 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                     "CMS Old Gen",
                     "Compressed Class Space",
                     "Metaspace",
-                    "Par Survivor Space"]
+                    "Par Survivor Space"
+                ],
+                IntGauge
             ],
             [
                 'jvm.memory.pool.max',
@@ -170,7 +188,9 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                     "CMS Old Gen",
                     "Compressed Class Space",
                     "Metaspace",
-                    "Par Survivor Space"]
+                    "Par Survivor Space"
+                ],
+                IntGauge
             ],
             [
                 'jvm.memory.pool.used',
@@ -182,21 +202,33 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
                     "CMS Old Gen",
                     "Compressed Class Space",
                     "Metaspace",
-                    "Par Survivor Space"]
+                    "Par Survivor Space"
+                ],
+                IntGauge
             ],
             [
                 'jvm.threads.count',
                 'number of threads',
                 '1',
-                []
+                [],
+                IntGauge
             ],
         ].eachWithIndex{ item, index ->
+            def expectedType = item[4]
+
             Metric metric = metrics.get(index)
             assert metric.name == item[0]
             assert metric.description == item[1]
             assert metric.unit == item[2]
-            assert metric.hasIntSum()
-            IntSum datapoints = metric.intSum
+
+            def datapoints
+            if (expectedType == IntGauge) {
+                assert metric.hasIntGauge()
+                datapoints = metric.intGauge
+            } else {
+                assert metric.hasIntSum()
+                datapoints = metric.intSum
+            }
             def expectedLabelCount = item[3].size()
             def expectedLabels = item[3] as Set
 


### PR DESCRIPTION
**Description:**

These changes follow pattern of https://github.com/open-telemetry/opentelemetry-java-contrib/pull/21 and migrate JVM target script instruments to use asynchronous helpers.

**Testing:**

Updates existing test suite.

**Documentation:**

Updates instrument types in existing readme

**Outstanding items:**

Doesn't contain Kafka target script migration, which will be opened shortly.
