### PR TITLE
JMX: Add kafka-consumer target script

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -146,6 +146,7 @@ The currently available target systems are:
 | [`jvm`](./docs/target-systems/jvm.md) |
 | [`cassandra`](./docs/target-systems/cassandra.md) |
 | [`kafka`](./docs/target-systems/kafka.md) |
+| [`kafka-consumer`](./docs/target-systems/kafka-consumer.md) |
 
 ### Configuration
 

--- a/contrib/jmx-metrics/docs/target-systems/kafka-consumer.md
+++ b/contrib/jmx-metrics/docs/target-systems/kafka-consumer.md
@@ -1,0 +1,58 @@
+# Kafka Consumer Metrics
+
+The JMX Metric Gatherer provides built in Kafka consumer metric gathering capabilities for versions v0.8.2.x and above.
+These metrics are sourced from Kafka's exposed Yammer metrics for each instance: https://kafka.apache.org/documentation/#monitoring
+
+## Metrics
+
+### Consumer Metrics
+
+* Name: `kafka.consumer.fetch-rate`
+* Description: The number of fetch requests for all topics per second.
+* Unit: `1`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.records-lag-max`
+* Description: Number of messages the consumer lags behind the producer.
+* Unit: `1`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.total.bytes-consumed-rate`
+* Description: The average number of bytes consumed for all topics per second.
+* Unit: `by`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.total.fetch-size-avg`
+* Description: The average number of bytes fetched per request for all topics.
+* Unit: `by`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.total.records-consumed-rate`
+* Description: The average number of records consumed for all topics per second.
+* Unit: `1`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+### Per-Topic Consumer Metrics
+
+* Name: `kafka.consumer.bytes-consumed-rate`
+* Description: The average number of bytes consumed per second
+* Unit: `by`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.fetch-size-avg`
+* Description: The average number of bytes fetched per request
+* Unit: `by`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.consumer.records-consumed-rate`
+* Description: The average number of records consumed per second
+* Unit: `1`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -108,7 +108,6 @@ class InstrumentHelper {
                     def updatedInstrumentName = "${instrumentName}.${key}"
                     def labels = getLabels(mbean, labelFuncs)
                     def inst = instrument(updatedInstrumentName, description, unit)
-                    println "InstrumentHelper.update (composite) - ${inst}"
                     logger.fine("Recording ${updatedInstrumentName} - ${inst} w/ ${val} - ${labels}")
                     if (!instToUpdates.containsKey(inst)) {
                         instToUpdates[inst] = []
@@ -118,7 +117,6 @@ class InstrumentHelper {
             } else {
                 def labels = getLabels(mbean, labelFuncs)
                 def inst = instrument(instrumentName, description, unit)
-                println "InstrumentHelper.update - ${inst}"
                 logger.fine("Recording ${instrumentName} - ${inst} w/ ${value} - ${labels}")
                 if (!instToUpdates.containsKey(inst)) {
                     instToUpdates[inst] = []

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -39,7 +39,8 @@ class JmxConfig {
   static final String JMX_REMOTE_PROFILE = PREFIX + "jmx.remote.profile";
   static final String JMX_REALM = PREFIX + "jmx.realm";
 
-  static final List<String> AVAILABLE_TARGET_SYSTEMS = Arrays.asList("jvm", "kafka", "cassandra");
+  static final List<String> AVAILABLE_TARGET_SYSTEMS =
+      Arrays.asList("cassandra", "jvm", "kafka", "kafka-consumer");
 
   final String serviceUrl;
   final String groovyScript;

--- a/contrib/jmx-metrics/src/main/resources/target-systems/kafka-consumer.groovy
+++ b/contrib/jmx-metrics/src/main/resources/target-systems/kafka-consumer.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def consumerFetchManagerMetrics = otel.mbeans("kafka.consumer:client-id=*,type=consumer-fetch-manager-metrics")
+otel.instrument(consumerFetchManagerMetrics, "kafka.consumer.fetch-rate",
+        "The number of fetch requests for all topics per second", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "fetch-rate", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetrics, "kafka.consumer.records-lag-max",
+        "Number of messages the consumer lags behind the producer", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "records-lag-max", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetrics, "kafka.consumer.total.bytes-consumed-rate",
+        "The average number of bytes consumed for all topics per second", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "bytes-consumed-rate", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetrics, "kafka.consumer.total.fetch-size-avg",
+        "The average number of bytes fetched per request for all topics", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "fetch-size-avg", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetrics, "kafka.consumer.total.records-consumed-rate",
+        "The average number of records consumed for all topics per second", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "records-consumed-rate", otel.&doubleValueObserver)
+
+def consumerFetchManagerMetricsByTopic = otel.mbeans("kafka.consumer:client-id=*,topic=*,type=consumer-fetch-manager-metrics")
+otel.instrument(consumerFetchManagerMetricsByTopic, "kafka.consumer.bytes-consumed-rate",
+        "The average number of bytes consumed per second", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "bytes-consumed-rate", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetricsByTopic, "kafka.consumer.fetch-size-avg",
+        "The average number of bytes fetched per request", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "fetch-size-avg", otel.&doubleValueObserver)
+
+otel.instrument(consumerFetchManagerMetricsByTopic, "kafka.consumer.records-consumed-rate",
+        "The average number of records consumed per second", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "records-consumed-rate", otel.&doubleValueObserver)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -21,7 +21,12 @@ class JmxConfigTest extends UnitTest {
 
     def 'static values'() {
         expect: 'static values to be expected'
-        JmxConfig.AVAILABLE_TARGET_SYSTEMS == ["jvm", "kafka", "cassandra"]
+        JmxConfig.AVAILABLE_TARGET_SYSTEMS == [
+            "cassandra",
+            "jvm",
+            "kafka",
+            "kafka-consumer"
+        ]
     }
 
     def 'default values'() {
@@ -139,6 +144,6 @@ class JmxConfigTest extends UnitTest {
 
         expect: 'config fails to validate'
         raised != null
-        raised.message ==  "unavailabletargetsystem must be one of [jvm, kafka, cassandra]"
+        raised.message ==  "unavailabletargetsystem must be one of [cassandra, jvm, kafka, kafka-consumer]"
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaConsumerTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaConsumerTargetSystemIntegrationTests.groovy
@@ -1,0 +1,156 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import org.testcontainers.Testcontainers
+import spock.lang.Requires
+import spock.lang.Timeout
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+@Timeout(60)
+class KafkaConsumerTargetSystemIntegrationTests extends OtlpIntegrationTest {
+
+    def 'end to end'() {
+        setup: 'we configure JMX metrics gatherer and target server to use Kafka as target system'
+        targets = ["kafka-consumer"]
+        Testcontainers.exposeHostPorts(otlpPort)
+        configureContainers('target-systems/kafka-consumer.properties',  otlpPort, 0, false)
+
+        expect:
+        when: 'we receive metrics from the JMX metric gatherer'
+        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+        then: 'they are of the expected size'
+        receivedMetrics.size() == 1
+
+        when: "we examine the received metric's instrumentation library metrics lists"
+        ResourceMetrics receivedMetric = receivedMetrics.get(0)
+        List<InstrumentationLibraryMetrics> ilMetrics =
+                receivedMetric.instrumentationLibraryMetricsList
+        then: 'they of the expected size'
+        ilMetrics.size() == 1
+
+        when: 'we examine the instrumentation library metric metrics list'
+        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+        metrics.sort{ a, b -> a.name <=> b.name}
+        then: 'they are of the expected size and content'
+        metrics.size() == 8
+
+        def expectedTopics = [
+            'test-topic-1',
+            'test-topic-2',
+            'test-topic-3'
+        ]
+
+        [
+            [
+                'kafka.consumer.bytes-consumed-rate',
+                'The average number of bytes consumed per second',
+                'by',
+                ['client-id' : '', 'topic' : expectedTopics.clone() ],
+            ],
+            [
+                'kafka.consumer.fetch-rate',
+                'The number of fetch requests for all topics per second',
+                '1',
+                ['client-id' : '']
+            ],
+            [
+                'kafka.consumer.fetch-size-avg',
+                'The average number of bytes fetched per request',
+                'by',
+                ['client-id' : '', 'topic' : expectedTopics.clone() ],
+            ],
+            [
+                'kafka.consumer.records-consumed-rate',
+                'The average number of records consumed per second',
+                '1',
+                ['client-id' : '', 'topic' : expectedTopics.clone() ],
+            ],
+            [
+                'kafka.consumer.records-lag-max',
+                'Number of messages the consumer lags behind the producer',
+                '1',
+                ['client-id' : '']
+            ],
+            [
+                'kafka.consumer.total.bytes-consumed-rate',
+                'The average number of bytes consumed for all topics per second',
+                'by',
+                ['client-id' : '']
+            ],
+            [
+                'kafka.consumer.total.fetch-size-avg',
+                'The average number of bytes fetched per request for all topics',
+                'by',
+                ['client-id' : '']
+            ],
+            [
+                'kafka.consumer.total.records-consumed-rate',
+                'The average number of records consumed for all topics per second',
+                '1',
+                ['client-id' : '']
+            ],
+        ].eachWithIndex{ item, index ->
+            Metric metric = metrics.get(index)
+            assert metric.name == item[0]
+            assert metric.description == item[1]
+            assert metric.unit == item[2]
+
+            assert metric.hasDoubleGauge()
+            def datapoints = metric.doubleGauge
+
+            Map<String, String> expectedLabels = item[3]
+            def expectedLabelCount = expectedLabels.size()
+
+            assert datapoints.dataPointsCount == expectedLabelCount == 1 ? 1 : 3
+
+            (0..<datapoints.dataPointsCount).each { i ->
+                def datapoint = datapoints.getDataPoints(i)
+
+                List<StringKeyValue> labels = datapoint.labelsList
+                assert labels.size() == expectedLabelCount
+
+                (0..<expectedLabelCount).each { j ->
+                    def key = labels[j].key
+                    assert expectedLabels.containsKey(key)
+                    def value = expectedLabels[key]
+                    if (!value.empty) {
+                        def actual = labels[j].value
+                        assert value.contains(actual)
+                        value.remove(actual)
+                        if (value.empty) {
+                            expectedLabels.remove(key)
+                        }
+                    }
+                }
+            }
+
+            assert expectedLabels == ['client-id': '']
+        }
+
+        cleanup:
+        targetContainers.each { it.stop() }
+        jmxExtensionAppContainer.stop()
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka-consumer.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka-consumer.properties
@@ -1,0 +1,9 @@
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = otlp
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka-consumer:7199/jmxrmi
+otel.jmx.target.system = kafka-consumer
+
+# these will be overridden by cmd line
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password
+otel.otlp.endpoint = host.testcontainers.internal:80


### PR DESCRIPTION
**Description:**
Feature addition - These changes add a new `kafka-consumer` target system script to the JMX Metric Gatherer that will report consumer activity via `kafka.consumer` metrics.

**Testing:**
Adds additional integration test suite.

**Documentation:**
New target and main readme updates.

**Outstanding items:**
Opened https://github.com/open-telemetry/opentelemetry-java-contrib/issues/24 to address undesired bloat in `IntegrationTest.configureContainers()`
