### PR TITLE
JMX: Add kafka-producer target script

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -147,6 +147,7 @@ The currently available target systems are:
 | [`cassandra`](./docs/target-systems/cassandra.md) |
 | [`kafka`](./docs/target-systems/kafka.md) |
 | [`kafka-consumer`](./docs/target-systems/kafka-consumer.md) |
+| [`kafka-producer`](./docs/target-systems/kafka-producer.md) |
 
 ### Configuration
 

--- a/contrib/jmx-metrics/docs/target-systems/kafka-producer.md
+++ b/contrib/jmx-metrics/docs/target-systems/kafka-producer.md
@@ -1,0 +1,70 @@
+# Kafka Producer Metrics
+
+The JMX Metric Gatherer provides built in Kafka producer metric gathering capabilities for versions v0.8.2.x and above.
+These metrics are sourced from Kafka's exposed Yammer metrics for each instance: https://kafka.apache.org/documentation/#monitoring
+
+## Metrics
+
+### Producer Metrics
+
+* Name: `kafka.producer.io-wait-time-ns-avg`
+* Description: The average length of time the I/O thread spent waiting for a socket ready for reads or writes.
+* Unit: `ns`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.outgoing-byte-rate`
+* Description: The average number of outgoing bytes sent per second to all servers.
+* Unit: `by`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.request-latency-avg`
+* Description: The average request latency.
+* Unit: `ms`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.request-rate`
+* Description: The average number of requests sent per second.
+* Unit: `1`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.response-rate`
+* Description: Responses received per second.
+* Unit: `1`
+* Labels: `client-id`
+* Instrument Type: DoubleValueObserver
+
+### Per-Topic Producer Metrics
+
+* Name: `kafka.producer.byte-rate`
+* Description: The average number of bytes sent per second for a topic.
+* Unit: `by`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.compression-rate`
+* Description: The average compression rate of record batches for a topic.
+* Unit: `1`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.record-error-rate`
+* Description: The average per-second number of record sends that resulted in errors for a topic.
+* Unit: `1`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.record-retry-rate`
+* Description: The average per-second number of retried record sends for a topic.
+* Unit: `1`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver
+
+* Name: `kafka.producer.record-send-rate`
+* Description: The average number of records sent per second for a topic.
+* Unit: `1`
+* Labels: `client-id`, `topic`
+* Instrument Type: DoubleValueObserver

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -40,7 +40,7 @@ class JmxConfig {
   static final String JMX_REALM = PREFIX + "jmx.realm";
 
   static final List<String> AVAILABLE_TARGET_SYSTEMS =
-      Arrays.asList("cassandra", "jvm", "kafka", "kafka-consumer");
+      Arrays.asList("cassandra", "jvm", "kafka", "kafka-consumer", "kafka-producer");
 
   final String serviceUrl;
   final String groovyScript;

--- a/contrib/jmx-metrics/src/main/resources/target-systems/kafka-producer.groovy
+++ b/contrib/jmx-metrics/src/main/resources/target-systems/kafka-producer.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def producerMetrics = otel.mbeans("kafka.producer:client-id=*,type=producer-metrics")
+otel.instrument(producerMetrics, "kafka.producer.io-wait-time-ns-avg",
+        "The average length of time the I/O thread spent waiting for a socket ready for reads or writes", "ns",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "io-wait-time-ns-avg", otel.&doubleValueObserver)
+otel.instrument(producerMetrics, "kafka.producer.outgoing-byte-rate",
+        "The average number of outgoing bytes sent per second to all servers", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "outgoing-byte-rate", otel.&doubleValueObserver)
+otel.instrument(producerMetrics, "kafka.producer.request-latency-avg",
+        "The average request latency", "ms",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "request-latency-avg", otel.&doubleValueObserver)
+otel.instrument(producerMetrics, "kafka.producer.request-rate",
+        "The average number of requests sent per second", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "request-rate", otel.&doubleValueObserver)
+otel.instrument(producerMetrics, "kafka.producer.response-rate",
+        "Responses received per second", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") }],
+        "response-rate", otel.&doubleValueObserver)
+
+def producerTopicMetrics = otel.mbeans("kafka.producer:client-id=*,topic=*,type=producer-topic-metrics")
+otel.instrument(producerTopicMetrics, "kafka.producer.byte-rate",
+        "The average number of bytes sent per second for a topic", "by",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "byte-rate", otel.&doubleValueObserver)
+otel.instrument(producerTopicMetrics, "kafka.producer.compression-rate",
+        "The average compression rate of record batches for a topic", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "compression-rate", otel.&doubleValueObserver)
+otel.instrument(producerTopicMetrics, "kafka.producer.record-error-rate",
+        "The average per-second number of record sends that resulted in errors for a topic", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "record-error-rate", otel.&doubleValueObserver)
+otel.instrument(producerTopicMetrics, "kafka.producer.record-retry-rate",
+        "The average per-second number of retried record sends for a topic", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "record-retry-rate", otel.&doubleValueObserver)
+otel.instrument(producerTopicMetrics, "kafka.producer.record-send-rate",
+        "The average number of records sent per second for a topic", "1",
+        ["client-id" : { mbean -> mbean.name().getKeyProperty("client-id") },
+            "topic" : { mbean -> mbean.name().getKeyProperty("topic") }],
+        "record-send-rate", otel.&doubleValueObserver)

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -25,7 +25,8 @@ class JmxConfigTest extends UnitTest {
             "cassandra",
             "jvm",
             "kafka",
-            "kafka-consumer"
+            "kafka-consumer",
+            "kafka-producer"
         ]
     }
 
@@ -144,6 +145,6 @@ class JmxConfigTest extends UnitTest {
 
         expect: 'config fails to validate'
         raised != null
-        raised.message ==  "unavailabletargetsystem must be one of [cassandra, jvm, kafka, kafka-consumer]"
+        raised.message ==  "unavailabletargetsystem must be one of [cassandra, jvm, kafka, kafka-consumer, kafka-producer]"
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaProducerTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaProducerTargetSystemIntegrationTests.groovy
@@ -1,0 +1,161 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import org.testcontainers.Testcontainers
+import spock.lang.Requires
+import spock.lang.Timeout
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+@Timeout(60)
+class KafkaProducerTargetSystemIntegrationTests extends OtlpIntegrationTest {
+
+    def 'end to end'() {
+        setup: 'we configure JMX metrics gatherer and target server to use Kafka as target system'
+        targets = ["kafka-producer"]
+        Testcontainers.exposeHostPorts(otlpPort)
+        configureContainers('target-systems/kafka-producer.properties',  otlpPort, 0, false)
+
+        expect:
+        when: 'we receive metrics from the JMX metric gatherer'
+        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+        then: 'they are of the expected size'
+        receivedMetrics.size() == 1
+
+        when: "we examine the received metric's instrumentation library metrics lists"
+        ResourceMetrics receivedMetric = receivedMetrics.get(0)
+        List<InstrumentationLibraryMetrics> ilMetrics =
+                receivedMetric.instrumentationLibraryMetricsList
+        then: 'they of the expected size'
+        ilMetrics.size() == 1
+
+        when: 'we examine the instrumentation library metric metrics list'
+        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+        metrics.sort{ a, b -> a.name <=> b.name}
+        then: 'they are of the expected size and content'
+        metrics.size() == 10
+
+        [
+            [
+                "kafka.producer.byte-rate",
+                "The average number of bytes sent per second for a topic",
+                "by",
+                ['client-id' : '', 'topic' : ['test-topic-1']],
+            ],
+            [
+                "kafka.producer.compression-rate",
+                "The average compression rate of record batches for a topic",
+                "1",
+                ['client-id' : '', 'topic' : ['test-topic-1']],
+            ],
+            [
+                "kafka.producer.io-wait-time-ns-avg",
+                "The average length of time the I/O thread spent waiting for a socket ready for reads or writes",
+                "ns",
+                ['client-id' : ''],
+            ],
+            [
+                "kafka.producer.outgoing-byte-rate",
+                "The average number of outgoing bytes sent per second to all servers",
+                "by",
+                ['client-id' : ''],
+            ],
+            [
+                "kafka.producer.record-error-rate",
+                "The average per-second number of record sends that resulted in errors for a topic",
+                "1",
+                ['client-id' : '', 'topic' : ['test-topic-1']],
+            ],
+            [
+                "kafka.producer.record-retry-rate",
+                "The average per-second number of retried record sends for a topic",
+                "1",
+                ['client-id' : '', 'topic' : ['test-topic-1']],
+            ],
+            [
+                "kafka.producer.record-send-rate",
+                "The average number of records sent per second for a topic",
+                "1",
+                ['client-id' : '', 'topic' : ['test-topic-1']],
+            ],
+            [
+                "kafka.producer.request-latency-avg",
+                "The average request latency",
+                "ms",
+                ['client-id' : ''],
+            ],
+            [
+                "kafka.producer.request-rate",
+                "The average number of requests sent per second",
+                "1",
+                ['client-id' : ''],
+            ],
+            [
+                "kafka.producer.response-rate",
+                "Responses received per second",
+                "1",
+                ['client-id' : ''],
+            ],
+        ].eachWithIndex{ item, index ->
+            Metric metric = metrics.get(index)
+            assert metric.name == item[0]
+            assert metric.description == item[1]
+            assert metric.unit == item[2]
+
+            assert metric.hasDoubleGauge()
+            def datapoints = metric.doubleGauge
+
+            Map<String, String> expectedLabels = item[3]
+            def expectedLabelCount = expectedLabels.size()
+
+            assert datapoints.dataPointsCount == 1
+
+            def datapoint = datapoints.getDataPoints(0)
+
+            List<StringKeyValue> labels = datapoint.labelsList
+            assert labels.size() == expectedLabelCount
+
+            (0..<expectedLabelCount).each { j ->
+                def key = labels[j].key
+                assert expectedLabels.containsKey(key)
+                def value = expectedLabels[key]
+                if (!value.empty) {
+                    def actual = labels[j].value
+                    assert value.contains(actual)
+                    value.remove(actual)
+                    if (value.empty) {
+                        expectedLabels.remove(key)
+                    }
+                }
+            }
+
+            assert expectedLabels == ['client-id': '']
+        }
+
+        cleanup:
+        targetContainers.each { it.stop() }
+        println jmxExtensionAppContainer.getLogs()
+        jmxExtensionAppContainer.stop()
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.properties
@@ -1,0 +1,9 @@
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = otlp
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka-producer:7199/jmxrmi
+otel.jmx.target.system = kafka-producer
+
+# these will be overridden by cmd line
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password
+otel.otlp.endpoint = host.testcontainers.internal:80

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.sh
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function msg() {
+    while true; do
+        echo 'some message'
+        sleep .25
+    done
+}
+
+msg | kafka-console-producer.sh --bootstrap-server kafka:9092 --topic test-topic-1


### PR DESCRIPTION
**Description:**
depends on https://github.com/open-telemetry/opentelemetry-java-contrib/pull/25

Feature addition - These changes add a new `kafka-producer` target system script to the JMX Metric Gatherer that will report consumer activity via `kafka.producer` metrics.

**Testing:**
Adds additional integration test suite.

**Documentation:**
New target and main readme updates.