### PR TITLE
JMX: Allow specifying multiple target system scripts

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -14,7 +14,7 @@ $ java -D<otel.jmx.property=value> -jar opentelemetry-java-contrib-jmx-metrics-<
 
 ```properties
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
-otel.jmx.groovy.script = /opt/script.groovy
+otel.jmx.target.system = jvm,kafka
 otel.jmx.interval.milliseconds = 5000
 otel.exporter = otlp
 otel.otlp.endpoint = my-opentelemetry-collector:55680
@@ -34,8 +34,8 @@ otel.instrument(storageLoadMBean, "cassandra.storage.load",
 
 As configured in the example, this metric gatherer will configure an otlp gRPC metric exporter
 at the `otel.otlp.endpoint` and establish an MBean server connection using the
-provided `otel.jmx.service.url`. After loading the Groovy script whose path is specified
-via `otel.jmx.groovy.script`, it will then run the script on the specified
+provided `otel.jmx.service.url`. After loading the included metric gathering scripts specified by the
+comma-separated list in `otel.jmx.target.system`, it will then run the scripts on the specified
 `otel.jmx.interval.milliseconds` and export the resulting metrics.
 
 ### JMX Query Helpers
@@ -138,8 +138,8 @@ This metric extension supports Java 7+, though SASL is only supported where
 ### Target Systems
 
 The JMX Metric Gatherer also provides built in metric producing Groovy scripts for supported target systems
-capable of being specified via the `otel.jmx.target.system` property (mutually exclusive with `otel.jmx.groovy.script`).
-The currently available target systems are:
+capable of being specified via the `otel.jmx.target.system` property as a comma-separated list (mutually exclusive with
+`otel.jmx.groovy.script`). The currently available target systems are:
 
 | `otel.jmx.target.system` |
 | ------------------------ |
@@ -159,7 +159,7 @@ file contents can also be provided via stdin on startup when using `-config -` a
 | ------------- | -------- | ----------- |
 | `otel.jmx.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
 | `otel.jmx.groovy.script` | if not using `otel.jmx.target.system` | The path for the desired Groovy script. |
-| `otel.jmx.target.system` | if not using `otel.jmx.groovy.script` | The supported target application with built in Groovy script. |
+| `otel.jmx.target.system` | if not using `otel.jmx.groovy.script` | A comma-separated list of the supported target applications with built in Groovy scripts. |
 | `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10000 by default. |
 | `otel.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
 | `otel.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.groovy
@@ -44,7 +44,7 @@ class GroovyRunnerTest extends UnitTest {
                 })
 
         then: 'it is successfully loaded and runnable'
-        groovyRunner.script != null
+        groovyRunner.scripts.size() == 1
         groovyRunner.run()
         exportCalled
     }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -38,6 +38,7 @@ class JmxConfigTest extends UnitTest {
         config.serviceUrl == null
         config.groovyScript == null
         config.targetSystem == ""
+        config.targetSystems == [] as LinkedHashSet
         config.intervalMilliseconds == 10000
         config.exporterType == "logging"
         config.otlpExporterEndpoint == null
@@ -54,7 +55,7 @@ class JmxConfigTest extends UnitTest {
         def properties = [
             "jmx.service.url" : "myServiceUrl",
             "jmx.groovy.script" : "myGroovyScript",
-            "jmx.target.system" : "mytargetsystem",
+            "jmx.target.system" : "mytargetsystem,mytargetsystem,myothertargetsystem,myadditionaltargetsystem",
             "jmx.interval.milliseconds": "123",
             "exporter": "inmemory",
             "exporter.otlp.endpoint": "myOtlpEndpoint",
@@ -71,7 +72,12 @@ class JmxConfigTest extends UnitTest {
         then:
         config.serviceUrl == "myServiceUrl"
         config.groovyScript == "myGroovyScript"
-        config.targetSystem == "mytargetsystem"
+        config.targetSystem == "mytargetsystem,mytargetsystem,myothertargetsystem,myadditionaltargetsystem"
+        config.targetSystems == [
+            "mytargetsystem",
+            "myothertargetsystem",
+            "myadditionaltargetsystem"
+        ] as LinkedHashSet
         config.intervalMilliseconds == 123
         config.exporterType == "inmemory"
         config.otlpExporterEndpoint == "myOtlpEndpoint"
@@ -130,7 +136,7 @@ class JmxConfigTest extends UnitTest {
         setup: "config is set with nonexistant target system"
         [
             "service.url" : "requiredValue",
-            "target.system": "unavailableTargetSystem"
+            "target.system": "jvm,unavailableTargetSystem"
         ].each {
             System.setProperty("otel.jmx.${it.key}", it.value)
         }
@@ -145,6 +151,6 @@ class JmxConfigTest extends UnitTest {
 
         expect: 'config fails to validate'
         raised != null
-        raised.message ==  "unavailabletargetsystem must be one of [cassandra, jvm, kafka, kafka-consumer, kafka-producer]"
+        raised.message ==  "[jvm, unavailabletargetsystem] must specify targets from [cassandra, jvm, kafka, kafka-consumer, kafka-producer]"
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
@@ -1,0 +1,420 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.contrib.jmxmetrics
+
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.common.v1.StringKeyValue
+import io.opentelemetry.proto.metrics.v1.DoubleGauge
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
+import io.opentelemetry.proto.metrics.v1.IntGauge
+import io.opentelemetry.proto.metrics.v1.IntSum
+import io.opentelemetry.proto.metrics.v1.Metric
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import org.testcontainers.Testcontainers
+import spock.lang.Requires
+import spock.lang.Timeout
+
+@Requires({
+    System.getProperty('ojc.integration.tests') == 'true'
+})
+@Timeout(60)
+class MultipleTargetSystemsIntegrationTests extends OtlpIntegrationTest {
+
+    def 'end to end'() {
+        setup: 'we configure JMX metrics gatherer and target server to use JVM and Kafka as target systems'
+        targets = ["kafka"]
+        Testcontainers.exposeHostPorts(otlpPort)
+        configureContainers('target-systems/jvm-and-kafka.properties',  otlpPort, 0, false)
+
+        expect:
+        when: 'we receive metrics from the JMX metrics gatherer'
+        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+        then: 'they are of the expected size'
+        receivedMetrics.size() == 1
+
+        when: "we examine the received metric's instrumentation library metrics lists"
+        ResourceMetrics receivedMetric = receivedMetrics.get(0)
+        List<InstrumentationLibraryMetrics> ilMetrics =
+                receivedMetric.instrumentationLibraryMetricsList
+        then: 'they of the expected size'
+        ilMetrics.size() == 1
+
+        when: 'we examine the instrumentation library'
+        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+        InstrumentationLibrary il = ilMetric.instrumentationLibrary
+        then: 'it is of the expected content'
+        il.name  == 'io.opentelemetry.contrib.jmxmetrics'
+        il.version == '0.0.1'
+
+        when: 'we examine the instrumentation library metric metrics list'
+        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+        metrics.sort{ a, b -> a.name <=> b.name}
+        then: 'they are of the expected size and content'
+        metrics.size() == 37
+
+        def expectedMetrics = [
+            [
+                'jvm.classes.loaded',
+                'number of loaded classes',
+                '1',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.gc.collections.count',
+                'total number of collections that have occurred',
+                '1',
+                [
+                    "G1 Young Generation",
+                    "G1 Old Generation",
+                ],
+                IntSum
+            ],
+            [
+                'jvm.gc.collections.elapsed',
+                'the approximate accumulated collection elapsed time in milliseconds',
+                'ms',
+                [
+                    "G1 Young Generation",
+                    "G1 Old Generation",
+                ],
+                IntSum
+            ],
+            [
+                'jvm.memory.heap.committed',
+                'current heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.heap.init',
+                'current heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.heap.max',
+                'current heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.heap.used',
+                'current heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.nonheap.committed',
+                'current non-heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.nonheap.init',
+                'current non-heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.nonheap.max',
+                'current non-heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.nonheap.used',
+                'current non-heap usage',
+                'by',
+                [],
+                IntGauge
+            ],
+            [
+                'jvm.memory.pool.committed',
+                'current memory pool usage',
+                'by',
+                [
+                    "CodeHeap 'non-nmethods'",
+                    "CodeHeap 'non-profiled nmethods'",
+                    "CodeHeap 'profiled nmethods'",
+                    "Compressed Class Space",
+                    "G1 Eden Space",
+                    "G1 Old Gen",
+                    "G1 Survivor Space",
+                    "Metaspace",
+                ],
+                IntGauge
+            ],
+            [
+                'jvm.memory.pool.init',
+                'current memory pool usage',
+                'by',
+                [
+                    "CodeHeap 'non-nmethods'",
+                    "CodeHeap 'non-profiled nmethods'",
+                    "CodeHeap 'profiled nmethods'",
+                    "Compressed Class Space",
+                    "G1 Eden Space",
+                    "G1 Old Gen",
+                    "G1 Survivor Space",
+                    "Metaspace",
+                ],
+                IntGauge
+            ],
+            [
+                'jvm.memory.pool.max',
+                'current memory pool usage',
+                'by',
+                [
+                    "CodeHeap 'non-nmethods'",
+                    "CodeHeap 'non-profiled nmethods'",
+                    "CodeHeap 'profiled nmethods'",
+                    "Compressed Class Space",
+                    "G1 Eden Space",
+                    "G1 Old Gen",
+                    "G1 Survivor Space",
+                    "Metaspace",
+                ],
+                IntGauge
+            ],
+            [
+                'jvm.memory.pool.used',
+                'current memory pool usage',
+                'by',
+                [
+                    "CodeHeap 'non-nmethods'",
+                    "CodeHeap 'non-profiled nmethods'",
+                    "CodeHeap 'profiled nmethods'",
+                    "Compressed Class Space",
+                    "G1 Eden Space",
+                    "G1 Old Gen",
+                    "G1 Survivor Space",
+                    "Metaspace",
+                ],
+                IntGauge
+            ],
+            [
+                'jvm.threads.count',
+                'number of threads',
+                '1',
+                [],
+                IntGauge
+            ],
+            [
+                'kafka.bytes.in',
+                'bytes in per second from clients',
+                'by',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.bytes.out',
+                'bytes out per second to clients',
+                'by',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.controller.active.count',
+                'controller is active on broker',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.fetch.consumer.total.time.99p',
+                'fetch consumer request time - 99th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.fetch.consumer.total.time.count',
+                'fetch consumer request count',
+                '1',
+                [],
+                IntSum,
+            ],
+            [
+                'kafka.fetch.consumer.total.time.median',
+                'fetch consumer request time - 50th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.fetch.follower.total.time.99p',
+                'fetch follower request time - 99th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.fetch.follower.total.time.count',
+                'fetch follower request count',
+                '1',
+                [],
+                IntSum,
+            ],
+            [
+                'kafka.fetch.follower.total.time.median',
+                'fetch follower request time - 50th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.isr.expands',
+                'in-sync replica expands per second',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.isr.shrinks',
+                'in-sync replica shrinks per second',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.leader.election.rate',
+                'leader election rate - non-zero indicates broker failures',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.max.lag',
+                'max lag in messages between follower and leader replicas',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.messages.in',
+                'number of messages in per second',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.partitions.offline.count',
+                'number of partitions without an active leader',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.partitions.underreplicated.count',
+                'number of under replicated partitions',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.produce.total.time.99p',
+                'produce request time - 99th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.produce.total.time.count',
+                'produce request count',
+                '1',
+                [],
+                IntSum,
+            ],
+            [
+                'kafka.produce.total.time.median',
+                'produce request time - 50th percentile',
+                'ms',
+                [],
+                DoubleGauge,
+            ],
+            [
+                'kafka.request.queue',
+                'size of the request queue',
+                '1',
+                [],
+                IntGauge,
+            ],
+            [
+                'kafka.unclean.election.rate',
+                'unclean leader election rate - non-zero indicates broker failures',
+                '1',
+                [],
+                IntGauge,
+            ],
+        ].eachWithIndex{ item, index ->
+            def expectedType = item[4]
+
+            Metric metric = metrics.get(index)
+            assert metric.name == item[0]
+            assert metric.description == item[1]
+            assert metric.unit == item[2]
+
+            def datapoints
+            switch(expectedType) {
+                case IntGauge :
+                    assert metric.hasIntGauge()
+                    datapoints = metric.intGauge
+                    break
+                case DoubleGauge :
+                    assert metric.hasDoubleGauge()
+                    datapoints = metric.doubleGauge
+                    break
+                default:
+                    assert metric.hasIntSum()
+                    datapoints = metric.intSum
+            }
+
+            def expectedLabelCount = item[3].size()
+            def expectedLabels = item[3] as Set
+
+            def expectedDatapointCount = expectedLabelCount == 0 ? 1 : expectedLabelCount
+            assert datapoints.dataPointsCount == expectedDatapointCount
+
+            (0..<expectedDatapointCount).each { i ->
+                def datapoint = datapoints.getDataPoints(i)
+                List<StringKeyValue> labels = datapoint.labelsList
+                if (expectedLabelCount != 0) {
+                    assert labels.size() == 1
+                    assert labels[0].key == 'name'
+                    def value = labels[0].value
+                    assert expectedLabels.remove(value)
+                } else {
+                    assert labels.size() == 0
+                }
+            }
+
+            assert expectedLabels.size() == 0
+        }
+
+        cleanup:
+        targetContainers.each { it.stop() }
+        jmxExtensionAppContainer.stop()
+    }
+}

--- a/contrib/jmx-metrics/src/test/resources/target-systems/jvm-and-kafka.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/jvm-and-kafka.properties
@@ -1,0 +1,9 @@
+otel.jmx.interval.milliseconds = 3000
+otel.exporter = otlp
+otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka:7199/jmxrmi
+otel.jmx.target.system = jvm,kafka
+
+# these will be overridden by cmd line
+otel.jmx.username = wrong_username
+otel.jmx.password = wrong_password
+otel.otlp.endpoint = host.testcontainers.internal:80


### PR DESCRIPTION
**Description:**
~~Requires https://github.com/open-telemetry/opentelemetry-java-contrib/pull/27~~

Feature addition - These changes add comma-separated value support for `otel.jmx.target.system` so that multiple builtin scripts can be run against the same mbean server.  This is useful when wanting* general JVM metrics along with a more specific target system.

**Existing Issue(s):**

Resolves https://github.com/open-telemetry/opentelemetry-java-contrib/issues/26

**Testing:**

Updates existing unit tests and adds integration suite.

**Documentation:**

Updates existing documentation

**Outstanding items:**

Doesn't add default target system of `jvm`, which will be introduced in a later change to resolve https://github.com/open-telemetry/opentelemetry-java-contrib/issues/12
