### PR TITLE
Add otelRelease task

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,3 +40,11 @@ production environments.
 
 This task requires an account and API key for the OpenTelemetry Bintray organization.  If you have been provided access
 and configured your key, please set the required environment variables detailed in the publish script plugin.
+
+## `./gradlew otelRelease`
+
+This task will invoke the [Bintray Plugin](https://github.com/bintray/gradle-bintray-plugin)
+and publish all applicable snapshot artifacts to https://dl.bintray.com/open-telemetry/maven/io/opentelemetry/contrib/,
+assuming the current version is not a snapshot.  Syncing with Maven Central is not performed at this time.
+
+Like `ossSnapshot`, this task requires an account and API key for the OpenTelemetry Bintray organization.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.diffplug.spotless' version '5.1.1'
     id "com.github.johnrengelman.shadow" version "6.0.0" apply false
     id "com.jfrog.artifactory" version "4.17.2" apply false
+    id 'com.jfrog.bintray' version '1.8.5' apply false
 }
 
 description = 'OpenTelemetry Contrib libraries and utilities for the JVM'

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -35,7 +35,7 @@ def versions = [
 
 def deps = [
     slf4j : "org.slf4j:slf4j-api:${versions.slf4j}",
-    testcontainers : "org.testcontainers:testcontainers:1.14.3",
+    testcontainers : "org.testcontainers:testcontainers:1.15.1",
 ]
 
 dependencies {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'com.jfrog.bintray'
 
 publishing {
     repositories {
@@ -88,10 +89,41 @@ artifactory {
     }
 }
 
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['maven']
+    publish = true
+
+    pkg {
+        repo = 'maven'
+        name = 'opentelemetry-java-contrib'
+        userOrg = 'open-telemetry'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/open-telemetry/opentelemetry-java-contrib.git'
+
+        githubRepo = 'open-telemetry/opentelemetry-java-contrib'
+
+        version {
+            name = project.version
+            gpg {
+                sign = true
+            }
+        }
+    }
+}
+
 task ossSnapshot {
     artifactoryPublish {
         enabled = version.toString().contains('SNAPSHOT')
         publications('maven')
     }
     finalizedBy artifactoryPublish
+}
+
+task otelRelease {
+    bintrayUpload {
+        enabled = !version.toString().contains('SNAPSHOT')
+    }
+    finalizedBy bintrayUpload
 }


### PR DESCRIPTION
**Description:**
Feature addition - These changes add a task for pushing publishable contrib projects to the OTel Bintray organization.

Also includes a test dependency update to account for unrelated flake.

**Testing:**

I tested it by prematurely [releasing 0.0.1](https://dl.bintray.com/open-telemetry/maven/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/0.0.1/) since the dry run functionality output didn't give me enough confidence.

**Documentation:**

Release readme has been updated.

**Outstanding items:**

Subsequently releasing a 0.10.0 version and moving to 0.14.0 development.
