### PR TITLE
Adopt OpenTelemetry 1.0.0-alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ description = 'OpenTelemetry Contrib libraries and utilities for the JVM'
 
 allprojects {
     group = 'io.opentelemetry.contrib'
-    version = '0.0.1-SNAPSHOT'
+    version = '1.0.0-alpha-SNAPSHOT'
 
     apply from: "$rootDir/gradle/spotless.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"

--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -1,47 +1,83 @@
 # JMX Metric Gatherer
 
 This utility provides an easy framework for gathering and reporting metrics based on queried
-MBeans from a JMX server.  It loads a custom Groovy script and establishes a helpful, bound `otel`
-object with methods for obtaining MBeans and constructing synchronous OpenTelemetry instruments:
+MBeans from a JMX server.  It loads an included or custom Groovy script and establishes a helpful,
+bound `otel` object with methods for obtaining MBeans and constructing OpenTelemetry instruments:
 
 ### Usage
 
+The JMX Metric Gatherer is intended to be run as an uber jar and configured with properties from the command line,
+properties file, and stdin (`-`).  Its metric-gathering scripts are specified by supported `otel.jmx.target.system`
+values or a `otel.jmx.groovy.script` path to run your own.
+
 ```bash
-$ java -D<otel.jmx.property=value> -jar opentelemetry-java-contrib-jmx-metrics-<version>.jar [-config {optional_config.properties, '-'}]
+$ java -D<otel.jmx.property=value> -jar opentelemetry-java-contrib-jmx-metrics-<version>.jar [-config {session.properties, '-'}]
 ```
 
-##### `optional_config.properties` example
+##### `session.properties`
 
 ```properties
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
 otel.jmx.target.system = jvm,kafka
 otel.jmx.interval.milliseconds = 5000
-otel.exporter = otlp
-otel.otlp.endpoint = my-opentelemetry-collector:55680
 otel.jmx.username = my-username
 otel.jmx.password = my-password
+
+otel.metrics.exporter = otlp
+otel.exporter.otlp.endpoint = http://my-opentelemetry-collector:55680
 ```
 
-##### `script.groovy` example
+As configured in this example, the metric gatherer will establish an MBean server connection using the
+specified `otel.jmx.service.url` (required) and credentials and configure an OTLP gRPC metrics exporter reporting to
+`otel.exporter.otlp.endpoint`. After loading the included JVM and Kafka metric-gathering scripts determined by
+the comma-separated list in `otel.jmx.target.system`, it will then run the scripts on the desired interval
+length of `otel.jmx.interval.milliseconds` and export the resulting metrics.
+
+For custom metrics and unsupported targets, you can provide your own MBean querying scripts to produce
+OpenTelemetry instruments:
+
+```bash
+$ java -Dotel.jmx.groovy.script=./script.groovy -jar opentelemetry-java-contrib-jmx-metrics-<version>.jar [-config {optional.properties, '-'}]
+```
+
+##### `script.groovy`
 
 ```groovy
-def storageLoadMBean = otel.mbean("org.apache.cassandra.metrics:type=Storage,name=Load")
-otel.instrument(storageLoadMBean, "cassandra.storage.load",
-        "Size, in bytes, of the on disk data size this node manages",
+// Query the target JMX server for the desired MBean and create a helper representing the first result
+def loadMBean = otel.mbean("io.example.service:type=MyType,name=Load")
+
+// Create a LongValueObserver whose updater will set the instrument value to the
+// loadMBean's most recent `Count` attribute's long value.  The instrument will have a
+// name of "my.type.load" and the specified description and unit, respectively.
+otel.instrument(
+        loadMBean, "my.type.load",
+        "Load, in bytes, of the service of MyType",
         "By", "Count", otel.&longValueObserver
 )
 ```
 
-As configured in the example, this metric gatherer will configure an otlp gRPC metric exporter
-at the `otel.otlp.endpoint` and establish an MBean server connection using the
-provided `otel.jmx.service.url`. After loading the included metric gathering scripts specified by the
-comma-separated list in `otel.jmx.target.system`, it will then run the scripts on the specified
-`otel.jmx.interval.milliseconds` and export the resulting metrics.
+The specified `script.groovy` file will be run on the desired `otel.jmx.interval.milliseconds` (10000 by default),
+resulting in an exported `my.type.load` instrument with the observed value of the desired MBean's `Count`
+attribute as queried in each interval.
+
+### Target Systems
+
+The JMX Metric Gatherer provides built in metric producing Groovy scripts for supported target systems
+capable of being specified via the `otel.jmx.target.system` property as a comma-separated list.  This property is
+mutually exclusive with `otel.jmx.groovy.script`. The currently supported target systems are:
+
+| `otel.jmx.target.system` |
+| ------------------------ |
+| [`jvm`](./docs/target-systems/jvm.md) |
+| [`cassandra`](./docs/target-systems/cassandra.md) |
+| [`kafka`](./docs/target-systems/kafka.md) |
+| [`kafka-consumer`](./docs/target-systems/kafka-consumer.md) |
+| [`kafka-producer`](./docs/target-systems/kafka-producer.md) |
 
 ### JMX Query Helpers
 
 - `otel.queryJmx(String objectNameStr)`
-   - This method will query the connected JMX application for the given `objectName`, which can
+   - This method will query the connected JMX application for the given `objectNameStr`, which can
    include wildcards.  The return value will be a sorted `List<GroovyMBean>` of zero or more
    [`GroovyMBean` objects](http://docs.groovy-lang.org/latest/html/api/groovy/jmx/GroovyMBean.html),
    which are conveniently wrapped to make accessing attributes on the MBean simple.
@@ -56,18 +92,21 @@ comma-separated list in `otel.jmx.target.system`, it will then run the scripts o
 - `otel.mbean(String objectNameStr)`
    - This method will query for the given `objectNameStr` using `otel.queryJmx()` as previously described,
    but returns an `MBeanHelper` instance representing the alphabetically first matching MBean for usage by
-   subsequent `InstrumentHelper` instances (available via `otel.instrument()`) as described below.
+   subsequent `InstrumentHelper` instances (available via `otel.instrument()`) as described below.  It is
+   intended to be used in cases where your `objectNameStr` will return a single element `List<GroovyMBean>`
+   to avoid redundant item access.
 
 - `otel.mbeans(String objectNameStr)`
    - This method will query for the given `objectNameStr` using `otel.queryJmx()` as previously described,
    but returns an `MBeanHelper` instance representing all matching MBeans for usage by subsequent `InstrumentHelper`
-   instances (available via `otel.instrument()`) as described below.
+   instances (available via `otel.instrument()`) as described below.  It is intended to be used in cases
+   where your given `objectNameStr` can return a multiple element `List<GroovyMBean>`.
 
 - `otel.instrument(MBeanHelper mBeanHelper, String instrumentName, String description, String unit, Map<String, Closure> labelFuncs, String attribute, Closure instrument)`
    - This method provides the ability to easily create and automatically update instrument instances from an
-   `MBeanHelper`'s underlying MBean instances via an OpenTelemetry instrument helper method pointer as described below.
-   - The method parameters map to those of the instrument helpers, while the new `Map<String, Closure> labelFuncs` will
-   be used to specify updated instrument labels that have access to the inspected MBean:
+   `MBeanHelper`'s underlying MBeans via an OpenTelemetry instrument helper method pointer as described below.
+   - The method parameters map to those of the instrument helpers, while the additional `Map<String, Closure> labelFuncs`
+   will be used to specify updated instrument labels that have access to the inspected MBean:
 
    ```groovy
       // This example's resulting datapoint(s) will have Labels consisting of the specified key
@@ -110,44 +149,42 @@ aren't desired upon invocation.
 
 ### OpenTelemetry Asynchronous Instrument Helpers
 
-- `otel.doubleSumObserver(String name, String description, String unit)`
+- `otel.doubleSumObserver(String name, String description, String unit, Closure updater)`
 
-- `otel.longSumObserver(String name, String description, String unit)`
+- `otel.longSumObserver(String name, String description, String unit, Closure updater)`
 
-- `otel.doubleUpDownSumObserver(String name, String description, String unit)`
+- `otel.doubleUpDownSumObserver(String name, String description, String unit, Closure updater)`
 
-- `otel.longUpDownSumObserver(String name, String description, String unit)`
+- `otel.longUpDownSumObserver(String name, String description, String unit, Closure updater)`
 
-- `otel.doubleValueObserver(String name, String description, String unit)`
+- `otel.doubleValueObserver(String name, String description, String unit, Closure updater)`
 
-- `otel.longValueObserver(String name, String description, String unit)`
+- `otel.longValueObserver(String name, String description, String unit, Closure updater)`
 
 These methods will return a new or previously registered instance of the applicable metric
 instruments.  Each one provides two additional signatures where unit and description aren't
 desired upon invocation.
 
-- `otel.<meterMethod>(String name, String description)` - `unit` is "1".
+- `otel.<meterMethod>(String name, String description, Closure updater)` - `unit` is "1".
 
-- `otel.<meterMethod>(String name)` - `description` is empty string and `unit` is "1".
+- `otel.<meterMethod>(String name, Closure updater)` - `description` is empty string and `unit` is "1".
+
+Though asynchronous instrument updaters are exclusively set by their builders in the OpenTelemetry API,
+the JMX Metric Gatherer asynchronous instrument helpers allow using the specified updater Closure for
+each instrument as run on the desired interval:
+
+```groovy
+def loadMBean = otel.mbean("io.example.service:type=MyType,name=Load")
+otel.longValueObserver(
+        "my.type.load", "Load, in bytes, of the service of MyType", "By",
+        { longResult -> longResult.observe(storageLoadMBean.getAttribute("Count")) }
+)
+```
 
 ### Compatibility
 
-This metric extension supports Java 7+, though SASL is only supported where
+This metric extension supports Java 8+, though SASL is only supported where
 `com.sun.security.sasl.Provider` is available.
-
-### Target Systems
-
-The JMX Metric Gatherer also provides built in metric producing Groovy scripts for supported target systems
-capable of being specified via the `otel.jmx.target.system` property as a comma-separated list (mutually exclusive with
-`otel.jmx.groovy.script`). The currently available target systems are:
-
-| `otel.jmx.target.system` |
-| ------------------------ |
-| [`jvm`](./docs/target-systems/jvm.md) |
-| [`cassandra`](./docs/target-systems/cassandra.md) |
-| [`kafka`](./docs/target-systems/kafka.md) |
-| [`kafka-consumer`](./docs/target-systems/kafka-consumer.md) |
-| [`kafka-producer`](./docs/target-systems/kafka-producer.md) |
 
 ### Configuration
 
@@ -161,19 +198,18 @@ file contents can also be provided via stdin on startup when using `-config -` a
 | `otel.jmx.groovy.script` | if not using `otel.jmx.target.system` | The path for the desired Groovy script. |
 | `otel.jmx.target.system` | if not using `otel.jmx.groovy.script` | A comma-separated list of the supported target applications with built in Groovy scripts. |
 | `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10000 by default. |
-| `otel.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
-| `otel.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
-| `otel.exporter.otlp.metric.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |
-| `otel.exporter.otlp.use.tls` | no | Whether to use TLS for otlp channel.  Setting any value evaluates to `true`. |
-| `otel.exporter.otlp.metadata` | no | Any headers to include in otlp exporter metric submissions.  Of the form `'header1=value1;header2=value2'` |
-| `otel.exporter.prometheus.host` | no | The prometheus collector server host. Default is `localhost`.  |
-| `otel.exporter.prometheus.port` | no | The prometheus collector server port. Default is `9090`.  |
 | `otel.jmx.username` | no | Username for JMX authentication, if applicable. |
 | `otel.jmx.password` | no | Password for JMX authentication, if applicable. |
+| `otel.jmx.remote.profile` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
+| `otel.jmx.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |
+| `otel.metrics.exporter` | no | The type of metric exporter to use: (`otlp`, `prometheus`, `inmemory`, `logging`).  `logging` by default. |
+| `otel.exporter.otlp.endpoint` | no | The otlp exporter endpoint to use, Required for `otlp`.  |
+| `otel.exporter.otlp.headers` | no | Any headers to include in otlp exporter metric submissions.  Of the form `header1=value1,header2=value2` |
+| `otel.exporter.otlp.timeout` | no | The otlp exporter request timeout (in milliseconds).  Default is 1000.  |
+| `otel.exporter.prometheus.host` | no | The prometheus collector server host. Default is `0.0.0.0`.  |
+| `otel.exporter.prometheus.port` | no | The prometheus collector server port. Default is `9464`.  |
 | `javax.net.ssl.keyStore` | no | The key store path is required if client authentication is enabled on the target JVM. |
 | `javax.net.ssl.keyStorePassword` | no | The key store file password if required. |
 | `javax.net.ssl.keyStoreType` | no | The key store type. |
 | `javax.net.ssl.trustStore` | no | The trusted store path if the TLS profile is required. |
 | `javax.net.ssl.trustStorePassword` | no | The trust store file password if required. |
-| `otel.jmx.remote.profile` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |
-| `otel.jmx.realm` | no | The realm is required by profile SASL/DIGEST-MD5. |

--- a/contrib/jmx-metrics/jmx-metrics.gradle
+++ b/contrib/jmx-metrics/jmx-metrics.gradle
@@ -26,7 +26,7 @@ sourceSets.test.java.srcDirs = []
 mainClassName = 'io.opentelemetry.contrib.jmxmetrics.JmxMetrics'
 
 def versions = [
-    grpc : '1.30.2',
+    grpc : '1.37.0',
     protobuf : '3.11.4',
     groovy : '2.5.11',
     slf4j : "1.7.30",
@@ -45,10 +45,13 @@ dependencies {
             "io.prometheus:simpleclient:${versions.prometheus}",
             "io.prometheus:simpleclient_httpserver:${versions.prometheus}",
             libraries.otelApi,
+            libraries.otelApiMetrics,
+            libraries.otelAutoconfig,
             libraries.otelExporterLogging,
             libraries.otelExporterOtlp,
             libraries.otelExporterPrometheus,
             libraries.otelSdk,
+            libraries.otelSdkMetrics,
             libraries.otelSdkTesting,
             deps.slf4j,
             dependencies.create(group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j)

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -179,75 +179,75 @@ class OtelHelper {
         return longValueRecorder(name, '')
     }
 
-    DoubleSumObserver doubleSumObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getDoubleSumObserver(name, description, unit)
+    DoubleSumObserver doubleSumObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getDoubleSumObserver(name, description, unit, updater)
     }
 
-    DoubleSumObserver doubleSumObserver(String name, String description) {
-        return doubleSumObserver(name, description, SCALAR)
+    DoubleSumObserver doubleSumObserver(String name, String description, Closure updater) {
+        return doubleSumObserver(name, description, SCALAR, updater)
     }
 
-    DoubleSumObserver doubleSumObserver(String name) {
-        return doubleSumObserver(name, '')
+    DoubleSumObserver doubleSumObserver(String name, Closure updater) {
+        return doubleSumObserver(name, '', updater)
     }
 
-    LongSumObserver longSumObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getLongSumObserver(name, description, unit)
+    LongSumObserver longSumObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getLongSumObserver(name, description, unit, updater)
     }
 
-    LongSumObserver longSumObserver(String name, String description) {
-        return longSumObserver(name, description, SCALAR)
+    LongSumObserver longSumObserver(String name, String description, Closure updater) {
+        return longSumObserver(name, description, SCALAR, updater)
     }
 
-    LongSumObserver longSumObserver(String name) {
-        return longSumObserver(name, '')
+    LongSumObserver longSumObserver(String name, Closure updater) {
+        return longSumObserver(name, '', updater)
     }
 
-    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getDoubleUpDownSumObserver(name, description, unit)
+    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getDoubleUpDownSumObserver(name, description, unit, updater)
     }
 
-    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description) {
-        return doubleUpDownSumObserver(name, description, SCALAR)
+    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, String description, Closure updater) {
+        return doubleUpDownSumObserver(name, description, SCALAR, updater)
     }
 
-    DoubleUpDownSumObserver doubleUpDownSumObserver(String name) {
-        return doubleUpDownSumObserver(name, '')
+    DoubleUpDownSumObserver doubleUpDownSumObserver(String name, Closure updater) {
+        return doubleUpDownSumObserver(name, '', updater)
     }
 
-    LongUpDownSumObserver longUpDownSumObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getLongUpDownSumObserver(name, description, unit)
+    LongUpDownSumObserver longUpDownSumObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getLongUpDownSumObserver(name, description, unit, updater)
     }
 
-    LongUpDownSumObserver longUpDownSumObserver(String name, String description) {
-        return longUpDownSumObserver(name, description, SCALAR)
+    LongUpDownSumObserver longUpDownSumObserver(String name, String description, Closure updater) {
+        return longUpDownSumObserver(name, description, SCALAR, updater)
     }
 
-    LongUpDownSumObserver longUpDownSumObserver(String name) {
-        return longUpDownSumObserver(name, '')
+    LongUpDownSumObserver longUpDownSumObserver(String name, Closure updater) {
+        return longUpDownSumObserver(name, '', updater)
     }
 
-    DoubleValueObserver doubleValueObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getDoubleValueObserver(name, description, unit)
+    DoubleValueObserver doubleValueObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getDoubleValueObserver(name, description, unit, updater)
     }
 
-    DoubleValueObserver doubleValueObserver(String name, String description) {
-        return doubleValueObserver(name, description, SCALAR)
+    DoubleValueObserver doubleValueObserver(String name, String description, Closure updater) {
+        return doubleValueObserver(name, description, SCALAR, updater)
     }
 
-    DoubleValueObserver doubleValueObserver(String name) {
-        return doubleValueObserver(name, '')
+    DoubleValueObserver doubleValueObserver(String name, Closure updater) {
+        return doubleValueObserver(name, '', updater)
     }
 
-    LongValueObserver longValueObserver(String name, String description, String unit) {
-        return groovyMetricEnvironment.getLongValueObserver(name, description, unit)
+    LongValueObserver longValueObserver(String name, String description, String unit, Closure updater) {
+        return groovyMetricEnvironment.getLongValueObserver(name, description, unit, updater)
     }
 
-    LongValueObserver longValueObserver(String name, String description) {
-        return longValueObserver(name, description, SCALAR)
+    LongValueObserver longValueObserver(String name, String description, Closure updater) {
+        return longValueObserver(name, description, SCALAR, updater)
     }
 
-    LongValueObserver longValueObserver(String name) {
-        return longValueObserver(name, '')
+    LongValueObserver longValueObserver(String name, Closure updater) {
+        return longValueObserver(name, '', updater)
     }
 }

--- a/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/contrib/jmx-metrics/src/main/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -155,6 +155,5 @@ public class GroovyRunner {
 
   public void shutdown() {
     flush();
-    groovyMetricEnvironment.shutdown();
   }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -66,7 +66,7 @@ class IntegrationTest extends Specification{
             "/app/OpenTelemetryJava.jar",
             "-Dotel.jmx.username=cassandra",
             "-Dotel.jmx.password=cassandra",
-            "-Dotel.exporter.otlp.endpoint=host.testcontainers.internal:${otlpPort}",
+            "-Dotel.exporter.otlp.endpoint=http://host.testcontainers.internal:${otlpPort}",
             "io.opentelemetry.contrib.jmxmetrics.JmxMetrics",
             "-config",
         ]

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.groovy
@@ -40,10 +40,10 @@ class JmxConfigTest extends UnitTest {
         config.targetSystem == ""
         config.targetSystems == [] as LinkedHashSet
         config.intervalMilliseconds == 10000
-        config.exporterType == "logging"
+        config.metricsExporterType == "logging"
         config.otlpExporterEndpoint == null
-        config.prometheusExporterHost == "localhost"
-        config.prometheusExporterPort == 9090
+        config.prometheusExporterHost == "0.0.0.0"
+        config.prometheusExporterPort == 9464
         config.username == null
         config.password == null
         config.remoteProfile == null
@@ -57,8 +57,8 @@ class JmxConfigTest extends UnitTest {
             "jmx.groovy.script" : "myGroovyScript",
             "jmx.target.system" : "mytargetsystem,mytargetsystem,myothertargetsystem,myadditionaltargetsystem",
             "jmx.interval.milliseconds": "123",
-            "exporter": "inmemory",
-            "exporter.otlp.endpoint": "myOtlpEndpoint",
+            "metrics.exporter": "inmemory",
+            "exporter.otlp.endpoint": "https://myOtlpEndpoint",
             "exporter.prometheus.host": "myPrometheusHost",
             "exporter.prometheus.port": "234",
             "jmx.username": "myUsername",
@@ -79,8 +79,8 @@ class JmxConfigTest extends UnitTest {
             "myadditionaltargetsystem"
         ] as LinkedHashSet
         config.intervalMilliseconds == 123
-        config.exporterType == "inmemory"
-        config.otlpExporterEndpoint == "myOtlpEndpoint"
+        config.metricsExporterType == "inmemory"
+        config.otlpExporterEndpoint == "https://myOtlpEndpoint"
         config.prometheusExporterHost == "myPrometheusHost"
         config.prometheusExporterPort == 234
         config.username == "myUsername"

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.groovy
@@ -16,16 +16,18 @@
 
 package io.opentelemetry.contrib.jmxmetrics
 
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.GAUGE_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_DOUBLE
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.NON_MONOTONIC_LONG
-import static io.opentelemetry.sdk.metrics.data.MetricData.Type.SUMMARY
 
-import io.opentelemetry.api.common.Labels
-import io.opentelemetry.sdk.OpenTelemetrySdk
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_GAUGE
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_GAUGE
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.DOUBLE_SUM
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.LONG_SUM
+import static io.opentelemetry.sdk.metrics.data.MetricDataType.SUMMARY
+
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+
+import io.opentelemetry.api.metrics.GlobalMetricsProvider
+import io.opentelemetry.api.metrics.common.Labels
 import org.junit.Rule
 import org.junit.rules.TestName
 import org.junit.rules.TestRule
@@ -47,7 +49,7 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         // Set up a MeterSdk per test to be able to collect its metrics alone
         gme = new GroovyMetricEnvironment(
                 new JmxConfig(new Properties().tap {
-                    it.setProperty(JmxConfig.EXPORTER_TYPE, 'inmemory')
+                    it.setProperty(JmxConfig.METRICS_EXPORTER_TYPE, 'inmemory')
                     it.setProperty(JmxConfig.INTERVAL_MILLISECONDS, '100')
                 }),
                 name.methodName, ''
@@ -56,10 +58,14 @@ class OtelHelperAsynchronousMetricTest extends Specification{
     }
 
     def exportMetrics() {
-        def provider = OpenTelemetrySdk.globalMeterProvider.get(name.methodName, '')
-        return provider.collectAll().sort { md1, md2 ->
-            def p1 = md1.points[0]
-            def p2 = md2.points[0]
+        def now = Clock.systemUTC().instant();
+        def nanos = TimeUnit.SECONDS.toNanos(now.epochSecond) + now.nano
+
+        def provider = GlobalMetricsProvider.get().get(name.methodName, '')
+        def all = provider.collectAll(nanos)
+        return all.sort { md1, md2 ->
+            def p1 = md1.data.points[0]
+            def p2 = md2.data.points[0]
             def s1 = p1.startEpochNanos
             def s2 = p2.startEpochNanos
             if (s1 == s2) {
@@ -76,23 +82,19 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         when:
         def dso = otel.doubleSumObserver(
                 'double-sum', 'a double sum',
-                'ms')
-        dso.setCallback({doubleResult ->
-            doubleResult.observe(123.456, Labels.of('key', 'value'))
-        })
+                'ms', {doubleResult ->
+                    doubleResult.observe(123.456, Labels.of('key', 'value'))
+                })
 
-        dso = otel.doubleSumObserver('my-double-sum', 'another double sum', 'µs')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleSumObserver('my-double-sum', 'another double sum', 'µs', { doubleResult ->
             doubleResult.observe(234.567, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.doubleSumObserver('another-double-sum', 'double sum')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleSumObserver('another-double-sum', 'double sum', { doubleResult ->
             doubleResult.observe(345.678, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.doubleSumObserver('yet-another-double-sum')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleSumObserver('yet-another-double-sum', { doubleResult ->
             doubleResult.observe(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -108,54 +110,50 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'double-sum'
         assert first.description == 'a double sum'
         assert first.unit == 'ms'
-        assert first.type == MONOTONIC_DOUBLE
-        assert first.points.size() == 1
-        assert first.points[0].value == 123.456
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == DOUBLE_SUM
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123.456
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-double-sum'
         assert second.description == 'another double sum'
         assert second.unit == 'µs'
-        assert second.type == MONOTONIC_DOUBLE
-        assert second.points.size() == 1
-        assert second.points[0].value == 234.567
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == DOUBLE_SUM
+        assert second.data.points.size() == 1
+        assert second.data.points[0].value == 234.567
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-double-sum'
         assert third.description == 'double sum'
         assert third.unit == '1'
-        assert third.type == MONOTONIC_DOUBLE
-        assert third.points.size() == 1
-        assert third.points[0].value == 345.678
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == DOUBLE_SUM
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345.678
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-double-sum'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == MONOTONIC_DOUBLE
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456.789
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == DOUBLE_SUM
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456.789
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "double sum observer memoization"() {
         when:
-        def dcOne = otel.doubleSumObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcOne = otel.doubleSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(10.1, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.doubleSumObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcTwo = otel.doubleSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(20.2, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.doubleSumObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcThree = otel.doubleSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(30.3, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.doubleSumObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcFour = otel.doubleSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(40.4, Labels.of('key4', 'value4'))
         })
         def secondMetrics = exportMetrics()
@@ -172,44 +170,38 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'double'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == MONOTONIC_DOUBLE
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20.2
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == DOUBLE_SUM
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20.2
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'double'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == MONOTONIC_DOUBLE
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 20.2
-        assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
-        assert secondMetric.points[1].value == 40.4
-        assert secondMetric.points[1].labels == Labels.of('key4', 'value4')
+        assert secondMetric.type == DOUBLE_SUM
+        assert secondMetric.data.points.size() == 1
+        assert secondMetric.data.points[0].value == 40.4
+        assert secondMetric.data.points[0].labels == Labels.of('key4', 'value4')
     }
 
     def "long sum observer"() {
         when:
         def dso = otel.longSumObserver(
                 'long-sum', 'a long sum',
-                'ms')
-        dso.setCallback({longResult ->
-            longResult.observe(123, Labels.of('key', 'value'))
-        })
+                'ms', {longResult ->
+                    longResult.observe(123, Labels.of('key', 'value'))
+                })
 
-        dso = otel.longSumObserver('my-long-sum', 'another long sum', 'µs')
-        dso.setCallback({ longResult ->
+        dso = otel.longSumObserver('my-long-sum', 'another long sum', 'µs', { longResult ->
             longResult.observe(234, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.longSumObserver('another-long-sum', 'long sum')
-        dso.setCallback({ longResult ->
+        dso = otel.longSumObserver('another-long-sum', 'long sum', { longResult ->
             longResult.observe(345, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.longSumObserver('yet-another-long-sum')
-        dso.setCallback({ longResult ->
+        dso = otel.longSumObserver('yet-another-long-sum', { longResult ->
             longResult.observe(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -225,54 +217,50 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'long-sum'
         assert first.description == 'a long sum'
         assert first.unit == 'ms'
-        assert first.type == MONOTONIC_LONG
-        assert first.points.size() == 1
-        assert first.points[0].value == 123
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == LONG_SUM
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-long-sum'
         assert second.description == 'another long sum'
         assert second.unit == 'µs'
-        assert second.type == MONOTONIC_LONG
-        assert second.points.size() == 1
-        assert second.points[0].value == 234
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == LONG_SUM
+        assert second.data.points.size() == 1
+        assert second.data.points[0].value == 234
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-long-sum'
         assert third.description == 'long sum'
         assert third.unit == '1'
-        assert third.type == MONOTONIC_LONG
-        assert third.points.size() == 1
-        assert third.points[0].value == 345
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == LONG_SUM
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-long-sum'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == MONOTONIC_LONG
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == LONG_SUM
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "long sum observer memoization"() {
         when:
-        def dcOne = otel.longSumObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcOne = otel.longSumObserver('dc', 'long', { longResult ->
             longResult.observe(10, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.longSumObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcTwo = otel.longSumObserver('dc', 'long', { longResult ->
             longResult.observe(20, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.longSumObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcThree = otel.longSumObserver('dc', 'long', { longResult ->
             longResult.observe(30, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.longSumObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcFour = otel.longSumObserver('dc', 'long', { longResult ->
             longResult.observe(40, Labels.of('key4', 'value4'))
         })
         def secondMetrics = exportMetrics()
@@ -289,44 +277,38 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'long'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == MONOTONIC_LONG
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == LONG_SUM
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'long'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == MONOTONIC_LONG
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 20
-        assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
-        assert secondMetric.points[1].value == 40
-        assert secondMetric.points[1].labels == Labels.of('key4', 'value4')
+        assert secondMetric.type == LONG_SUM
+        assert secondMetric.data.points.size() == 1
+        assert secondMetric.data.points[0].value == 40
+        assert secondMetric.data.points[0].labels == Labels.of('key4', 'value4')
     }
 
     def "double up down sum observer"() {
         when:
         def dso = otel.doubleUpDownSumObserver(
                 'double-up-down-sum', 'a double up down sum',
-                'ms')
-        dso.setCallback({doubleResult ->
-            doubleResult.observe(123.456, Labels.of('key', 'value'))
-        })
+                'ms', {doubleResult ->
+                    doubleResult.observe(123.456, Labels.of('key', 'value'))
+                })
 
-        dso = otel.doubleUpDownSumObserver('my-double-up-down-sum', 'another double up down sum', 'µs')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleUpDownSumObserver('my-double-up-down-sum', 'another double up down sum', 'µs', { doubleResult ->
             doubleResult.observe(234.567, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.doubleUpDownSumObserver('another-double-up-down-sum', 'double up down sum')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleUpDownSumObserver('another-double-up-down-sum', 'double up down sum', { doubleResult ->
             doubleResult.observe(345.678, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.doubleUpDownSumObserver('yet-another-double-up-down-sum')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleUpDownSumObserver('yet-another-double-up-down-sum', { doubleResult ->
             doubleResult.observe(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -342,54 +324,50 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'double-up-down-sum'
         assert first.description == 'a double up down sum'
         assert first.unit == 'ms'
-        assert first.type == NON_MONOTONIC_DOUBLE
-        assert first.points.size() == 1
-        assert first.points[0].value == 123.456
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == DOUBLE_SUM
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123.456
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-double-up-down-sum'
         assert second.description == 'another double up down sum'
         assert second.unit == 'µs'
-        assert second.type == NON_MONOTONIC_DOUBLE
-        assert second.points.size() == 1
-        assert second.points[0].value == 234.567
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == DOUBLE_SUM
+        assert second.data.points.size() == 1
+        assert second.data.points[0].value == 234.567
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-double-up-down-sum'
         assert third.description == 'double up down sum'
         assert third.unit == '1'
-        assert third.type == NON_MONOTONIC_DOUBLE
-        assert third.points.size() == 1
-        assert third.points[0].value == 345.678
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == DOUBLE_SUM
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345.678
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-double-up-down-sum'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == NON_MONOTONIC_DOUBLE
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456.789
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == DOUBLE_SUM
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456.789
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "double up down sum observer memoization"() {
         when:
-        def dcOne = otel.doubleUpDownSumObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcOne = otel.doubleUpDownSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(10.1, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.doubleUpDownSumObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcTwo = otel.doubleUpDownSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(20.2, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.doubleUpDownSumObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcThree = otel.doubleUpDownSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(30.3, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.doubleUpDownSumObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcFour = otel.doubleUpDownSumObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(40.4, Labels.of('key4', 'value4'))
         })
         def secondMetrics = exportMetrics()
@@ -406,44 +384,38 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'double'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == NON_MONOTONIC_DOUBLE
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20.2
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == DOUBLE_SUM
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20.2
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'double'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == NON_MONOTONIC_DOUBLE
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 20.2
-        assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
-        assert secondMetric.points[1].value == 40.4
-        assert secondMetric.points[1].labels == Labels.of('key4', 'value4')
+        assert secondMetric.type == DOUBLE_SUM
+        assert secondMetric.data.points.size() == 1
+        assert secondMetric.data.points[0].value == 40.4
+        assert secondMetric.data.points[0].labels == Labels.of('key4', 'value4')
     }
 
     def "long up down sum observer"() {
         when:
         def dso = otel.longUpDownSumObserver(
                 'long-up-down-sum', 'a long up down sum',
-                'ms')
-        dso.setCallback({longResult ->
-            longResult.observe(123, Labels.of('key', 'value'))
-        })
+                'ms', {longResult ->
+                    longResult.observe(123, Labels.of('key', 'value'))
+                })
 
-        dso = otel.longUpDownSumObserver('my-long-up-down-sum', 'another long up down sum', 'µs')
-        dso.setCallback({ longResult ->
+        dso = otel.longUpDownSumObserver('my-long-up-down-sum', 'another long up down sum', 'µs', { longResult ->
             longResult.observe(234, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.longUpDownSumObserver('another-long-up-down-sum', 'long up down sum')
-        dso.setCallback({ longResult ->
+        dso = otel.longUpDownSumObserver('another-long-up-down-sum', 'long up down sum', { longResult ->
             longResult.observe(345, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.longUpDownSumObserver('yet-another-long-up-down-sum')
-        dso.setCallback({ longResult ->
+        dso = otel.longUpDownSumObserver('yet-another-long-up-down-sum', { longResult ->
             longResult.observe(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -459,54 +431,50 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'long-up-down-sum'
         assert first.description == 'a long up down sum'
         assert first.unit == 'ms'
-        assert first.type == NON_MONOTONIC_LONG
-        assert first.points.size() == 1
-        assert first.points[0].value == 123
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == LONG_SUM
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-long-up-down-sum'
         assert second.description == 'another long up down sum'
         assert second.unit == 'µs'
-        assert second.type == NON_MONOTONIC_LONG
-        assert second.points.size() == 1
-        assert second.points[0].value == 234
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == LONG_SUM
+        assert second.data.points.size() == 1
+        assert second.data.points[0].value == 234
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-long-up-down-sum'
         assert third.description == 'long up down sum'
         assert third.unit == '1'
-        assert third.type == NON_MONOTONIC_LONG
-        assert third.points.size() == 1
-        assert third.points[0].value == 345
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == LONG_SUM
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-long-up-down-sum'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == NON_MONOTONIC_LONG
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == LONG_SUM
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "long up down sum observer memoization"() {
         when:
-        def dcOne = otel.longUpDownSumObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcOne = otel.longUpDownSumObserver('dc', 'long', { longResult ->
             longResult.observe(10, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.longUpDownSumObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcTwo = otel.longUpDownSumObserver('dc', 'long', { longResult ->
             longResult.observe(20, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.longUpDownSumObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcThree = otel.longUpDownSumObserver('dc', 'long', { longResult ->
             longResult.observe(30, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.longUpDownSumObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcFour = otel.longUpDownSumObserver('dc', 'long', { longResult ->
             longResult.observe(40, Labels.of('key4', 'value4'))
         })
         def secondMetrics = exportMetrics()
@@ -523,44 +491,38 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'long'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == NON_MONOTONIC_LONG
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == LONG_SUM
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'long'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == NON_MONOTONIC_LONG
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 20
-        assert secondMetric.points[0].labels == Labels.of('key2', 'value2')
-        assert secondMetric.points[1].value == 40
-        assert secondMetric.points[1].labels == Labels.of('key4', 'value4')
+        assert secondMetric.type == LONG_SUM
+        assert secondMetric.data.points.size() == 1
+        assert secondMetric.data.points[0].value == 40
+        assert secondMetric.data.points[0].labels == Labels.of('key4', 'value4')
     }
 
     def "double value observer"() {
         when:
         def dso = otel.doubleValueObserver(
                 'double-value', 'a double value',
-                'ms')
-        dso.setCallback({doubleResult ->
-            doubleResult.observe(123.456, Labels.of('key', 'value'))
-        })
+                'ms', {doubleResult ->
+                    doubleResult.observe(123.456, Labels.of('key', 'value'))
+                })
 
-        dso = otel.doubleValueObserver('my-double-value', 'another double value', 'µs')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleValueObserver('my-double-value', 'another double value', 'µs', { doubleResult ->
             doubleResult.observe(234.567, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.doubleValueObserver('another-double-value', 'double value')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleValueObserver('another-double-value', 'double value', { doubleResult ->
             doubleResult.observe(345.678, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.doubleValueObserver('yet-another-double-value')
-        dso.setCallback({ doubleResult ->
+        dso = otel.doubleValueObserver('yet-another-double-value', { doubleResult ->
             doubleResult.observe(456.789, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -576,53 +538,49 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'double-value'
         assert first.description == 'a double value'
         assert first.unit == 'ms'
-        assert first.type == GAUGE_DOUBLE
-        assert first.points.size() == 1
-        assert first.points[0].value == 123.456
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == DOUBLE_GAUGE
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123.456
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-double-value'
         assert second.description == 'another double value'
         assert second.unit == 'µs'
-        assert second.type == GAUGE_DOUBLE
-        assert second.points[0].value == 234.567
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == DOUBLE_GAUGE
+        assert second.data.points[0].value == 234.567
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-double-value'
         assert third.description == 'double value'
         assert third.unit == '1'
-        assert third.type == GAUGE_DOUBLE
-        assert third.points.size() == 1
-        assert third.points[0].value == 345.678
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == DOUBLE_GAUGE
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345.678
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-double-value'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == GAUGE_DOUBLE
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456.789
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == DOUBLE_GAUGE
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456.789
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "double value observer memoization"() {
         when:
-        def dcOne = otel.doubleValueObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcOne = otel.doubleValueObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(10.1, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.doubleValueObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcTwo = otel.doubleValueObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(20.2, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.doubleValueObserver('dc', 'double')
-        dcOne.setCallback({ doubleResult ->
+        def dcThree = otel.doubleValueObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(30.3, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.doubleValueObserver('dc', 'double')
-        dcTwo.setCallback({ doubleResult ->
+        def dcFour = otel.doubleValueObserver('dc', 'double', { doubleResult ->
             doubleResult.observe(40.4, Labels.of('key4', 'value4'))
             doubleResult.observe(50.5, Labels.of('key2', 'value2'))
         })
@@ -640,44 +598,40 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'double'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == GAUGE_DOUBLE
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20.2
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == DOUBLE_GAUGE
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20.2
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'double'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == GAUGE_DOUBLE
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 40.4
-        assert secondMetric.points[0].labels == Labels.of('key4', 'value4')
-        assert secondMetric.points[1].value == 50.5
-        assert secondMetric.points[1].labels == Labels.of('key2', 'value2')
+        assert secondMetric.type == DOUBLE_GAUGE
+        assert secondMetric.data.points.size() == 2
+        assert secondMetric.data.points[1].value == 40.4
+        assert secondMetric.data.points[1].labels == Labels.of('key4', 'value4')
+        assert secondMetric.data.points[0].value == 50.5
+        assert secondMetric.data.points[0].labels == Labels.of('key2', 'value2')
     }
 
     def "long value observer"() {
         when:
         def dso = otel.longValueObserver(
                 'long-value', 'a long value',
-                'ms')
-        dso.setCallback({longResult ->
-            longResult.observe(123, Labels.of('key', 'value'))
-        })
+                'ms', {longResult ->
+                    longResult.observe(123, Labels.of('key', 'value'))
+                })
 
-        dso = otel.longValueObserver('my-long-value', 'another long value', 'µs')
-        dso.setCallback({ longResult ->
+        dso = otel.longValueObserver('my-long-value', 'another long value', 'µs', { longResult ->
             longResult.observe(234, Labels.of('myKey', 'myValue'))
         } )
 
-        dso = otel.longValueObserver('another-long-value', 'long value')
-        dso.setCallback({ longResult ->
+        dso = otel.longValueObserver('another-long-value', 'long value', { longResult ->
             longResult.observe(345, Labels.of('anotherKey', 'anotherValue'))
         })
 
-        dso = otel.longValueObserver('yet-another-long-value')
-        dso.setCallback({ longResult ->
+        dso = otel.longValueObserver('yet-another-long-value', { longResult ->
             longResult.observe(456, Labels.of('yetAnotherKey', 'yetAnotherValue'))
         })
 
@@ -693,54 +647,50 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert first.name == 'long-value'
         assert first.description == 'a long value'
         assert first.unit == 'ms'
-        assert first.type == GAUGE_LONG
-        assert first.points.size() == 1
-        assert first.points[0].value == 123
-        assert first.points[0].labels == Labels.of('key', 'value')
+        assert first.type == LONG_GAUGE
+        assert first.data.points.size() == 1
+        assert first.data.points[0].value == 123
+        assert first.data.points[0].labels == Labels.of('key', 'value')
 
         assert second.name == 'my-long-value'
         assert second.description == 'another long value'
         assert second.unit == 'µs'
-        assert second.type == GAUGE_LONG
-        assert second.points.size() == 1
-        assert second.points[0].value == 234
-        assert second.points[0].labels == Labels.of('myKey', 'myValue')
+        assert second.type == LONG_GAUGE
+        assert second.data.points.size() == 1
+        assert second.data.points[0].value == 234
+        assert second.data.points[0].labels == Labels.of('myKey', 'myValue')
 
         assert third.name == 'another-long-value'
         assert third.description == 'long value'
         assert third.unit == '1'
-        assert third.type == GAUGE_LONG
-        assert third.points.size() == 1
-        assert third.points[0].value == 345
-        assert third.points[0].labels == Labels.of('anotherKey', 'anotherValue')
+        assert third.type == LONG_GAUGE
+        assert third.data.points.size() == 1
+        assert third.data.points[0].value == 345
+        assert third.data.points[0].labels == Labels.of('anotherKey', 'anotherValue')
 
         assert fourth.name == 'yet-another-long-value'
         assert fourth.description == ''
         assert fourth.unit == '1'
-        assert fourth.type == GAUGE_LONG
-        assert fourth.points.size() == 1
-        assert fourth.points[0].value == 456
-        assert fourth.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
+        assert fourth.type == LONG_GAUGE
+        assert fourth.data.points.size() == 1
+        assert fourth.data.points[0].value == 456
+        assert fourth.data.points[0].labels == Labels.of('yetAnotherKey', 'yetAnotherValue')
     }
 
     def "long value observer memoization"() {
         when:
-        def dcOne = otel.longValueObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcOne = otel.longValueObserver('dc', 'long', { longResult ->
             longResult.observe(10, Labels.of('key1', 'value1'))
         })
-        def dcTwo = otel.longValueObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcTwo = otel.longValueObserver('dc', 'long', { longResult ->
             longResult.observe(20, Labels.of('key2', 'value2'))
         })
         def firstMetrics = exportMetrics()
 
-        def dcThree = otel.longValueObserver('dc', 'long')
-        dcOne.setCallback({ longResult ->
+        def dcThree = otel.longValueObserver('dc', 'long', { longResult ->
             longResult.observe(30, Labels.of('key3', 'value3'))
         })
-        def dcFour = otel.longValueObserver('dc', 'long')
-        dcTwo.setCallback({ longResult ->
+        def dcFour = otel.longValueObserver('dc', 'long', { longResult ->
             longResult.observe(40, Labels.of('key4', 'value4'))
             longResult.observe(50, Labels.of('key2', 'value2'))
         })
@@ -758,20 +708,20 @@ class OtelHelperAsynchronousMetricTest extends Specification{
         assert firstMetric.name == 'dc'
         assert firstMetric.description == 'long'
         assert firstMetric.unit == '1'
-        assert firstMetric.type == GAUGE_LONG
-        assert firstMetric.points.size() == 1
-        assert firstMetric.points[0].value == 20
-        assert firstMetric.points[0].labels == Labels.of('key2', 'value2')
+        assert firstMetric.type == LONG_GAUGE
+        assert firstMetric.data.points.size() == 1
+        assert firstMetric.data.points[0].value == 20
+        assert firstMetric.data.points[0].labels == Labels.of('key2', 'value2')
 
         def secondMetric = secondMetrics[0]
         assert secondMetric.name == 'dc'
         assert secondMetric.description == 'long'
         assert secondMetric.unit == '1'
-        assert secondMetric.type == GAUGE_LONG
-        assert secondMetric.points.size() == 2
-        assert secondMetric.points[0].value == 40
-        assert secondMetric.points[0].labels == Labels.of('key4', 'value4')
-        assert secondMetric.points[1].value == 50
-        assert secondMetric.points[1].labels == Labels.of('key2', 'value2')
+        assert secondMetric.type == LONG_GAUGE
+        assert secondMetric.data.points.size() == 2
+        assert secondMetric.data.points[0].value == 40
+        assert secondMetric.data.points[0].labels == Labels.of('key4', 'value4')
+        assert secondMetric.data.points[1].value == 50
+        assert secondMetric.data.points[1].labels == Labels.of('key2', 'value2')
     }
 }

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -61,7 +61,7 @@ class OtlpIntegrationTests extends OtlpIntegrationTest {
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
         il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '0.0.1'
+        il.version == '1.0.0-alpha'
 
         when: 'we examine the instrumentation library metric metrics list'
         List<Metric> metrics = ilMetric.metricsList

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/UnitTest.groovy
@@ -28,7 +28,7 @@ class UnitTest extends Specification {
             JmxConfig.GROOVY_SCRIPT,
             JmxConfig.TARGET_SYSTEM,
             JmxConfig.INTERVAL_MILLISECONDS,
-            JmxConfig.EXPORTER_TYPE,
+            JmxConfig.METRICS_EXPORTER_TYPE,
             JmxConfig.OTLP_ENDPOINT,
             JmxConfig.PROMETHEUS_HOST,
             JmxConfig.PROMETHEUS_PORT,

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
@@ -61,7 +61,7 @@ class CassandraIntegrationTests extends OtlpIntegrationTest  {
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
         il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '0.0.1'
+        il.version == '1.0.0-alpha'
 
         when: 'we examine the instrumentation library metric metrics list'
         ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -60,7 +60,7 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
         il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '0.0.1'
+        il.version == '1.0.0-alpha'
 
         when: 'we examine the instrumentation library metric metrics list'
         ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList

--- a/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
+++ b/contrib/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
@@ -60,7 +60,7 @@ class MultipleTargetSystemsIntegrationTests extends OtlpIntegrationTest {
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
         il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '0.0.1'
+        il.version == '1.0.0-alpha'
 
         when: 'we examine the instrumentation library metric metrics list'
         ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList

--- a/contrib/jmx-metrics/src/test/resources/otlp_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/otlp_config.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
 otel.jmx.groovy.script = /app/script.groovy
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.exporter.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
+++ b/contrib/jmx-metrics/src/test/resources/prometheus_config.properties
@@ -1,5 +1,5 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = prometheus
+otel.metrics.exporter = prometheus
 otel.exporter.prometheus.host = 0.0.0.0
 otel.exporter.prometheus.port = 9123
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi

--- a/contrib/jmx-metrics/src/test/resources/script.groovy
+++ b/contrib/jmx-metrics/src/test/resources/script.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import io.opentelemetry.api.common.Labels
+import io.opentelemetry.api.metrics.common.Labels
 
 def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
 def load = loadMatches.first()

--- a/contrib/jmx-metrics/src/test/resources/target-systems/cassandra.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/cassandra.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
 otel.jmx.target.system = cassandra
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.exporter.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/target-systems/jvm-and-kafka.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/jvm-and-kafka.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka:7199/jmxrmi
 otel.jmx.target.system = jvm,kafka
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/target-systems/jvm.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/jvm.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://cassandra:7199/jmxrmi
 otel.jmx.target.system = jvm
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.exporter.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka-consumer.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka-consumer.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka-consumer:7199/jmxrmi
 otel.jmx.target.system = kafka-consumer
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka-producer.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka-producer:7199/jmxrmi
 otel.jmx.target.system = kafka-producer
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/contrib/jmx-metrics/src/test/resources/target-systems/kafka.properties
+++ b/contrib/jmx-metrics/src/test/resources/target-systems/kafka.properties
@@ -1,9 +1,9 @@
 otel.jmx.interval.milliseconds = 3000
-otel.exporter = otlp
+otel.metrics.exporter = otlp
 otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://kafka:7199/jmxrmi
 otel.jmx.target.system = kafka
 
 # these will be overridden by cmd line
 otel.jmx.username = wrong_username
 otel.jmx.password = wrong_password
-otel.otlp.endpoint = host.testcontainers.internal:80
+otel.exporter.otlp.endpoint = http://host.testcontainers.internal

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,19 +1,23 @@
 ext {
     versions = [
-        otelStable : '0.10.0'
+        otelStable : '1.0.0',
+        otelAlpha : '1.0.0-alpha'
     ]
 
     libraries = [
         // otel
         otelApi            : "io.opentelemetry:opentelemetry-api:${versions.otelStable}",
+        otelApiMetrics            : "io.opentelemetry:opentelemetry-api-metrics:${versions.otelAlpha}",
         otelSdk            : "io.opentelemetry:opentelemetry-sdk:${versions.otelStable}",
+        otelSdkMetrics            : "io.opentelemetry:opentelemetry-sdk-metrics:${versions.otelAlpha}",
+        otelAutoconfig     : "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${versions.otelAlpha}",
         otelSdkTesting       : "io.opentelemetry:opentelemetry-sdk-testing:${versions.otelStable}",
         otelExporterJaeger         : "io.opentelemetry:opentelemetry-exporter-jaeger:${versions.otelStable}",
         otelExporterLogging        : "io.opentelemetry:opentelemetry-exporter-logging:${versions.otelStable}",
-        otelExporterOtlp           : "io.opentelemetry:opentelemetry-exporter-otlp:${versions.otelStable}",
-        otelExporterPrometheus     : "io.opentelemetry:opentelemetry-exporter-prometheus:${versions.otelStable}",
+        otelExporterOtlp           : "io.opentelemetry:opentelemetry-exporter-otlp-metrics:${versions.otelAlpha}",
+        otelExporterPrometheus     : "io.opentelemetry:opentelemetry-exporter-prometheus:${versions.otelAlpha}",
         otelExporterZipkin         : "io.opentelemetry:opentelemetry-exporter-zipkin:${versions.otelStable}",
-        otelProto          : "io.opentelemetry:opentelemetry-proto:${versions.otelStable}",
+        otelProto          : "io.opentelemetry:opentelemetry-proto:${versions.otelAlpha}",
 
         // testing
         spock : dependencies.create('org.spockframework:spock-core:1.3-groovy-2.5', {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
-distributionSha256Sum=e6f83508f0970452f56197f610d13c5f593baaf43c0e3c6a571e5967be754025
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionSha256Sum=7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Description:**
These change update the project and JMX Metric Gatherer OTel dependencies to use 1.0.0(-alpha).  They are largely transparent signature change adoptions, and reliance on the Autoconfigure sdk extension, but also include readme improvements for the utility.  The largest changes are in the observer instrument helpers to account for only being able to specify the updater on the instrument builder in the api.

**Testing:**

All existing tests have been updated with some basic expansion for coverage.

**Documentation:**

Metric gatherer docs have been updated to account for signature changes, with additional readability/accuracy improvements.

**Outstanding items:**

Updating the release tasks to use Sonatype and upgrading to 1.1.0(-alpha).