### PR TITLE
Move from Bintray/Artifactory to OSSRH

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 # Releasing OpenTelemetry Java Contrib Artifacts
 
-This project currently has two gradle tasks capable of preparing and releasing artifacts: `mavenPublish`
-and `ossSnapshot`.  In order for you to register your contributed project to be published by these commands,
-you must apply the provided publish script plugin in your subproject's gradle file:
+This project currently has three gradle tasks capable of preparing and releasing artifacts: `mavenPublish`,
+`ossSnapshot`, and `otelRelease`.  In order for you to register your contributed project to be published by
+these commands, you must apply the provided publish script plugin in your subproject's gradle file:
 
 ```groovy
 apply from: project.publish
@@ -33,18 +33,20 @@ your machine. The ability to publish to a stable remote repository like Maven Ce
 
 ## `./gradlew ossSnapshot`
 
-This task will invoke the [Artifactory Plugin](https://www.jfrog.com/confluence/display/JFROG/Gradle+Artifactory+Plugin)
-and publish all applicable snapshot artifacts to https://oss.jfrog.org/artifactory/oss-snapshot-local.  It's important
+This task will invoke the [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin)
+and publish all applicable snapshot artifacts to https://oss.sonatype.org/content/repositories/snapshots.  It's important
 to note that these snapshot releases are often from unstable development states and should generally not be used in
 production environments.
 
-This task requires an account and API key for the OpenTelemetry Bintray organization.  If you have been provided access
-and configured your key, please set the required environment variables detailed in the publish script plugin.
+This task requires an account and password for Sonatype's OSSRH with `io.opentelemetry` group permissions.  If you have been
+provided access please set the required gradle properties detailed in the publish script plugin.
 
 ## `./gradlew otelRelease`
 
-This task will invoke the [Bintray Plugin](https://github.com/bintray/gradle-bintray-plugin)
-and publish all applicable snapshot artifacts to https://dl.bintray.com/open-telemetry/maven/io/opentelemetry/contrib/,
-assuming the current version is not a snapshot.  Syncing with Maven Central is not performed at this time.
+This task will also invoke the [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin)
+and publish all applicable artifacts to a new staging repository at https://oss.sonatype.org/#stagingRepositories before
+closing it for manual release through the Nexus UI.  Releasing the repository will initiate automatic syncing with
+Maven Central.
 
-Like `ossSnapshot`, this task requires an account and API key for the OpenTelemetry Bintray organization.
+Like `ossSnapshot`, this task requires an account and permissions for Sonatype OSSRH, in addition to a PGP key registered
+with a public keyserver.

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 plugins {
     id 'com.diffplug.spotless' version '5.1.1'
     id "com.github.johnrengelman.shadow" version "6.0.0" apply false
-    id "com.jfrog.artifactory" version "4.17.2" apply false
-    id 'com.jfrog.bintray' version '1.8.5' apply false
+    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 description = 'OpenTelemetry Contrib libraries and utilities for the JVM'
@@ -37,3 +36,11 @@ task integrationTest {
     }
 }
 integrationTest.finalizedBy allprojects.test
+
+// At this time authentication relies on sonatypeUsername and sonatypePassword project properties or
+// ORG_GRADLE_PROJECT_sonatypeUsername and ORG_GRADLE_PROJECT_sonatypePassword environment variables.
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.artifactory'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'signing'
 
 publishing {
     repositories {
@@ -36,8 +35,8 @@ publishing {
                 developers {
                     developer {
                         id = 'opentelemetry'
-                        name = 'OpenTelemetry Gitter'
-                        url = 'https://gitter.im/open-telemetry/community'
+                        name = 'OpenTelemetry'
+                        url = "https://github.com/open-telemetry/opentelemetry-java-contrib/issues"
                     }
                 }
 
@@ -78,52 +77,29 @@ task mavenPublish {
     }
 }
 
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = System.getenv('BINTRAY_USER')
-            password = System.getenv('BINTRAY_API_KEY')
-        }
-    }
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
-    publications = ['maven']
-    publish = true
-
-    pkg {
-        repo = 'maven'
-        name = 'opentelemetry-java-contrib'
-        userOrg = 'open-telemetry'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/open-telemetry/opentelemetry-java-contrib.git'
-
-        githubRepo = 'open-telemetry/opentelemetry-java-contrib'
-
-        version {
-            name = project.version
-            gpg {
-                sign = true
-            }
-        }
-    }
-}
-
 task ossSnapshot {
-    artifactoryPublish {
-        enabled = version.toString().contains('SNAPSHOT')
-        publications('maven')
+    if (version.toString().endsWith("-SNAPSHOT")) {
+        it.finalizedBy tasks.publishToSonatype
+    } else {
+        it.doFirst {
+            println "ossSnapshot: ${version} isn't a snapshot.  Not releasing."
+        }
     }
-    finalizedBy artifactoryPublish
 }
 
 task otelRelease {
-    bintrayUpload {
-        enabled = !version.toString().contains('SNAPSHOT')
+    if (!version.toString().endsWith("-SNAPSHOT")) {
+        // closeSonatypeStagingRepository is a dynamically registered task and cannot be referenced directly
+        it.finalizedBy "publishToSonatype", rootProject.tasks.named("closeSonatypeStagingRepository")
+    } else {
+        it.doFirst {
+            println "otelRelease: ${version} is a snapshot.  Not releasing."
+        }
     }
-    finalizedBy bintrayUpload
+}
+
+// At this time signing depends on properly configured gradle properties for registered public key:
+// https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials.
+signing {
+    sign publishing.publications.maven
 }


### PR DESCRIPTION
**Description:**
These changes move the publishing tasks from BintrayArtifactory to Sonatype in line with the other OTel java projects.

**Testing:**

Tested by publishing snapshots and going through the release process before dropping staging repository in Nexus.

**Documentation:**

Release readme has been updated.