### PR TITLE
Initial 1.0.0-alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+## 1.0.0-alpha
+
+* Adopt OpenTelemetry 1.0.0(-alpha) dependencies (#32)
+  * Update JMX Metric Gatherer to use 1.0.0(-alpha) proto, API, SDK, and exporters.
+  * Update JMX Metric Gatherer to use Autoconfigure SDK extension properties*
+* JMX Metric Gatherer - Handle missing MBean attributes without failing (#39)
+  * Thanks to @dehaansa.

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ description = 'OpenTelemetry Contrib libraries and utilities for the JVM'
 
 allprojects {
     group = 'io.opentelemetry.contrib'
-    version = '1.0.0-alpha-SNAPSHOT'
+    version = '1.0.0-alpha'
 
     apply from: "$rootDir/gradle/spotless.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"


### PR DESCRIPTION
**Description:**

EDIT: After [feedback from @anuraaga](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/36#issuecomment-846338604) I've decided to not implement the versioning scheme proposed below to avoid any [potential fallout](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/36#pullrequestreview-665878215) from using the build number in an unanticipated fashion.  This project will maintain the opentelemetry-java major and minor release versions but use the patch release as an incremental signifier of its own instead of the initially proposed build number.

~These changes propose an initial release version of `1.0.0-alpha-0` to track with the minimum OpenTelemetry Java API/SDK dependency version and use a build number for project-specific releases*.  This system will allow us to clearly document which version of the OTel libraries we are using and allow additional maintenance releases to be pushed out to a build number:~

~`1.0.0-alpha-0` -> `1.0.0-alpha-1-SNAPSHOT` -> `1.1.0-alpha-0-SNAPSHOT` -> `1.1.0-alpha-0` -> `1.2.0-alpha-0-SNAPSHOT` -> `1.2.0-alpha-0` -> `1.2.0-alpha-1-SNAPSHOT` etc.~

~This way as new features and bug fixes are added to our projects we aren't forced to move to a version that obscures our OTel dependencies.  As alpha specifiers are removed when metrics are stable they will be removed from these versions as well.~

**Existing Issue(s):**

Resolves https://github.com/open-telemetry/opentelemetry-java-contrib/issues/8

**Testing:**

~Tested using maven-artifact's `ComparableVersion`, which I believe is the basis for version comparisons.  A relevant article is a bit vague to me (https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855) but I believe the proposed system is acceptable and doesn't fall into the string comparison trap of nonstandard versions.~

```groovy
   def 'proposed versions are ordered as expected'() {
        when: 'versions use build numbers'
        def numMajor = 10
        def numMinor = 10
        def numMaintenance = 10
        def numBuild = 10
        def versions = []
        (0..numMajor).each{ major ->
            (0..numMinor).each{ minor ->
                (0..numMaintenance).each { maintenance ->
                    (0..numBuild).each { build ->
                        versions.add(new ComparableVersion("${major}.${minor}.${maintenance}-alpha-${build}-SNAPSHOT"))
                        versions.add(new ComparableVersion("${major}.${minor}.${maintenance}-alpha-${build}"))
                    }
                    (0..numBuild).each { build ->
                        versions.add(new ComparableVersion("${major}.${minor}.${maintenance}-${build}-SNAPSHOT"))
                        versions.add(new ComparableVersion("${major}.${minor}.${maintenance}-${build}"))
                    }
                }
            }
        }

        def cloned = versions.clone()
        Collections.sort(cloned)

        then:
        versions == cloned
    }
```

**Documentation:**

Added initial change log since this will be first version tagged and published to Maven Central.
