### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/contrib/jmx-metrics/README.md
+++ b/contrib/jmx-metrics/README.md
@@ -24,7 +24,7 @@ otel.jmx.username = my-username
 otel.jmx.password = my-password
 
 otel.metrics.exporter = otlp
-otel.exporter.otlp.endpoint = http://my-opentelemetry-collector:55680
+otel.exporter.otlp.endpoint = http://my-opentelemetry-collector:4317
 ```
 
 As configured in this example, the metric gatherer will establish an MBean server connection using the


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565