### PR TITLE
Handle missing attributes without failing

### DIFF
--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -106,7 +106,7 @@ class InstrumentHelper {
                     }
                     tupleToUpdates[tuple].add(prepareUpdateClosure(instrument, val, labels))
                 }
-            } else {
+            } else if (value != null) {
                 def labels = getLabels(mbean, labelFuncs)
                 def tuple = new Tuple(instrument, instrumentName, description, unit)
                 logger.fine("Recording ${instrumentName} - ${instrument.method} w/ ${value} - ${labels}")

--- a/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
+++ b/contrib/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
@@ -19,6 +19,7 @@ package io.opentelemetry.contrib.jmxmetrics
 import groovy.transform.PackageScope
 import javax.management.MBeanServerConnection
 import javax.management.ObjectName
+import javax.management.AttributeNotFoundException
 import java.util.logging.Logger
 
 /**
@@ -87,7 +88,12 @@ class MBeanHelper {
 
         def ofInterest = isSingle ? [mbeans[0]]: mbeans
         return ofInterest.collect {
-            it.getProperty(attribute)
+            try {
+                it.getProperty(attribute)
+            } catch (AttributeNotFoundException e) {
+                logger.warning("Expected attribute ${attribute} not found in mbean ${it.name()}")
+                null
+            }
         }
     }
 }


### PR DESCRIPTION
**Description:** Enhance InstrumentHelper & MBeanHelper to handle AttributeNotFoundException cleanly. Prior to this PR, if a groovy script included an instrument where the MBean existed but the Attribute was missing, it would fail and the remainder of the metrics listed afterwards in the groovy script would not be collected. This PR makes the AttributeNotFoundException cause that metric to be missing, but the remainder of the script's requested metrics are still collected.

**Existing Issue(s):** #38 

**Testing:** Enhanced groovy tests to capture this.