### PR TITLE
Await expected metrics count for all integration tests.

### DIFF
--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -4,6 +4,8 @@
  */
 package io.opentelemetry.contrib.jmxmetrics
 
+import static org.awaitility.Awaitility.await
+
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary
 import io.opentelemetry.proto.common.v1.KeyValue
 import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
@@ -11,6 +13,7 @@ import io.opentelemetry.proto.metrics.v1.IntGauge
 import io.opentelemetry.proto.metrics.v1.IntSum
 import io.opentelemetry.proto.metrics.v1.Metric
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import java.util.concurrent.TimeUnit
 import org.testcontainers.Testcontainers
 import spock.lang.Requires
 import spock.lang.Timeout
@@ -27,31 +30,26 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/jvm.properties',  otlpPort, 0, false)
 
-        expect:
-        when: 'we receive metrics from the JMX metrics gatherer'
-        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
-        then: 'they are of the expected size'
-        receivedMetrics.size() == 1
+        ArrayList<Metric> metrics
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted {
+            List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+            assert receivedMetrics.size() == 1
 
-        when: "we examine the received metric's instrumentation library metrics lists"
-        ResourceMetrics receivedMetric = receivedMetrics.get(0)
-        List<InstrumentationLibraryMetrics> ilMetrics =
-                receivedMetric.instrumentationLibraryMetricsList
-        then: 'they of the expected size'
-        ilMetrics.size() == 1
+            ResourceMetrics receivedMetric = receivedMetrics.get(0)
+            List<InstrumentationLibraryMetrics> ilMetrics =
+                    receivedMetric.instrumentationLibraryMetricsList
+            assert ilMetrics.size() == 1
 
-        when: 'we examine the instrumentation library'
-        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
-        InstrumentationLibrary il = ilMetric.instrumentationLibrary
-        then: 'it is of the expected content'
-        il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '1.0.0-alpha'
+            InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+            InstrumentationLibrary il = ilMetric.instrumentationLibrary
+            assert il.name  == 'io.opentelemetry.contrib.jmxmetrics'
+            assert il.version == '1.0.0-alpha'
 
-        when: 'we examine the instrumentation library metric metrics list'
-        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
-        metrics.sort{ a, b -> a.name <=> b.name}
-        then: 'they are of the expected size and content'
-        metrics.size() == 16
+            when: 'we examine the instrumentation library metric metrics list'
+            metrics = ilMetric.metricsList as ArrayList
+            metrics.sort{ a, b -> a.name <=> b.name}
+            assert metrics.size() == 16
+        }
 
         def expectedMetrics = [
             [

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaConsumerTargetSystemIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaConsumerTargetSystemIntegrationTests.groovy
@@ -4,10 +4,13 @@
  */
 package io.opentelemetry.contrib.jmxmetrics
 
+import static org.awaitility.Awaitility.await
+
 import io.opentelemetry.proto.common.v1.KeyValue
 import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
 import io.opentelemetry.proto.metrics.v1.Metric
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics
+import java.util.concurrent.TimeUnit
 import org.testcontainers.Testcontainers
 import spock.lang.Requires
 import spock.lang.Timeout
@@ -24,25 +27,21 @@ class KafkaConsumerTargetSystemIntegrationTests extends OtlpIntegrationTest {
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/kafka-consumer.properties',  otlpPort, 0, false)
 
-        expect:
-        when: 'we receive metrics from the JMX metric gatherer'
-        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
-        then: 'they are of the expected size'
-        receivedMetrics.size() == 1
+        ArrayList<Metric> metrics
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted {
+            List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+            assert receivedMetrics.size() == 1
 
-        when: "we examine the received metric's instrumentation library metrics lists"
-        ResourceMetrics receivedMetric = receivedMetrics.get(0)
-        List<InstrumentationLibraryMetrics> ilMetrics =
-                receivedMetric.instrumentationLibraryMetricsList
-        then: 'they of the expected size'
-        ilMetrics.size() == 1
+            ResourceMetrics receivedMetric = receivedMetrics.get(0)
+            List<InstrumentationLibraryMetrics> ilMetrics =
+                    receivedMetric.instrumentationLibraryMetricsList
+            assert ilMetrics.size() == 1
 
-        when: 'we examine the instrumentation library metric metrics list'
-        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
-        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
-        metrics.sort{ a, b -> a.name <=> b.name}
-        then: 'they are of the expected size and content'
-        metrics.size() == 8
+            InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+            metrics = ilMetric.metricsList as ArrayList
+            metrics.sort{ a, b -> a.name <=> b.name}
+            assert metrics.size() == 8
+        }
 
         def expectedTopics = [
             'test-topic-1',

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
@@ -4,12 +4,15 @@
  */
 package io.opentelemetry.contrib.jmxmetrics
 
+import static org.awaitility.Awaitility.await
+
 import io.opentelemetry.proto.common.v1.KeyValue
 import io.opentelemetry.proto.metrics.v1.Gauge
 import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics
 import io.opentelemetry.proto.metrics.v1.Metric
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics
 import io.opentelemetry.proto.metrics.v1.Sum
+import java.util.concurrent.TimeUnit
 import org.testcontainers.Testcontainers
 import spock.lang.Requires
 import spock.lang.Timeout
@@ -26,25 +29,20 @@ class KafkaTargetSystemIntegrationTests extends OtlpIntegrationTest {
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/kafka.properties',  otlpPort, 0, false)
 
-        expect:
-        when: 'we receive metrics from the JMX metric gatherer'
-        List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
-        then: 'they are of the expected size'
-        receivedMetrics.size() == 1
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted {
+            List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
+            assert receivedMetrics.size() == 1
 
-        when: "we examine the received metric's instrumentation library metrics lists"
-        ResourceMetrics receivedMetric = receivedMetrics.get(0)
-        List<InstrumentationLibraryMetrics> ilMetrics =
-                receivedMetric.instrumentationLibraryMetricsList
-        then: 'they of the expected size'
-        ilMetrics.size() == 1
+            ResourceMetrics receivedMetric = receivedMetrics.get(0)
+            List<InstrumentationLibraryMetrics> ilMetrics =
+                    receivedMetric.instrumentationLibraryMetricsList
+            assert ilMetrics.size() == 1
 
-        when: 'we examine the instrumentation library metric metrics list'
-        InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
-        ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
-        metrics.sort{ a, b -> a.name <=> b.name}
-        then: 'they are of the expected size and content'
-        metrics.size() == 21
+            InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
+            ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+            metrics.sort{ a, b -> a.name <=> b.name}
+            assert metrics.size() == 21
+        }
 
         def expectedMetrics = [
             [

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/KafkaTargetSystemIntegrationTests.groovy
@@ -29,6 +29,7 @@ class KafkaTargetSystemIntegrationTests extends OtlpIntegrationTest {
         Testcontainers.exposeHostPorts(otlpPort)
         configureContainers('target-systems/kafka.properties',  otlpPort, 0, false)
 
+        ArrayList<Metric> metrics
         await().atMost(30, TimeUnit.SECONDS).untilAsserted {
             List<ResourceMetrics> receivedMetrics = collector.receivedMetrics
             assert receivedMetrics.size() == 1
@@ -39,7 +40,7 @@ class KafkaTargetSystemIntegrationTests extends OtlpIntegrationTest {
             assert ilMetrics.size() == 1
 
             InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
-            ArrayList<Metric> metrics = ilMetric.metricsList as ArrayList
+            metrics = ilMetric.metricsList as ArrayList
             metrics.sort{ a, b -> a.name <=> b.name}
             assert metrics.size() == 21
         }


### PR DESCRIPTION
Found a test flake on the main branch build, as I sort of expected anyways. Went ahead and added same wait pattern to all the tests.