### PR TITLE
Fix order of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,15 +5,14 @@
 #####################################################
 #
 # Learn about membership in OpenTelemetry community:
-#  https://github.com/open-telemetry/community/blob/master/community-membership.md
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
 # 
 #
 # Learn about CODEOWNERS file format: 
 #  https://help.github.com/en/articles/about-code-owners
 #
-#
-
-aws-xray/ @open-telemetry/opentelemetry-java-contrib-approvers @willarmiros
 
 # Global Owners
 * @open-telemetry/opentelemetry-java-contrib-approvers
+
+aws-xray/ @open-telemetry/opentelemetry-java-contrib-approvers @willarmiros


### PR DESCRIPTION
From https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners

> Order is important; the last matching pattern takes the most precedence