### PR TITLE
Don't use static client ID to allow multiple xray samplers in same pr…

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -40,14 +40,13 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
   private static final Random RANDOM = new Random();
   private static final Logger logger = Logger.getLogger(AwsXrayRemoteSampler.class.getName());
 
-  // Unique per-process client ID, generated as a random string.
-  private static final String CLIENT_ID = generateClientId();
-
   private final Resource resource;
   private final Clock clock;
   private final Sampler initialSampler;
   private final XraySamplerClient client;
   private final ScheduledExecutorService executor;
+  // Unique per-sampler client ID, generated as a random string.
+  private final String clientId;
   private final long pollingIntervalNanos;
   private final int jitterNanos;
 
@@ -89,6 +88,8 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
               return t;
             });
 
+    clientId = generateClientId();
+
     sampler = initialSampler;
 
     this.pollingIntervalNanos = pollingIntervalNanos;
@@ -123,7 +124,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
       if (!response.equals(previousRulesResponse)) {
         sampler =
             new XrayRulesSampler(
-                CLIENT_ID,
+                clientId,
                 resource,
                 clock,
                 initialSampler,

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/GetSamplingTargetsRequest.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/GetSamplingTargetsRequest.java
@@ -4,7 +4,6 @@
  */
 package io.opentelemetry.contrib.awsxray;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.value.AutoValue;
@@ -47,10 +46,6 @@ abstract class GetSamplingTargetsRequest {
     abstract long getSampledCount();
 
     @JsonProperty("Timestamp")
-    @JsonFormat(
-        shape = JsonFormat.Shape.STRING,
-        pattern = "yyyy-MM-dd'T'HH:mm:ss",
-        timezone = "UTC")
     abstract Date getTimestamp();
 
     @AutoValue.Builder

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/JdkHttpClient.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/JdkHttpClient.java
@@ -84,7 +84,7 @@ final class JdkHttpClient {
       if (responseCode != 200) {
         logger.log(
             Level.FINE,
-            "Error reponse from "
+            "Error response from "
                 + urlStr
                 + " code ("
                 + responseCode

--- a/aws-xray/src/test/resources/get-sampling-targets-request.json
+++ b/aws-xray/src/test/resources/get-sampling-targets-request.json
@@ -3,7 +3,7 @@
     {
       "RuleName":"Test",
       "ClientID":"ABCDEF1234567890ABCDEF10",
-      "Timestamp":"2021-06-21T06:46:07",
+      "Timestamp":1624257967000,
       "RequestCount":110,
       "SampledCount":30,
       "BorrowCount":20
@@ -11,7 +11,7 @@
     {
       "RuleName":"polling-scorekeep",
       "ClientID":"ABCDEF1234567890ABCDEF11",
-      "Timestamp":"2018-07-07T00:20:06",
+      "Timestamp":1530922806000,
       "RequestCount":10500,
       "SampledCount":31,
       "BorrowCount":0


### PR DESCRIPTION
In practice, there is only one initialized SDK in an app with a sampler. But there could be use cases for having multiple client IDs in the same process (like the integration test we have) and it doesn't really make sense to forbid this by using a static.

Also fix serialization of Timestamp - I thought it is String based on the AWS CLI output in the [doc](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sampling.html) but the CLI just formats that for humans but must be sending milliseconds in the actual API call. The Jackson default is milliseconds so no need for anything special.

Was able to confirm targets acting something like targets - with 2 r/s centralized reservoir, it often allocated 1/s for each sampler, but sometimes ended up with 2/s for one or both, with a period of 0/s presumably as it compensated for the oversampling, and back to 1/s, etc. Seems like what one might expect.