### PR TITLE
Allow configuring endpoint with environment variable.

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProvider.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProvider.java
@@ -9,13 +9,24 @@ import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.Map;
 
 @AutoService(ConfigurableSamplerProvider.class)
 public class AwsXrayRemoteSamplerProvider implements ConfigurableSamplerProvider {
 
   @Override
   public Sampler createSampler(ConfigProperties config) {
-    return AwsXrayRemoteSampler.newBuilder(OpenTelemetrySdkAutoConfiguration.getResource()).build();
+    AwsXrayRemoteSamplerBuilder builder =
+        AwsXrayRemoteSampler.newBuilder(OpenTelemetrySdkAutoConfiguration.getResource());
+
+    Map<String, String> params = config.getCommaSeparatedMap("otel.traces.sampler.arg");
+
+    String endpoint = params.get("endpoint");
+    if (endpoint != null) {
+      builder.setEndpoint(endpoint);
+    }
+
+    return builder.build();
   }
 
   @Override

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
@@ -6,12 +6,21 @@ package io.opentelemetry.contrib.awsxray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.mockito.Mockito.when;
 
+import io.opentelemetry.sdk.autoconfigure.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurableSamplerProvider;
+import java.util.Collections;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class AwsXrayRemoteSamplerProviderTest {
+
+  @Mock private ConfigProperties config;
 
   @Test
   void serviceProvider() {
@@ -19,6 +28,37 @@ class AwsXrayRemoteSamplerProviderTest {
         ServiceLoader.load(ConfigurableSamplerProvider.class);
     assertThat(samplerProviders)
         .singleElement(type(AwsXrayRemoteSamplerProvider.class))
-        .satisfies(provider -> assertThat(provider.getName()).isEqualTo("xray"));
+        .satisfies(
+            provider -> {
+              assertThat(provider.getName()).isEqualTo("xray");
+            });
+  }
+
+  @Test
+  void emptyConfig() {
+    try (AwsXrayRemoteSampler sampler =
+        (AwsXrayRemoteSampler) new AwsXrayRemoteSamplerProvider().createSampler(config)) {
+      // Inspect implementation details for simplicity, otherwise we'd probably need to make a
+      // test HTTP server that records requests.
+      assertThat(sampler)
+          .extracting("client")
+          .extracting("getSamplingRulesEndpoint", type(String.class))
+          .isEqualTo("http://localhost:2000/GetSamplingRules");
+    }
+  }
+
+  @Test
+  void setEndpoint() {
+    when(config.getCommaSeparatedMap("otel.traces.sampler.arg"))
+        .thenReturn(Collections.singletonMap("endpoint", "http://localhost:3000"));
+    try (AwsXrayRemoteSampler sampler =
+        (AwsXrayRemoteSampler) new AwsXrayRemoteSamplerProvider().createSampler(config)) {
+      // Inspect implementation details for simplicity, otherwise we'd probably need to make a
+      // test HTTP server that records requests.
+      assertThat(sampler)
+          .extracting("client")
+          .extracting("getSamplingRulesEndpoint", type(String.class))
+          .isEqualTo("http://localhost:3000/GetSamplingRules");
+    }
   }
 }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     testImplementation("org.awaitility:awaitility")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("org.mockito:mockito-junit-jupiter")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -39,6 +39,11 @@ val DEPENDENCY_SETS = listOf(
         listOf("simpleclient", "simpleclient_common", "simpleclient_httpserver")
     ),
     DependencySet(
+        "org.mockito",
+        "3.10.0",
+        listOf("mockito-core", "mockito-junit-jupiter")
+    ),
+    DependencySet(
         "org.slf4j",
         "1.7.30",
         listOf("slf4j-api", "slf4j-simple", "log4j-over-slf4j", "jcl-over-slf4j", "jul-to-slf4j")


### PR DESCRIPTION
While I didn't want to introduce too much environment variable configuration initially, especially when even the sampler name is stuck in spec review, I realized it's too important to be able to change endpoint for docker use.