### PR TITLE
First try rate limited sampler for initialSampler of XRay remote samp…

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/OrElseSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/OrElseSampler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.opentelemetry.contrib.awsxray;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.List;
+
+class OrElseSampler implements Sampler {
+
+  private final Sampler first;
+  private final Sampler second;
+
+  OrElseSampler(Sampler first, Sampler second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  @Override
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      SpanKind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
+    SamplingResult result =
+        first.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+    if (result.getDecision() != SamplingDecision.DROP) {
+      return result;
+    }
+    return second.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+  }
+
+  @Override
+  public String getDescription() {
+    return "OrElse{"
+        + "first:"
+        + first.getDescription()
+        + ", second:"
+        + second.getDescription()
+        + "}";
+  }
+}

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
@@ -236,7 +236,12 @@ class AwsXrayRemoteSamplerTest {
 
   @Test
   void defaultInitialSampler() {
-    assertThat(AwsXrayRemoteSampler.newBuilder(Resource.empty()).build().getDescription())
-        .startsWith("AwsXrayRemoteSampler{ParentBased{root:TraceIdRatioBased{0.050000}");
+    try (AwsXrayRemoteSampler sampler = AwsXrayRemoteSampler.newBuilder(Resource.empty()).build()) {
+      assertThat(sampler.getDescription())
+          .startsWith(
+              "AwsXrayRemoteSampler{"
+                  + "ParentBased{root:OrElse{"
+                  + "first:RateLimitingSampler{1}, second:TraceIdRatioBased{0.050000}");
+    }
   }
 }

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/OrElseSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/OrElseSamplerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.opentelemetry.contrib.awsxray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceId;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrElseSamplerTest {
+
+  @Test
+  void firstWins() {
+    Sampler sampler = new OrElseSampler(Sampler.alwaysOn(), Sampler.alwaysOff());
+    assertThat(doSample(sampler).getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
+  }
+
+  @Test
+  void fallsBackToSecond() {
+    Sampler sampler = new OrElseSampler(Sampler.alwaysOff(), Sampler.alwaysOn());
+    assertThat(doSample(sampler).getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
+    sampler = new OrElseSampler(Sampler.alwaysOff(), Sampler.alwaysOff());
+    assertThat(doSample(sampler).getDecision()).isEqualTo(SamplingDecision.DROP);
+  }
+
+  private SamplingResult doSample(Sampler sampler) {
+    return sampler.shouldSample(
+        Context.current(),
+        TraceId.fromLongs(1, 2),
+        "span",
+        SpanKind.CLIENT,
+        Attributes.empty(),
+        Collections.emptyList());
+  }
+}


### PR DESCRIPTION
…ler.

To match behavior of X-Ray SDK and because testing apps locally can be harder if the backend is required just to see traces, 1 trace per second ensures that traces are created regardless of backend.