### PR TITLE
Set JMX metric gatherer meter version from manifest

### DIFF
--- a/jmx-metrics/build.gradle.kts
+++ b/jmx-metrics/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
 
 tasks {
     shadowJar {
+        manifest {
+            attributes["Implementation-Version"] = project.version
+        }
         // This should always be standalone, so remove "-all" to prevent unnecessary artifact.
         archiveClassifier.set("")
     }
@@ -66,5 +69,6 @@ tasks {
     withType<Test>().configureEach {
         dependsOn(shadowJar)
         systemProperty("shadow.jar.path", shadowJar.get().archiveFile.get().asFile.absolutePath)
+        systemProperty("gradle.project.version", "${project.version}")
     }
 }

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -95,7 +95,10 @@ public class GroovyMetricEnvironment {
    * @param config - used to establish exporter type (logging by default) and connection info
    */
   public GroovyMetricEnvironment(final JmxConfig config) {
-    this(config, "io.opentelemetry.contrib.jmxmetrics", "1.0.0-alpha");
+    this(
+        config,
+        "io.opentelemetry.contrib.jmxmetrics",
+        GroovyMetricEnvironment.class.getPackage().getImplementationVersion());
   }
 
   /** Will collect all metrics from OpenTelemetrySdk and export via configured exporter. */

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/IntegrationTest.groovy
@@ -246,4 +246,11 @@ class OtlpIntegrationTest extends IntegrationTest  {
             return received
         }
     }
+
+    static final String expectedMeterVersion() {
+        // Automatically set by gradle when running the tests
+        def version = System.getProperty("gradle.project.version")
+        assert version != null && version != ""
+        return version
+    }
 }

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTests.groovy
@@ -48,7 +48,7 @@ class OtlpIntegrationTests extends OtlpIntegrationTest {
         InstrumentationLibrary il = ilMetric.instrumentationLibrary
         then: 'it is of the expected content'
         il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-        il.version == '1.0.0-alpha'
+        il.version == expectedMeterVersion()
 
         when: 'we examine the instrumentation library metric metrics list'
         List<Metric> metrics = ilMetric.metricsList

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/CassandraIntegrationTests.groovy
@@ -43,7 +43,7 @@ class CassandraIntegrationTests extends OtlpIntegrationTest  {
             InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
             InstrumentationLibrary il = ilMetric.instrumentationLibrary
             assert il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-            assert il.version == '1.0.0-alpha'
+            assert il.version == expectedMeterVersion()
 
             metrics = ilMetric.metricsList as ArrayList
             metrics.sort{ a, b -> a.name <=> b.name}

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/JVMTargetSystemIntegrationTests.groovy
@@ -43,7 +43,7 @@ class JVMTargetSystemIntegrationTests extends OtlpIntegrationTest {
             InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
             InstrumentationLibrary il = ilMetric.instrumentationLibrary
             assert il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-            assert il.version == '1.0.0-alpha'
+            assert il.version == expectedMeterVersion()
 
             when: 'we examine the instrumentation library metric metrics list'
             metrics = ilMetric.metricsList as ArrayList

--- a/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
+++ b/jmx-metrics/src/test/groovy/io/opentelemetry/contrib/jmxmetrics/target-systems/MultipleTargetSystemsIntegrationTests.groovy
@@ -43,7 +43,7 @@ class MultipleTargetSystemsIntegrationTests extends OtlpIntegrationTest {
             InstrumentationLibraryMetrics ilMetric = ilMetrics.get(0)
             InstrumentationLibrary il = ilMetric.instrumentationLibrary
             assert il.name  == 'io.opentelemetry.contrib.jmxmetrics'
-            assert il.version == '1.0.0-alpha'
+            assert il.version == expectedMeterVersion()
 
             metrics = ilMetric.metricsList as ArrayList
             metrics.sort{ a, b -> a.name <=> b.name}


### PR DESCRIPTION
**Description:**
Feature addition - These changes ensure that the reported meter version for the JMX metric gatherer doesn't have to be hardcoded and manually updated with each release (which I didn't do before the last one).  It does this by setting the `Implementation-Version` in the gatherer's shadow jar manifest from the reported gradle version, which I think should be compatible with the nexus release plugin.

**Testing:**

Updated integration tests to confirm project version is reported with instruments.

