### PR TITLE
Add CODEOWNERS for maven-extension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,4 @@
 * @open-telemetry/opentelemetry-java-contrib-approvers
 
 aws-xray/ @open-telemetry/opentelemetry-java-contrib-approvers @willarmiros
+maven-extension/ @open-telemetry/opentelemetry-java-contrib-approvers @cyrille-leclerc @kenfinnigan


### PR DESCRIPTION
Add @cyrille-leclerc and @kenfinnigan as CODEOWNERS for [maven-extension](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension)