### PR TITLE
Update Cassandra units for latency counters

### DIFF
--- a/jmx-metrics/docs/target-systems/cassandra.md
+++ b/jmx-metrics/docs/target-systems/cassandra.md
@@ -18,7 +18,7 @@ These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each n
 * Instrument Type: DoubleValueObserver
 
 * Name: `cassandra.client.request.range_slice.latency.count`
-* Description: Total token range read request latency
+* Description: Number of token range read request operations
 * Unit: `1`
 * Instrument Type: LongSumObserver
 
@@ -48,7 +48,7 @@ These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each n
 * Instrument Type: DoubleValueObserver
 
 * Name: `cassandra.client.request.read.latency.count`
-* Description: Total standard read request latency
+* Description: Number of standard read request operations
 * Unit: `1`
 * Instrument Type: LongSumObserver
 
@@ -78,7 +78,7 @@ These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each n
 * Instrument Type: DoubleValueObserver
 
 * Name: `cassandra.client.request.write.latency.count`
-* Description: Total regular write request latency
+* Description: Number of regular write request operations
 * Unit: `1`
 * Instrument Type: LongSumObserver
 

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
@@ -52,7 +52,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
             assertSum(
                 metric,
                 "cassandra.client.request.range_slice.latency.count",
-                "Total token range read request latency",
+                "Number of token range read request operations",
                 "1"),
         metric ->
             assertGauge(
@@ -88,7 +88,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
             assertSum(
                 metric,
                 "cassandra.client.request.read.latency.count",
-                "Total standard read request latency",
+                "Number of standard read request operations",
                 "1"),
         metric ->
             assertGauge(
@@ -124,7 +124,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
             assertSum(
                 metric,
                 "cassandra.client.request.write.latency.count",
-                "Total regular write request latency",
+                "Number of regular write request operations",
                 "1"),
         metric ->
             assertGauge(

--- a/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
@@ -30,7 +30,7 @@ otel.instrument(clientRequestRangeSliceLatency,
 
 otel.instrument(clientRequestRangeSliceLatency,
         "cassandra.client.request.range_slice.latency.count",
-        "Total token range read request latency", "1", "Count",
+        "Number of token range read request operations", "1", "Count",
         otel.&longCounterCallback)
 
 otel.instrument(clientRequestRangeSliceLatency,
@@ -64,7 +64,7 @@ otel.instrument(clientRequestReadLatency,
 
 otel.instrument(clientRequestReadLatency,
         "cassandra.client.request.read.latency.count",
-        "Total standard read request latency", "1", "Count",
+        "Number of standard read request operations", "1", "Count",
         otel.&longCounterCallback)
 
 otel.instrument(clientRequestReadLatency,
@@ -98,7 +98,7 @@ otel.instrument(clientRequestWriteLatency,
 
 otel.instrument(clientRequestWriteLatency,
         "cassandra.client.request.write.latency.count",
-        "Total regular write request latency", "1", "Count",
+        "Number of regular write request operations", "1", "Count",
         otel.&longCounterCallback)
 
 otel.instrument(clientRequestWriteLatency,


### PR DESCRIPTION
**Description:**
Update Cassandra metrics latency counter units to better reflect what is being collected.

**Testing:**
Updated Cassandra Integration Test

**Documentation:**
Updated Cassandra Docs
