### PR TITLE
Update cassandra counters to be non-monotonic where appopriate

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
@@ -147,12 +147,18 @@ public abstract class AbstractIntegrationTest {
   }
 
   protected void assertSum(Metric metric, String name, String description, String unit) {
+    assertSum(metric, name, description, unit, true);
+  }
+
+  protected void assertSum(
+      Metric metric, String name, String description, String unit, boolean isMonotonic) {
     assertThat(metric.getName()).isEqualTo(name);
     assertThat(metric.getDescription()).isEqualTo(description);
     assertThat(metric.getUnit()).isEqualTo(unit);
     assertThat(metric.hasSum()).isTrue();
     assertThat(metric.getSum().getDataPointsList())
         .satisfiesExactly(point -> assertThat(point.getAttributesList()).isEmpty());
+    assertThat(metric.getSum().getIsMonotonic()).isEqualTo(isMonotonic);
   }
 
   protected void assertTypedGauge(

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
@@ -161,7 +161,8 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
                 metric,
                 "cassandra.storage.load.count",
                 "Size of the on disk data size this node manages",
-                "by"),
+                "by",
+                false),
         metric ->
             assertSum(
                 metric,
@@ -173,6 +174,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
                 metric,
                 "cassandra.storage.total_hints.in_progress.count",
                 "Number of hints attempting to be sent currently",
-                "1"));
+                "1",
+                false));
   }
 }

--- a/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
@@ -123,7 +123,7 @@ def storageLoad = otel.mbean("${storage},name=Load")
 otel.instrument(storageLoad,
         "cassandra.storage.load.count",
         "Size of the on disk data size this node manages", "by", "Count",
-        otel.&longCounterCallback)
+        otel.&longUpDownCounterCallback)
 
 def storageTotalHints = otel.mbean("${storage},name=TotalHints")
 otel.instrument(storageTotalHints,
@@ -135,7 +135,7 @@ def storageTotalHintsInProgress = otel.mbean("${storage},name=TotalHintsInProgre
 otel.instrument(storageTotalHintsInProgress,
         "cassandra.storage.total_hints.in_progress.count",
         "Number of hints attempting to be sent currently", "1", "Count",
-        otel.&longCounterCallback)
+        otel.&longUpDownCounterCallback)
 
 def compaction = "${cassandraMetrics}:type=Compaction"
 def compactionPendingTasks = otel.mbean("${compaction},name=PendingTasks")


### PR DESCRIPTION
**Description:** Two cassandra counters are non-monotonic, and should be treated as such. 

Decrement example for load.count: [source](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/io/sstable/IndexSummaryRedistribution.java#L290)
Decrement example for total_hints.in_progress.count: [source](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/service/StorageProxy.java#L2410)