### PR TITLE
Use service.name resource attribute instead of span name for service …

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
@@ -144,7 +144,7 @@ final class SamplingRuleApplier {
     this.nextSnapshotTimeNanos = nextSnapshotTimeNanos;
   }
 
-  boolean matches(String name, Attributes attributes, Resource resource) {
+  boolean matches(Attributes attributes, Resource resource) {
     int matchedAttributes = 0;
     String httpTarget = null;
     String httpMethod = null;
@@ -175,7 +175,7 @@ final class SamplingRuleApplier {
     }
 
     return urlPathMatcher.matches(httpTarget)
-        && serviceNameMatcher.matches(name)
+        && serviceNameMatcher.matches(resource.getAttribute(ResourceAttributes.SERVICE_NAME))
         && httpMethodMatcher.matches(httpMethod)
         && hostMatcher.matches(host)
         && serviceTypeMatcher.matches(getServiceType(resource))

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
@@ -76,7 +76,7 @@ final class XrayRulesSampler implements Sampler {
       Attributes attributes,
       List<LinkData> parentLinks) {
     for (SamplingRuleApplier applier : ruleAppliers) {
-      if (applier.matches(name, attributes, resource)) {
+      if (applier.matches(attributes, resource)) {
         return applier.shouldSample(
             parentContext, traceId, name, spanKind, attributes, parentLinks);
       }

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplierTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplierTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -51,6 +52,7 @@ class SamplingRuleApplierTest {
 
     private final Resource resource =
         Resource.builder()
+            .put(ResourceAttributes.SERVICE_NAME, "test-service-foo-bar")
             .put(ResourceAttributes.CLOUD_PLATFORM, ResourceAttributes.CloudPlatformValues.AWS_EKS)
             .put(
                 ResourceAttributes.AWS_ECS_CONTAINER_ARN,
@@ -101,24 +103,28 @@ class SamplingRuleApplierTest {
 
     @Test
     void matches() {
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
-    void nameNotMatch() {
-      assertThat(applier.matches("test-service-foo-baz", attributes, resource)).isFalse();
+    void serviceNameNotMatch() {
+      assertThat(
+              applier.matches(
+                  attributes,
+                  resource.toBuilder().put(SERVICE_NAME, "test-service-foo-baz").build()))
+          .isFalse();
     }
 
     @Test
-    void nullNotMatch() {
-      assertThat(applier.matches(null, attributes, resource)).isFalse();
+    void serviceNameNullNotMatch() {
+      assertThat(applier.matches(attributes, Resource.empty())).isFalse();
     }
 
     @Test
     void methodNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "POST").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -127,7 +133,7 @@ class SamplingRuleApplierTest {
       // wildcard.
       Attributes attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_HOST, "opentelemetryfio").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -136,20 +142,20 @@ class SamplingRuleApplierTest {
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_TARGET, "/instrument-you")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
     void attributeNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder().put(AttributeKey.stringKey("animal"), "dog").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
     void attributeMissing() {
       Attributes attributes = removeAttribute(this.attributes, AttributeKey.stringKey("animal"));
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -159,11 +165,11 @@ class SamplingRuleApplierTest {
               .put(
                   ResourceAttributes.CLOUD_PLATFORM, ResourceAttributes.CloudPlatformValues.AWS_EC2)
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       resource =
           Resource.create(
               removeAttribute(this.resource.getAttributes(), ResourceAttributes.CLOUD_PLATFORM));
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -174,7 +180,7 @@ class SamplingRuleApplierTest {
                   ResourceAttributes.AWS_ECS_CONTAINER_ARN,
                   "arn:aws:xray:us-east-1:595986152929:my-service2")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
   }
 
@@ -188,6 +194,7 @@ class SamplingRuleApplierTest {
 
     private final Resource resource =
         Resource.builder()
+            .put(ResourceAttributes.SERVICE_NAME, "test-service-foo-bar")
             .put(ResourceAttributes.CLOUD_PLATFORM, ResourceAttributes.CloudPlatformValues.AWS_EKS)
             .put(
                 ResourceAttributes.AWS_ECS_CONTAINER_ARN,
@@ -236,39 +243,57 @@ class SamplingRuleApplierTest {
     }
 
     @Test
-    void nameMatches() {
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
-      assertThat(applier.matches("test-service-foo-baz", attributes, resource)).isTrue();
-      assertThat(applier.matches("test-service-foo-", attributes, resource)).isTrue();
+    void serviceNameMatches() {
+      assertThat(
+              applier.matches(
+                  attributes,
+                  resource.toBuilder().put(SERVICE_NAME, "test-service-foo-bar").build()))
+          .isTrue();
+      assertThat(
+              applier.matches(
+                  attributes,
+                  resource.toBuilder().put(SERVICE_NAME, "test-service-foo-baz").build()))
+          .isTrue();
+      assertThat(
+              applier.matches(
+                  attributes, resource.toBuilder().put(SERVICE_NAME, "test-service-foo-").build()))
+          .isTrue();
     }
 
     @Test
-    void nameNotMatch() {
-      assertThat(applier.matches("test-service-foo", attributes, resource)).isFalse();
-      assertThat(applier.matches("prod-service-foo-bar", attributes, resource)).isFalse();
-      assertThat(applier.matches(null, attributes, resource)).isFalse();
+    void serviceNameNotMatch() {
+      assertThat(
+              applier.matches(
+                  attributes, resource.toBuilder().put(SERVICE_NAME, "test-service-foo").build()))
+          .isFalse();
+      assertThat(
+              applier.matches(
+                  attributes,
+                  resource.toBuilder().put(SERVICE_NAME, "prod-service-foo-bar").build()))
+          .isFalse();
+      assertThat(applier.matches(attributes, Resource.empty())).isFalse();
     }
 
     @Test
     void methodMatches() {
       Attributes attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "BADGETGOOD").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "BADGET").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "GETGET").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
     void methodNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "POST").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_METHOD);
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -277,40 +302,40 @@ class SamplingRuleApplierTest {
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_HOST, "alpha.opentelemetry.io")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_HOST, "opfdnqtelemetry.io")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_HOST, "opentglemetry.io").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_HOST, "opentglemry.io").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_HOST, "opentglemrz.io").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
     void hostNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder().put(SemanticAttributes.HTTP_HOST, "opentelemetryfio").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_HOST, "opentgalemetry.io")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_HOST, "alpha.oentelemetry.io")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_HOST);
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -319,13 +344,13 @@ class SamplingRuleApplierTest {
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_TARGET, "/instrument-me?foo=bar&cat=")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       // Deceptive question mark, it's actually a wildcard :-)
       attributes =
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_TARGET, "/instrument-meafoo=bar&cat=")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
@@ -334,41 +359,41 @@ class SamplingRuleApplierTest {
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_TARGET, "/instrument-mea?foo=bar&cat=")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
               .put(SemanticAttributes.HTTP_TARGET, "foo/instrument-meafoo=bar&cat=")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_TARGET);
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
     void attributeMatches() {
       Attributes attributes =
           this.attributes.toBuilder().put(AttributeKey.stringKey("animal"), "catman").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       attributes = this.attributes.toBuilder().put(AttributeKey.longKey("speed"), 20).build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
     void attributeNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder().put(AttributeKey.stringKey("animal"), "dog").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder().put(AttributeKey.stringKey("animal"), "mancat").build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       attributes = this.attributes.toBuilder().put(AttributeKey.longKey("speed"), 21).build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
     void attributeMissing() {
       Attributes attributes = removeAttribute(this.attributes, AttributeKey.stringKey("animal"));
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
     @Test
@@ -378,12 +403,12 @@ class SamplingRuleApplierTest {
               .put(
                   ResourceAttributes.CLOUD_PLATFORM, ResourceAttributes.CloudPlatformValues.AWS_EC2)
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
       resource =
           Resource.create(
               removeAttribute(this.resource.getAttributes(), ResourceAttributes.CLOUD_PLATFORM));
       // null matches for pattern '*'
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
@@ -394,7 +419,7 @@ class SamplingRuleApplierTest {
                   ResourceAttributes.AWS_ECS_CONTAINER_ARN,
                   "arn:aws:opentelemetry:us-east-3:52929:my-service")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
@@ -405,19 +430,19 @@ class SamplingRuleApplierTest {
                   ResourceAttributes.AWS_ECS_CONTAINER_ARN,
                   "arn:aws:xray:us-east-1:595986152929:my-service2")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       resource =
           this.resource.toBuilder()
               .put(
                   ResourceAttributes.AWS_ECS_CONTAINER_ARN,
                   "frn:aws:xray:us-east-1:595986152929:my-service")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       resource =
           Resource.create(
               removeAttribute(
                   this.resource.getAttributes(), ResourceAttributes.AWS_ECS_CONTAINER_ARN));
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
   }
 
@@ -448,7 +473,7 @@ class SamplingRuleApplierTest {
 
     @Test
     void resourceFaasIdMatches() {
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
@@ -460,7 +485,7 @@ class SamplingRuleApplierTest {
           this.attributes.toBuilder()
               .put(ResourceAttributes.FAAS_ID, "arn:aws:xray:us-east-1:595986152929:my-service")
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isTrue();
+      assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
@@ -471,11 +496,11 @@ class SamplingRuleApplierTest {
                   ResourceAttributes.CLOUD_PLATFORM,
                   ResourceAttributes.CloudPlatformValues.GCP_CLOUD_FUNCTIONS)
               .build();
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
       resource =
           Resource.create(
               removeAttribute(this.resource.getAttributes(), ResourceAttributes.CLOUD_PLATFORM));
-      assertThat(applier.matches("test-service-foo-bar", attributes, resource)).isFalse();
+      assertThat(applier.matches(attributes, resource)).isFalse();
     }
   }
 

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/XrayRulesSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/XrayRulesSamplerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.awsxray;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceId;
@@ -36,7 +37,7 @@ class XrayRulesSamplerTest {
   void updateTargets() {
     SamplingRule rule1 =
         SamplingRule.create(
-            Collections.emptyMap(),
+            Collections.singletonMap("test", "cat-service"),
             1.0,
             "*",
             "*",
@@ -45,13 +46,13 @@ class XrayRulesSamplerTest {
             "*",
             "*",
             "cat-rule",
-            "cat-service",
+            "*",
             "*",
             "*",
             1);
     SamplingRule rule2 =
         SamplingRule.create(
-            Collections.emptyMap(),
+            Collections.singletonMap("test", "dog-service"),
             0.0,
             "*",
             "*",
@@ -60,13 +61,13 @@ class XrayRulesSamplerTest {
             "*",
             "*",
             "dog-rule",
-            "dog-service",
+            "*",
             "*",
             "*",
             1);
     SamplingRule rule3 =
         SamplingRule.create(
-            Collections.emptyMap(),
+            Collections.singletonMap("test", "*-service"),
             1.0,
             "*",
             "*",
@@ -75,7 +76,7 @@ class XrayRulesSamplerTest {
             "*",
             "*",
             "bat-rule",
-            "*-service",
+            "*",
             "*",
             "*",
             1);
@@ -174,7 +175,7 @@ class XrayRulesSamplerTest {
         TraceId.fromLongs(1, 2),
         name,
         SpanKind.CLIENT,
-        Attributes.empty(),
+        Attributes.of(AttributeKey.stringKey("test"), name),
         Collections.emptyList());
   }
 }

--- a/aws-xray/src/test/resources/sampling-rule-awslambda.json
+++ b/aws-xray/src/test/resources/sampling-rule-awslambda.json
@@ -5,7 +5,7 @@
   "Priority": 1,
   "FixedRate": 1.0,
   "ReservoirSize": 1000,
-  "ServiceName": "test-service-foo-bar",
+  "ServiceName": "*",
   "ServiceType": "AWS::Lambda::Function",
   "Host": "opentelemetry.io",
   "HTTPMethod": "GET",

--- a/aws-xray/src/test/resources/test-sampling-rules-response-1.json
+++ b/aws-xray/src/test/resources/test-sampling-rules-response-1.json
@@ -8,13 +8,13 @@
         "Priority": 1,
         "FixedRate": 1.0,
         "ReservoirSize": 1,
-        "ServiceName": "cat-service",
+        "ServiceName": "*",
         "ServiceType": "*",
         "Host": "*",
         "HTTPMethod": "*",
         "URLPath": "*",
         "Version": 1,
-        "Attributes": {}
+        "Attributes": { "test": "cat-service" }
       },
       "CreatedAt": "2021-06-18T17:28:15+09:00",
       "ModifiedAt": "2021-06-18T17:28:15+09:00"

--- a/aws-xray/src/test/resources/test-sampling-rules-response-2.json
+++ b/aws-xray/src/test/resources/test-sampling-rules-response-2.json
@@ -8,13 +8,13 @@
         "Priority": 1,
         "FixedRate": 0.0,
         "ReservoirSize": 1,
-        "ServiceName": "cat-service",
+        "ServiceName": "*",
         "ServiceType": "*",
         "Host": "*",
         "HTTPMethod": "*",
         "URLPath": "*",
         "Version": 1,
-        "Attributes": {}
+        "Attributes": { "test":  "cat-service" }
       },
       "CreatedAt": "2021-06-18T17:28:15+09:00",
       "ModifiedAt": "2021-06-18T17:28:15+09:00"


### PR DESCRIPTION
I had misinterpreted the span name being more appropriate, remembering the transformation we do in the collector's xray exporter, but it should indeed by service name when sampling within OTel.