### PR TITLE
Remove usage of deprecated resource autoconfiguration

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -204,4 +204,14 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
     }
     return new String(clientIdChars);
   }
+
+  // Visible for testing
+  XraySamplerClient getClient() {
+    return client;
+  }
+
+  // Visible for testing
+  Resource getResource() {
+    return resource;
+  }
 }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProvider.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProvider.java
@@ -6,20 +6,26 @@
 package io.opentelemetry.contrib.awsxray;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.sdk.autoconfigure.OpenTelemetryResourceAutoConfiguration;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @AutoService(ConfigurableSamplerProvider.class)
 public class AwsXrayRemoteSamplerProvider implements ConfigurableSamplerProvider {
 
   @Override
   public Sampler createSampler(ConfigProperties config) {
-    AwsXrayRemoteSamplerBuilder builder =
-        AwsXrayRemoteSampler.newBuilder(
-            OpenTelemetryResourceAutoConfiguration.configureResource(config));
+    Resource resource = ResourceHolder.resource;
+    if (resource == null) {
+      // Should never be the case in practice.
+      resource = Resource.getDefault();
+    }
+    AwsXrayRemoteSamplerBuilder builder = AwsXrayRemoteSampler.newBuilder(resource);
 
     Map<String, String> params = config.getMap("otel.traces.sampler.arg");
 
@@ -34,5 +40,23 @@ public class AwsXrayRemoteSamplerProvider implements ConfigurableSamplerProvider
   @Override
   public String getName() {
     return "xray";
+  }
+
+  // Currently the only way to read the Resource from autoconfiguration. Best would be if the SPI
+  // could return a Function<SamplerFactoryArgs, Sampler> where SamplerFactoryArgs has
+  // SDK-constructed components like Resource and Clock.
+  @AutoService(AutoConfigurationCustomizerProvider.class)
+  public static final class ResourceHolder implements AutoConfigurationCustomizerProvider {
+
+    @Nullable static volatile Resource resource;
+
+    @Override
+    public void customize(AutoConfigurationCustomizer autoConfiguration) {
+      autoConfiguration.addResourceCustomizer(
+          (resource, config) -> {
+            ResourceHolder.resource = resource;
+            return resource;
+          });
+    }
   }
 }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XraySamplerClient.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XraySamplerClient.java
@@ -131,6 +131,11 @@ final class XraySamplerClient {
     return "";
   }
 
+  // Visible for testing
+  String getSamplingRulesEndpoint() {
+    return getSamplingRulesEndpoint;
+  }
+
   @SuppressWarnings("JavaUtilDate")
   private static class FloatDateDeserializer extends StdDeserializer<Date> {
 


### PR DESCRIPTION
The current method is deprecated, mostly because it's now possible to fully customize Resource customization out of band from any static context. New approach is hacky but should be fine until SDK provides a better solution. 