### PR TITLE
[Maven Extension] Support Maven Parallel Builds

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/OtelExecutionListener.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OtelExecutionListener.java
@@ -207,7 +207,7 @@ public final class OtelExecutionListener extends AbstractExecutionListener {
                 MavenOtelSemanticAttributes.MAVEN_EXECUTION_LIFECYCLE_PHASE,
                 mojoExecution.getLifecyclePhase())
             .startSpan();
-    spanRegistry.putSpan(span, mojoExecution);
+    spanRegistry.putSpan(span, mojoExecution, executionEvent.getProject());
   }
 
   @Override
@@ -216,8 +216,11 @@ public final class OtelExecutionListener extends AbstractExecutionListener {
       return;
     }
     MojoExecution mojoExecution = executionEvent.getMojoExecution();
-    logger.debug("OpenTelemetry: End succeeded mojo execution span: {}", mojoExecution);
-    Span mojoExecutionSpan = spanRegistry.removeSpan(mojoExecution);
+    logger.debug(
+        "OpenTelemetry: End succeeded mojo execution span: {}, {}",
+        mojoExecution,
+        executionEvent.getProject());
+    Span mojoExecutionSpan = spanRegistry.removeSpan(mojoExecution, executionEvent.getProject());
     mojoExecutionSpan.setStatus(StatusCode.OK);
 
     mojoExecutionSpan.end();
@@ -229,8 +232,11 @@ public final class OtelExecutionListener extends AbstractExecutionListener {
       return;
     }
     MojoExecution mojoExecution = executionEvent.getMojoExecution();
-    logger.debug("OpenTelemetry: End failed mojo execution span: {}", mojoExecution);
-    Span mojoExecutionSpan = spanRegistry.removeSpan(mojoExecution);
+    logger.debug(
+        "OpenTelemetry: End failed mojo execution span: {}, {}",
+        mojoExecution,
+        executionEvent.getProject());
+    Span mojoExecutionSpan = spanRegistry.removeSpan(mojoExecution, executionEvent.getProject());
     mojoExecutionSpan.setStatus(StatusCode.ERROR, "Mojo Failed"); // TODO verify description
     mojoExecutionSpan.end();
   }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
@@ -16,10 +16,14 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Hold the state of the spans in progress */
 @Component(role = SpanRegistry.class)
 public final class SpanRegistry {
+
+  private static final Logger logger = LoggerFactory.getLogger(SpanRegistry.class);
 
   private final Map<MojoExecutionKey, Span> mojoExecutionKeySpanMap = new ConcurrentHashMap<>();
   private final Map<MavenProjectKey, Span> mavenProjectKeySpanMap = new ConcurrentHashMap<>();
@@ -38,6 +42,7 @@ public final class SpanRegistry {
   }
 
   public Span getSpan(MavenProject mavenProject) {
+    logger.debug("OpenTelemetry: getSpan({}, {})", mavenProject, Thread.currentThread());
     final MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     final Span span = this.mavenProjectKeySpanMap.get(key);
     if (span == null) {
@@ -74,6 +79,7 @@ public final class SpanRegistry {
   }
 
   public void putSpan(Span span, MavenProject mavenProject) {
+    logger.debug("OpenTelemetry: putSpan({}, {})", mavenProject, Thread.currentThread());
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span previousSpanForKey = mavenProjectKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
@@ -81,15 +87,19 @@ public final class SpanRegistry {
     }
   }
 
-  public void putSpan(Span span, MojoExecution mojoExecution) {
-    MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution);
+  public void putSpan(Span span, MojoExecution mojoExecution, MavenProject project) {
+    logger.debug(
+        "OpenTelemetry: putSpan({}, {}, {})", mojoExecution, project, Thread.currentThread());
+    MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span previousSpanForKey = mojoExecutionKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
-      throw new IllegalStateException("A span has already been started for " + mojoExecution);
+      throw new IllegalStateException(
+          "A span has already been started for " + mojoExecution + ", " + project);
     }
   }
 
   public Span removeSpan(MavenProject mavenProject) {
+    logger.debug("OpenTelemetry: removeSpan({}, {})", mavenProject, Thread.currentThread());
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span span = mavenProjectKeySpanMap.remove(key);
     if (span == null) {
@@ -99,11 +109,13 @@ public final class SpanRegistry {
   }
 
   @Nonnull
-  public Span removeSpan(MojoExecution mojoExecution) {
-    MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution);
+  public Span removeSpan(MojoExecution mojoExecution, MavenProject project) {
+    logger.debug(
+        "OpenTelemetry: removeSpan({}, {}, {})", mojoExecution, project, Thread.currentThread());
+    MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span span = mojoExecutionKeySpanMap.remove(key);
     if (span == null) {
-      throw new IllegalStateException("No span found for " + mojoExecution);
+      throw new IllegalStateException("No span found for " + mojoExecution + " " + project);
     }
     return span;
   }
@@ -114,9 +126,11 @@ public final class SpanRegistry {
 
     abstract String artifactId();
 
-    public static MavenProjectKey fromMavenProject(@Nonnull MavenProject mavenProject) {
+    abstract String version();
+
+    public static MavenProjectKey fromMavenProject(@Nonnull MavenProject project) {
       return new AutoValue_SpanRegistry_MavenProjectKey(
-          mavenProject.getGroupId(), mavenProject.getArtifactId());
+          project.getGroupId(), project.getArtifactId(), project.getVersion());
     }
   }
 
@@ -134,7 +148,9 @@ public final class SpanRegistry {
 
     abstract String pluginArtifactId();
 
-    static MojoExecutionKey fromMojoExecution(MojoExecution mojoExecution) {
+    abstract MavenProjectKey projectKey();
+
+    static MojoExecutionKey fromMojoExecution(MojoExecution mojoExecution, MavenProject project) {
       if (mojoExecution == null) {
         throw new NullPointerException("Given MojoExecution is null");
       }
@@ -149,7 +165,8 @@ public final class SpanRegistry {
           mojoExecution.getGroupId(),
           mojoExecution.getArtifactId(),
           plugin.getGroupId(),
-          plugin.getArtifactId());
+          plugin.getArtifactId(),
+          MavenProjectKey.fromMavenProject(project));
     }
   }
 }


### PR DESCRIPTION
**Description:**

Support [Maven Parallel Builds](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3).

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/160


**Testing:**

Test the following build with the modified opentelemetry-maven-extension
```
otel-cli server tui
git clone https://github.com/apache/maven
cd maven
mvn dependency:copy -Dartifact=io.opentelemetry.contrib:opentelemetry-maven-extension:1.9.0-alpha
cp target/dependency/opentelemetry-maven-extension-1.9.0-alpha.jar /tmp/
mvn clean -Dotel.traces.exporter=otlp -Dotel.exporter.otlp.endpoint=http://localhost:4317 -Dmaven.ext.class.path=/tmp/opentelemetry-maven-extension-1.9.0-alpha.jar -T3
```

**Documentation:**

No change needed

**Outstanding items:**

None
