### PR TITLE
[Maven Extension] Remove thread name from log messages for performances

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
@@ -79,7 +79,7 @@ public final class SpanRegistry {
   }
 
   public void putSpan(Span span, MavenProject mavenProject) {
-    logger.debug("OpenTelemetry: putSpan({}, {})", mavenProject, Thread.currentThread());
+    logger.debug("OpenTelemetry: putSpan({})", mavenProject);
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span previousSpanForKey = mavenProjectKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
@@ -88,8 +88,7 @@ public final class SpanRegistry {
   }
 
   public void putSpan(Span span, MojoExecution mojoExecution, MavenProject project) {
-    logger.debug(
-        "OpenTelemetry: putSpan({}, {}, {})", mojoExecution, project, Thread.currentThread());
+    logger.debug("OpenTelemetry: putSpan({}, {})", mojoExecution, project);
     MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span previousSpanForKey = mojoExecutionKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
@@ -99,7 +98,7 @@ public final class SpanRegistry {
   }
 
   public Span removeSpan(MavenProject mavenProject) {
-    logger.debug("OpenTelemetry: removeSpan({}, {})", mavenProject, Thread.currentThread());
+    logger.debug("OpenTelemetry: removeSpan({})", mavenProject);
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span span = mavenProjectKeySpanMap.remove(key);
     if (span == null) {
@@ -110,8 +109,7 @@ public final class SpanRegistry {
 
   @Nonnull
   public Span removeSpan(MojoExecution mojoExecution, MavenProject project) {
-    logger.debug(
-        "OpenTelemetry: removeSpan({}, {}, {})", mojoExecution, project, Thread.currentThread());
+    logger.debug("OpenTelemetry: removeSpan({}, {})", mojoExecution, project);
     MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span span = mojoExecutionKeySpanMap.remove(key);
     if (span == null) {


### PR DESCRIPTION
**Description:**

Remove thread name from log messages for performances as recommended by @anuraaga in https://github.com/open-telemetry/opentelemetry-java-contrib/pull/161#discussion_r777770862

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/pull/161#discussion_r777770862
* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/160


**Testing:**

No test added

**Documentation:**

UX didn't change, no docs added.

**Outstanding items:**

None
