### PR TITLE
Upgrade to opentelemetry-java 1.10.0

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -18,8 +18,8 @@ val DEPENDENCY_BOMS = listOf(
     "org.junit:junit-bom:5.8.2",
     "com.linecorp.armeria:armeria-bom:1.9.1",
     "io.grpc:grpc-bom:1.42.1",
-    "io.opentelemetry:opentelemetry-bom:1.9.1",
-    "io.opentelemetry:opentelemetry-bom-alpha:1.9.1-alpha",
+    "io.opentelemetry:opentelemetry-bom:1.10.0",
+    "io.opentelemetry:opentelemetry-bom-alpha:1.10.0-alpha",
     "org.testcontainers:testcontainers-bom:1.16.2"
 )
 

--- a/jfr-streaming/build.gradle.kts
+++ b/jfr-streaming/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation("io.opentelemetry:opentelemetry-api-metrics")
+  implementation("io.opentelemetry:opentelemetry-api")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-metrics-testing")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -22,8 +22,8 @@ public final class Constants {
   public static final String USED = "used";
   public static final String COMMITTED = "committed";
 
-  public static final String NETWORK_BYTES_NAME = "runtime.jvm.network.io";
-  public static final String NETWORK_BYTES_DESCRIPTION = "Network read/write bytes";
+  public static final String METRIC_NAME_NETWORK_BYTES = "runtime.jvm.network.io";
+  public static final String METRIC_DESCRIPTION_NETWORK_BYTES = "Network read/write bytes";
   public static final String NETWORK_DURATION_NAME = "runtime.jvm.network.duration";
   public static final String NETWORK_DURATION_DESCRIPTION = "Network read/write duration";
   public static final String NETWORK_MODE_READ = "read";
@@ -37,4 +37,5 @@ public final class Constants {
   public static final AttributeKey<String> ATTR_MEMORY_USAGE = AttributeKey.stringKey("usage.type");
 
   public static final String METRIC_NAME_MEMORY_ALLOCATION = "runtime.jvm.memory.allocation";
+  public static final String METRIC_DESCRIPTION_MEMORY_ALLOCATION = "Allocation";
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/RecordedEventHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/RecordedEventHandler.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.contrib.jfr.metrics.internal;
 
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.internal.NoopMeter;
+import io.opentelemetry.api.metrics.MeterProvider;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -36,7 +36,7 @@ public interface RecordedEventHandler extends Consumer<RecordedEvent>, Predicate
 
   /**
    * Set the OpenTelemetry {@link Meter} after the SDK has been initialized. Until called,
-   * implementations should use instruments from {@link NoopMeter}.
+   * implementations should use instruments from {@link #defaultMeter()}.
    *
    * @param meter the meter
    */
@@ -60,5 +60,10 @@ public interface RecordedEventHandler extends Consumer<RecordedEvent>, Predicate
    */
   default Optional<Duration> getThreshold() {
     return Optional.empty();
+  }
+
+  /** The default {@link Meter} to use until {@link #initializeMeter(Meter)} is called. */
+  static Meter defaultMeter() {
+    return MeterProvider.noop().get("noop");
   }
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/container/ContainerConfigurationHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/container/ContainerConfigurationHandler.java
@@ -6,31 +6,29 @@
 package io.opentelemetry.contrib.jfr.metrics.internal.container;
 
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ONE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.internal.NoopMeter;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class ContainerConfigurationHandler implements RecordedEventHandler {
   private static final String EVENT_NAME = "jdk.ContainerConfiguration";
-  private static final String METRIC_NAME = "runtime.jvm.cpu.limit";
-
   private static final String EFFECTIVE_CPU_COUNT = "effectiveCpuCount";
 
   private volatile long value = 0L;
 
   public ContainerConfigurationHandler() {
-    initializeMeter(NoopMeter.getInstance());
+    initializeMeter(defaultMeter());
   }
 
   @Override
   public void initializeMeter(Meter meter) {
     meter
-        .upDownCounterBuilder(METRIC_NAME)
+        .upDownCounterBuilder("runtime.jvm.cpu.limit")
         .ofDoubles()
         .setUnit(ONE)
-        .buildWithCallback(codm -> codm.observe(value));
+        .buildWithCallback(codm -> codm.record(value));
   }
 
   @Override

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/container/ContainerConfigurationHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/container/ContainerConfigurationHandler.java
@@ -13,6 +13,7 @@ import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class ContainerConfigurationHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "runtime.jvm.cpu.limit";
   private static final String EVENT_NAME = "jdk.ContainerConfiguration";
   private static final String EFFECTIVE_CPU_COUNT = "effectiveCpuCount";
 
@@ -25,7 +26,7 @@ public final class ContainerConfigurationHandler implements RecordedEventHandler
   @Override
   public void initializeMeter(Meter meter) {
     meter
-        .upDownCounterBuilder("runtime.jvm.cpu.limit")
+        .upDownCounterBuilder(METRIC_NAME)
         .ofDoubles()
         .setUnit(ONE)
         .buildWithCallback(codm -> codm.record(value));

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/ContextSwitchRateHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/ContextSwitchRateHandler.java
@@ -6,9 +6,9 @@
 package io.opentelemetry.contrib.jfr.metrics.internal.cpu;
 
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.HERTZ;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.internal.NoopMeter;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
 import java.util.Optional;
@@ -16,12 +16,11 @@ import jdk.jfr.consumer.RecordedEvent;
 
 public final class ContextSwitchRateHandler implements RecordedEventHandler {
   private static final String EVENT_NAME = "jdk.ThreadContextSwitchRate";
-  private static final String METRIC_NAME = "runtime.jvm.cpu.context_switch";
 
   private volatile double value = 0;
 
   public ContextSwitchRateHandler() {
-    initializeMeter(NoopMeter.getInstance());
+    initializeMeter(defaultMeter());
   }
 
   @Override
@@ -37,10 +36,10 @@ public final class ContextSwitchRateHandler implements RecordedEventHandler {
   @Override
   public void initializeMeter(Meter meter) {
     meter
-        .upDownCounterBuilder(METRIC_NAME)
+        .upDownCounterBuilder("runtime.jvm.cpu.context_switch")
         .ofDoubles()
         .setUnit(HERTZ)
-        .buildWithCallback(codm -> codm.observe(value));
+        .buildWithCallback(codm -> codm.record(value));
   }
 
   @Override

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/ContextSwitchRateHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/ContextSwitchRateHandler.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class ContextSwitchRateHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "runtime.jvm.cpu.context_switch";
   private static final String EVENT_NAME = "jdk.ThreadContextSwitchRate";
 
   private volatile double value = 0;
@@ -36,7 +37,7 @@ public final class ContextSwitchRateHandler implements RecordedEventHandler {
   @Override
   public void initializeMeter(Meter meter) {
     meter
-        .upDownCounterBuilder("runtime.jvm.cpu.context_switch")
+        .upDownCounterBuilder(METRIC_NAME)
         .ofDoubles()
         .setUnit(HERTZ)
         .buildWithCallback(codm -> codm.record(value));

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/LongLockHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/LongLockHandler.java
@@ -20,6 +20,8 @@ import java.util.function.Consumer;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class LongLockHandler extends AbstractThreadDispatchingHandler {
+  private static final String METRIC_NAME = "runtime.jvm.cpu.longlock.time";
+  private static final String METRIC_DESCRIPTION = "Long lock times";
   private static final String EVENT_NAME = "jdk.JavaMonitorWait";
 
   private DoubleHistogram histogram;
@@ -33,8 +35,8 @@ public final class LongLockHandler extends AbstractThreadDispatchingHandler {
   public void initializeMeter(Meter meter) {
     histogram =
         meter
-            .histogramBuilder("runtime.jvm.cpu.longlock.time")
-            .setDescription("Long lock times")
+            .histogramBuilder(METRIC_NAME)
+            .setDescription(METRIC_DESCRIPTION)
             .setUnit(MILLISECONDS)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class OverallCPULoadHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "runtime.jvm.cpu.utilization";
+  private static final String METRIC_DESCRIPTION = "CPU Utilization";
   private static final String EVENT_NAME = "jdk.CPULoad";
   private static final String JVM_USER = "jvmUser";
   private static final String JVM_SYSTEM = "jvmSystem";
@@ -40,8 +42,8 @@ public final class OverallCPULoadHandler implements RecordedEventHandler {
   public void initializeMeter(Meter meter) {
     histogram =
         meter
-            .histogramBuilder("runtime.jvm.cpu.utilization")
-            .setDescription("CPU Utilization")
+            .histogramBuilder(METRIC_NAME)
+            .setDescription(METRIC_DESCRIPTION)
             .setUnit(PERCENTAGE)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1GarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1GarbageCollectionHandler.java
@@ -18,6 +18,8 @@ import jdk.jfr.consumer.RecordedEvent;
 
 /** This class aggregates the duration of G1 Garbage Collection JFR events */
 public final class G1GarbageCollectionHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME = "runtime.jvm.gc.duration";
+  private static final String METRIC_DESCRIPTION = "GC Duration";
   private static final String EVENT_NAME = "jdk.G1GarbageCollection";
   private static final Attributes ATTR_G1 = Attributes.of(ATTR_GC_COLLECTOR, G1);
 
@@ -31,8 +33,8 @@ public final class G1GarbageCollectionHandler implements RecordedEventHandler {
   public void initializeMeter(Meter meter) {
     histogram =
         meter
-            .histogramBuilder("runtime.jvm.gc.duration")
-            .setDescription("GC Duration")
+            .histogramBuilder(METRIC_NAME)
+            .setDescription(METRIC_DESCRIPTION)
             .setUnit(MILLISECONDS)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
@@ -22,6 +22,10 @@ import jdk.jfr.consumer.RecordedObject;
 
 /** This class handles GCHeapSummary JFR events. For GC purposes they come in pairs. */
 public final class GCHeapSummaryHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME_DURATION = "runtime.jvm.gc.duration";
+  private static final String METRIC_DESCRIPTION_DURATION = "GC Duration";
+  private static final String METRIC_NAME_MEMORY = "runtime.jvm.memory.utilization";
+  private static final String METRIC_DESCRIPTION_MEMORY = "Heap utilization";
   private static final String EVENT_NAME = "jdk.GCHeapSummary";
   private static final String BEFORE = "Before GC";
   private static final String AFTER = "After GC";
@@ -47,14 +51,14 @@ public final class GCHeapSummaryHandler implements RecordedEventHandler {
   public void initializeMeter(Meter meter) {
     durationHistogram =
         meter
-            .histogramBuilder("runtime.jvm.gc.duration")
-            .setDescription("GC Duration")
+            .histogramBuilder(METRIC_NAME_DURATION)
+            .setDescription(METRIC_DESCRIPTION_DURATION)
             .setUnit(BYTES)
             .build();
     memoryHistogram =
         meter
-            .histogramBuilder("runtime.jvm.memory.utilization")
-            .setDescription("Heap utilization")
+            .histogramBuilder(METRIC_NAME_MEMORY)
+            .setDescription(METRIC_DESCRIPTION_MEMORY)
             .setUnit(BYTES)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationInNewTLABHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationInNewTLABHandler.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.jfr.metrics.internal.memory;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ARENA_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_THREAD_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY_ALLOCATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_ALLOCATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
@@ -38,7 +39,7 @@ public final class ObjectAllocationInNewTLABHandler extends AbstractThreadDispat
     histogram =
         meter
             .histogramBuilder(METRIC_NAME_MEMORY_ALLOCATION)
-            .setDescription("Allocation")
+            .setDescription(METRIC_DESCRIPTION_MEMORY_ALLOCATION)
             .setUnit(BYTES)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationInNewTLABHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationInNewTLABHandler.java
@@ -9,12 +9,11 @@ import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ARENA
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_THREAD_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_ALLOCATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundDoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.internal.NoopMeter;
 import io.opentelemetry.contrib.jfr.metrics.internal.AbstractThreadDispatchingHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.ThreadGrouper;
 import java.util.function.Consumer;
@@ -26,13 +25,12 @@ import jdk.jfr.consumer.RecordedEvent;
  */
 public final class ObjectAllocationInNewTLABHandler extends AbstractThreadDispatchingHandler {
   private static final String EVENT_NAME = "jdk.ObjectAllocationInNewTLAB";
-  private static final String DESCRIPTION = "Allocation";
 
   private DoubleHistogram histogram;
 
   public ObjectAllocationInNewTLABHandler(ThreadGrouper grouper) {
     super(grouper);
-    initializeMeter(NoopMeter.getInstance());
+    initializeMeter(defaultMeter());
   }
 
   @Override
@@ -40,7 +38,7 @@ public final class ObjectAllocationInNewTLABHandler extends AbstractThreadDispat
     histogram =
         meter
             .histogramBuilder(METRIC_NAME_MEMORY_ALLOCATION)
-            .setDescription(DESCRIPTION)
+            .setDescription("Allocation")
             .setUnit(BYTES)
             .build();
   }
@@ -59,18 +57,18 @@ public final class ObjectAllocationInNewTLABHandler extends AbstractThreadDispat
   private static class PerThreadObjectAllocationInNewTLABHandler
       implements Consumer<RecordedEvent> {
     private static final String TLAB_SIZE = "tlabSize";
-    private static final String TLAB = "TLAB";
 
-    private final BoundDoubleHistogram boundHistogram;
+    private final DoubleHistogram histogram;
+    private final Attributes attributes;
 
     public PerThreadObjectAllocationInNewTLABHandler(DoubleHistogram histogram, String threadName) {
-      boundHistogram =
-          histogram.bind(Attributes.of(ATTR_THREAD_NAME, threadName, ATTR_ARENA_NAME, TLAB));
+      this.histogram = histogram;
+      this.attributes = Attributes.of(ATTR_THREAD_NAME, threadName, ATTR_ARENA_NAME, "TLAB");
     }
 
     @Override
     public void accept(RecordedEvent ev) {
-      boundHistogram.record(ev.getLong(TLAB_SIZE));
+      histogram.record(ev.getLong(TLAB_SIZE), attributes);
       // Probably too high a cardinality
       // ev.getClass("objectClass").getName();
     }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationOutsideTLABHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ObjectAllocationOutsideTLABHandler.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.jfr.metrics.internal.memory;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ARENA_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_THREAD_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY_ALLOCATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_ALLOCATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
@@ -38,7 +39,7 @@ public final class ObjectAllocationOutsideTLABHandler extends AbstractThreadDisp
     histogram =
         meter
             .histogramBuilder(METRIC_NAME_MEMORY_ALLOCATION)
-            .setDescription("Allocation")
+            .setDescription(METRIC_DESCRIPTION_MEMORY_ALLOCATION)
             .setUnit(BYTES)
             .build();
   }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkReadHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkReadHandler.java
@@ -8,9 +8,9 @@ package io.opentelemetry.contrib.jfr.metrics.internal.network;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_NETWORK_MODE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_THREAD_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_NETWORK_BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_NETWORK_BYTES;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_BYTES_DESCRIPTION;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_BYTES_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_DESCRIPTION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_MODE_READ;
@@ -39,8 +39,8 @@ public final class NetworkReadHandler extends AbstractThreadDispatchingHandler {
   public void initializeMeter(Meter meter) {
     bytesHistogram =
         meter
-            .histogramBuilder(NETWORK_BYTES_NAME)
-            .setDescription(NETWORK_BYTES_DESCRIPTION)
+            .histogramBuilder(METRIC_NAME_NETWORK_BYTES)
+            .setDescription(METRIC_DESCRIPTION_NETWORK_BYTES)
             .setUnit(BYTES)
             .build();
     durationHistogram =

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkReadHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkReadHandler.java
@@ -14,12 +14,11 @@ import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_BY
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_DESCRIPTION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_MODE_READ;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.BoundDoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.api.metrics.internal.NoopMeter;
 import io.opentelemetry.contrib.jfr.metrics.internal.AbstractThreadDispatchingHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.ThreadGrouper;
 import java.util.function.Consumer;
@@ -33,7 +32,7 @@ public final class NetworkReadHandler extends AbstractThreadDispatchingHandler {
 
   public NetworkReadHandler(ThreadGrouper nameNormalizer) {
     super(nameNormalizer);
-    initializeMeter(NoopMeter.getInstance());
+    initializeMeter(defaultMeter());
   }
 
   @Override
@@ -65,20 +64,22 @@ public final class NetworkReadHandler extends AbstractThreadDispatchingHandler {
   private static class PerThreadNetworkReadHandler implements Consumer<RecordedEvent> {
     private static final String BYTES_READ = "bytesRead";
 
-    private final BoundDoubleHistogram boundBytesHistogram;
-    private final BoundDoubleHistogram boundDurationHistogram;
+    private final DoubleHistogram bytesHistogram;
+    private final DoubleHistogram durationHistogram;
+    private final Attributes attributes;
 
     public PerThreadNetworkReadHandler(
         DoubleHistogram bytesHistogram, DoubleHistogram durationHistogram, String threadName) {
-      var attr = Attributes.of(ATTR_THREAD_NAME, threadName, ATTR_NETWORK_MODE, NETWORK_MODE_READ);
-      this.boundBytesHistogram = bytesHistogram.bind(attr);
-      this.boundDurationHistogram = durationHistogram.bind(attr);
+      this.bytesHistogram = bytesHistogram;
+      this.durationHistogram = durationHistogram;
+      this.attributes =
+          Attributes.of(ATTR_THREAD_NAME, threadName, ATTR_NETWORK_MODE, NETWORK_MODE_READ);
     }
 
     @Override
     public void accept(RecordedEvent ev) {
-      boundBytesHistogram.record(ev.getLong(BYTES_READ));
-      boundDurationHistogram.record(ev.getDuration().toMillis());
+      bytesHistogram.record(ev.getLong(BYTES_READ), attributes);
+      durationHistogram.record(ev.getDuration().toMillis(), attributes);
     }
   }
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkWriteHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/network/NetworkWriteHandler.java
@@ -8,9 +8,9 @@ package io.opentelemetry.contrib.jfr.metrics.internal.network;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_NETWORK_MODE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_THREAD_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_NETWORK_BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_NETWORK_BYTES;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_BYTES_DESCRIPTION;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_BYTES_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_DESCRIPTION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_DURATION_NAME;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.NETWORK_MODE_WRITE;
@@ -62,8 +62,8 @@ public final class NetworkWriteHandler extends AbstractThreadDispatchingHandler 
   public void initializeMeter(Meter meter) {
     bytesHistogram =
         meter
-            .histogramBuilder(NETWORK_BYTES_NAME)
-            .setDescription(NETWORK_BYTES_DESCRIPTION)
+            .histogramBuilder(METRIC_NAME_NETWORK_BYTES)
+            .setDescription(METRIC_DESCRIPTION_NETWORK_BYTES)
             .setUnit(BYTES)
             .build();
     durationHistogram =

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/AbstractMetricsTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/AbstractMetricsTest.java
@@ -8,11 +8,13 @@ package io.opentelemetry.contrib.jfr.metrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
-import io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions;
-import io.opentelemetry.sdk.testing.assertj.metrics.MetricDataAssert;
+import io.opentelemetry.sdk.testing.assertj.MetricAssertions;
+import io.opentelemetry.sdk.testing.assertj.MetricDataAssert;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,8 +27,8 @@ public class AbstractMetricsTest {
   @BeforeAll
   static void initializeOpenTelemetry() {
     metricReader = InMemoryMetricReader.create();
-    meterProvider =
-        SdkMeterProvider.builder().registerMetricReader(metricReader).buildAndRegisterGlobal();
+    meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
+    GlobalOpenTelemetry.set(OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build());
     JfrMetrics.enable(meterProvider);
   }
 

--- a/jmx-metrics/build.gradle.kts
+++ b/jmx-metrics/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
   implementation("io.prometheus:simpleclient")
   implementation("io.prometheus:simpleclient_httpserver")
   implementation("io.opentelemetry:opentelemetry-api")
-  implementation("io.opentelemetry:opentelemetry-api-metrics")
   implementation("io.opentelemetry:opentelemetry-sdk")
   implementation("io.opentelemetry:opentelemetry-sdk-metrics")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyMetricEnvironment.java
@@ -72,7 +72,12 @@ public class GroovyMetricEnvironment {
                       properties.put("otel.traces.exporter", "none");
                       // expose config.properties to autoconfigure
                       config.properties.forEach(
-                          (k, value) -> properties.put(k.toString(), value.toString()));
+                          (k, value) -> {
+                            String key = k.toString();
+                            if (key.startsWith("otel.") && !key.startsWith("otel.jmx")) {
+                              properties.put(key, value.toString());
+                            }
+                          });
                       return properties;
                     })
                 .build()

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -151,7 +151,7 @@ class InstrumentHelper {
         def labelMap = GroovyMetricEnvironment.mapToAttributes(labels)
         if (instrumentIsObserver(inst)) {
             return { result ->
-                result.observe(value, labelMap)
+                result.record(value, labelMap)
             }
         } else if (instrumentIsCounter(inst)) {
             return { i -> i.add(value, labelMap) }

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.contrib.jmxmetrics;
 
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
-import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 
 import groovy.lang.Closure;
@@ -14,7 +14,7 @@ import groovy.util.Eval;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.DoublePointData;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
-import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.contrib.jmxmetrics;
 
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
-import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,25 +37,24 @@ class OtelHelperAsynchronousMetricTest {
         "double-counter",
         "a double counter",
         "ms",
-        result -> result.observe(123.456, Attributes.builder().put("key", "value").build()));
+        result -> result.record(123.456, Attributes.builder().put("key", "value").build()));
 
     otel.doubleCounterCallback(
         "my-double-counter",
         "another double counter",
         "µs",
-        result -> result.observe(234.567, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(234.567, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.doubleCounterCallback(
         "another-double-counter",
         "double counter",
         result ->
-            result.observe(
-                345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.doubleCounterCallback(
         "yet-another-double-counter",
         result ->
-            result.observe(
+            result.record(
                 456.789, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -119,21 +118,21 @@ class OtelHelperAsynchronousMetricTest {
     otel.doubleCounterCallback(
         "dc",
         "double",
-        result -> result.observe(10.1, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(10.1, Attributes.builder().put("key1", "value1").build()));
     otel.doubleCounterCallback(
         "dc",
         "double",
-        result -> result.observe(20.2, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(20.2, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.doubleCounterCallback(
         "dc",
         "double",
-        result -> result.observe(30.3, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30.3, Attributes.builder().put("key3", "value3").build()));
     otel.doubleCounterCallback(
         "dc",
         "double",
-        result -> result.observe(40.4, Attributes.builder().put("key4", "value4").build()));
+        result -> result.record(40.4, Attributes.builder().put("key4", "value4").build()));
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
     assertThat(firstMetrics)
@@ -175,24 +174,24 @@ class OtelHelperAsynchronousMetricTest {
         "long-counter",
         "a long counter",
         "ms",
-        result -> result.observe(123, Attributes.builder().put("key", "value").build()));
+        result -> result.record(123, Attributes.builder().put("key", "value").build()));
 
     otel.longCounterCallback(
         "my-long-counter",
         "another long counter",
         "µs",
-        result -> result.observe(234, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(234, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.longCounterCallback(
         "another-long-counter",
         "long counter",
         result ->
-            result.observe(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.longCounterCallback(
         "yet-another-long-counter",
         result ->
-            result.observe(
+            result.record(
                 456, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -256,21 +255,21 @@ class OtelHelperAsynchronousMetricTest {
     otel.longCounterCallback(
         "dc",
         "long",
-        result -> result.observe(10, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(10, Attributes.builder().put("key1", "value1").build()));
     otel.longCounterCallback(
         "dc",
         "long",
-        result -> result.observe(20, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(20, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.longCounterCallback(
         "dc",
         "long",
-        result -> result.observe(30, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30, Attributes.builder().put("key3", "value3").build()));
     otel.longCounterCallback(
         "dc",
         "long",
-        result -> result.observe(40, Attributes.builder().put("key4", "value4").build()));
+        result -> result.record(40, Attributes.builder().put("key4", "value4").build()));
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
     assertThat(firstMetrics)
@@ -312,25 +311,24 @@ class OtelHelperAsynchronousMetricTest {
         "double-counter",
         "a double counter",
         "ms",
-        result -> result.observe(-123.456, Attributes.builder().put("key", "value").build()));
+        result -> result.record(-123.456, Attributes.builder().put("key", "value").build()));
 
     otel.doubleUpDownCounterCallback(
         "my-double-counter",
         "another double counter",
         "µs",
-        result -> result.observe(-234.567, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(-234.567, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.doubleUpDownCounterCallback(
         "another-double-counter",
         "double counter",
         result ->
-            result.observe(
-                345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.doubleUpDownCounterCallback(
         "yet-another-double-counter",
         result ->
-            result.observe(
+            result.record(
                 456.789, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -394,21 +392,21 @@ class OtelHelperAsynchronousMetricTest {
     otel.doubleUpDownCounterCallback(
         "dc",
         "double",
-        result -> result.observe(-10.1, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(-10.1, Attributes.builder().put("key1", "value1").build()));
     otel.doubleUpDownCounterCallback(
         "dc",
         "double",
-        result -> result.observe(-20.2, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(-20.2, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.doubleUpDownCounterCallback(
         "dc",
         "double",
-        result -> result.observe(30.3, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30.3, Attributes.builder().put("key3", "value3").build()));
     otel.doubleUpDownCounterCallback(
         "dc",
         "double",
-        result -> result.observe(40.4, Attributes.builder().put("key4", "value4").build()));
+        result -> result.record(40.4, Attributes.builder().put("key4", "value4").build()));
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
     assertThat(firstMetrics)
@@ -450,24 +448,24 @@ class OtelHelperAsynchronousMetricTest {
         "long-counter",
         "a long counter",
         "ms",
-        result -> result.observe(-123, Attributes.builder().put("key", "value").build()));
+        result -> result.record(-123, Attributes.builder().put("key", "value").build()));
 
     otel.longUpDownCounterCallback(
         "my-long-counter",
         "another long counter",
         "µs",
-        result -> result.observe(-234, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(-234, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.longUpDownCounterCallback(
         "another-long-counter",
         "long counter",
         result ->
-            result.observe(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.longUpDownCounterCallback(
         "yet-another-long-counter",
         result ->
-            result.observe(
+            result.record(
                 456, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -531,21 +529,21 @@ class OtelHelperAsynchronousMetricTest {
     otel.longUpDownCounterCallback(
         "dc",
         "long",
-        result -> result.observe(-10, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(-10, Attributes.builder().put("key1", "value1").build()));
     otel.longUpDownCounterCallback(
         "dc",
         "long",
-        result -> result.observe(-20, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(-20, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.longUpDownCounterCallback(
         "dc",
         "long",
-        result -> result.observe(30, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30, Attributes.builder().put("key3", "value3").build()));
     otel.longUpDownCounterCallback(
         "dc",
         "long",
-        result -> result.observe(40, Attributes.builder().put("key4", "value4").build()));
+        result -> result.record(40, Attributes.builder().put("key4", "value4").build()));
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
     assertThat(firstMetrics)
@@ -587,25 +585,24 @@ class OtelHelperAsynchronousMetricTest {
         "double-value",
         "a double value",
         "ms",
-        result -> result.observe(123.456, Attributes.builder().put("key", "value").build()));
+        result -> result.record(123.456, Attributes.builder().put("key", "value").build()));
 
     otel.doubleValueCallback(
         "my-double-value",
         "another double value",
         "µs",
-        result -> result.observe(234.567, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(234.567, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.doubleValueCallback(
         "another-double-value",
         "double value",
         result ->
-            result.observe(
-                345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345.678, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.doubleValueCallback(
         "yet-another-double-value",
         result ->
-            result.observe(
+            result.record(
                 456.789, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -669,23 +666,23 @@ class OtelHelperAsynchronousMetricTest {
     otel.doubleValueCallback(
         "dc",
         "double",
-        result -> result.observe(10.1, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(10.1, Attributes.builder().put("key1", "value1").build()));
     otel.doubleValueCallback(
         "dc",
         "double",
-        result -> result.observe(20.2, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(20.2, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.doubleValueCallback(
         "dc",
         "double",
-        result -> result.observe(30.3, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30.3, Attributes.builder().put("key3", "value3").build()));
     otel.doubleValueCallback(
         "dc",
         "double",
         result -> {
-          result.observe(40.4, Attributes.builder().put("key4", "value4").build());
-          result.observe(50.5, Attributes.builder().put("key2", "value2").build());
+          result.record(40.4, Attributes.builder().put("key4", "value4").build());
+          result.record(50.5, Attributes.builder().put("key2", "value2").build());
         });
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
@@ -733,24 +730,24 @@ class OtelHelperAsynchronousMetricTest {
         "long-value",
         "a long value",
         "ms",
-        result -> result.observe(123, Attributes.builder().put("key", "value").build()));
+        result -> result.record(123, Attributes.builder().put("key", "value").build()));
 
     otel.longValueCallback(
         "my-long-value",
         "another long value",
         "µs",
-        result -> result.observe(234, Attributes.builder().put("myKey", "myValue").build()));
+        result -> result.record(234, Attributes.builder().put("myKey", "myValue").build()));
 
     otel.longValueCallback(
         "another-long-value",
         "long value",
         result ->
-            result.observe(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
+            result.record(345, Attributes.builder().put("anotherKey", "anotherValue").build()));
 
     otel.longValueCallback(
         "yet-another-long-value",
         result ->
-            result.observe(
+            result.record(
                 456, Attributes.builder().put("yetAnotherKey", "yetAnotherValue").build()));
 
     assertThat(metricReader.collectAllMetrics())
@@ -814,21 +811,21 @@ class OtelHelperAsynchronousMetricTest {
     otel.longValueCallback(
         "dc",
         "long",
-        result -> result.observe(10, Attributes.builder().put("key1", "value1").build()));
+        result -> result.record(10, Attributes.builder().put("key1", "value1").build()));
     otel.longValueCallback(
         "dc",
         "long",
-        result -> result.observe(20, Attributes.builder().put("key2", "value2").build()));
+        result -> result.record(20, Attributes.builder().put("key2", "value2").build()));
     Collection<MetricData> firstMetrics = metricReader.collectAllMetrics();
 
     otel.longValueCallback(
         "dc",
         "long",
-        result -> result.observe(30, Attributes.builder().put("key3", "value3").build()));
+        result -> result.record(30, Attributes.builder().put("key3", "value3").build()));
     otel.longValueCallback(
         "dc",
         "long",
-        result -> result.observe(40, Attributes.builder().put("key4", "value4").build()));
+        result -> result.record(40, Attributes.builder().put("key4", "value4").build()));
     Collection<MetricData> secondMetrics = metricReader.collectAllMetrics();
 
     assertThat(firstMetrics)

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.contrib.jmxmetrics;
 
+import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
-import static io.opentelemetry.sdk.testing.assertj.metrics.MetricAssertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
@@ -16,7 +16,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-import io.opentelemetry.sdk.metrics.testing.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -322,10 +322,10 @@ class OtelHelperSynchronousMetricTest {
   @Test
   void doubleHistogram() {
     DoubleHistogram dh = otel.doubleHistogram("double-histogram", "a double histogram", "ms");
-    dh.record(-234.567, Attributes.builder().put("key", "value").build());
+    dh.record(234.567, Attributes.builder().put("key", "value").build());
 
     dh = otel.doubleHistogram("my-double-histogram", "another double histogram", "µs");
-    dh.record(-123.456, Attributes.builder().put("myKey", "myValue").build());
+    dh.record(123.456, Attributes.builder().put("myKey", "myValue").build());
 
     dh = otel.doubleHistogram("another-double-histogram", "double histogram");
     dh.record(345.678, Attributes.builder().put("anotherKey", "anotherValue").build());
@@ -345,7 +345,7 @@ class OtelHelperSynchronousMetricTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasSum(-234.567)
+                                .hasSum(234.567)
                                 .hasCount(1)
                                 .attributes()
                                 .containsOnly(attributeEntry("key", "value"))),
@@ -359,7 +359,7 @@ class OtelHelperSynchronousMetricTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasSum(-123.456)
+                                .hasSum(123.456)
                                 .hasCount(1)
                                 .attributes()
                                 .containsOnly(attributeEntry("myKey", "myValue"))),
@@ -396,10 +396,10 @@ class OtelHelperSynchronousMetricTest {
   @Test
   void longHistogram() {
     LongHistogram lh = otel.longHistogram("long-histogram", "a long histogram", "ms");
-    lh.record(-234, Attributes.builder().put("key", "value").build());
+    lh.record(234, Attributes.builder().put("key", "value").build());
 
     lh = otel.longHistogram("my-long-histogram", "another long histogram", "µs");
-    lh.record(-123, Attributes.builder().put("myKey", "myValue").build());
+    lh.record(123, Attributes.builder().put("myKey", "myValue").build());
 
     lh = otel.longHistogram("another-long-histogram", "long histogram");
     lh.record(345, Attributes.builder().put("anotherKey", "anotherValue").build());
@@ -419,7 +419,7 @@ class OtelHelperSynchronousMetricTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasSum(-234)
+                                .hasSum(234)
                                 .hasCount(1)
                                 .attributes()
                                 .containsOnly(attributeEntry("key", "value"))),
@@ -433,7 +433,7 @@ class OtelHelperSynchronousMetricTest {
                     .satisfiesExactly(
                         point ->
                             assertThat(point)
-                                .hasSum(-123)
+                                .hasSum(123)
                                 .hasCount(1)
                                 .attributes()
                                 .containsOnly(attributeEntry("myKey", "myValue"))),


### PR DESCRIPTION
Had to work around some breaking changes:
- Removal of bind api
- Location change of metrics testing assertj classes
- Location change of InMemoryMetricReader
- Removal of GlobalMeterProvider 
- Async instrument change from `.observe(..)` to `.record(..)`