### PR TITLE
Changed EXPORTER_INTERVAL constant in JMX config to be metric.export.interval

### DIFF
--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -20,7 +20,7 @@ class JmxConfig {
   static final String METRICS_EXPORTER_TYPE = PREFIX + "metrics.exporter";
   static final String EXPORTER = PREFIX + "exporter.";
 
-  static final String EXPORTER_INTERVAL = PREFIX + "imr.export.interval";
+  static final String EXPORTER_INTERVAL = PREFIX + "metric.export.interval";
 
   static final String OTLP_ENDPOINT = EXPORTER + "otlp.endpoint";
 


### PR DESCRIPTION
**Description:**
Bug Fix: Changed deprecated value `otel.imr.export.interval` to new value `otel.metric.export.interval` for `EXPORTER_INTERVAL` in JMX Config.

**Existing Issue(s):**

References #153 

**Testing:**

Tested locally with configuration through collector-contrib.

**Documentation:**
None

**Outstanding items:**

It's not clear that this export interval is being fully respected. During testing if you don't set the input interval, which then sets the export interval in jmx, the default should be 1 minute per [this](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/src/main/java/io/opentelemetry/sdk/autoconfigure/MetricExporterConfiguration.java#L159-L161) . It doesn't seem like that's the case. Looking into what is happening and if it's expected behavior.
