### PR TITLE
Fix default `service.name` + simplify configuration using Otel AutoConfig SDK 1.10 ResourceProvider SPI improvements

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -8,19 +8,14 @@ package io.opentelemetry.maven;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.propagation.ContextPropagators;
-import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import org.apache.maven.rtinfo.RuntimeInformation;
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Disposable;
 import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
 import org.slf4j.Logger;
@@ -32,16 +27,15 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
 
   private static final Logger logger = LoggerFactory.getLogger(OpenTelemetrySdkService.class);
 
-  @SuppressWarnings("NullAway") // Injected automatically to non-null
-  @Requirement
-  private RuntimeInformation runtimeInformation;
-
   private OpenTelemetry openTelemetry = OpenTelemetry.noop();
   @Nullable private OpenTelemetrySdk openTelemetrySdk;
 
   @Nullable private Tracer tracer;
 
   private boolean mojosInstrumentationEnabled;
+
+  /** Visible for testing */
+  @Nullable AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk;
 
   /**
    * Note: the JVM shutdown hook defined by the {@code
@@ -76,42 +70,28 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
     }
     this.openTelemetry = OpenTelemetry.noop();
 
+    this.autoConfiguredOpenTelemetrySdk = null;
     logger.debug("OpenTelemetry: OpenTelemetrySdkService disposed");
   }
 
   @Override
   public void initialize() {
     logger.debug("OpenTelemetry: initialize OpenTelemetrySdkService...");
-    AutoConfiguredOpenTelemetrySdkBuilder autoConfiguredSdkBuilder =
-        AutoConfiguredOpenTelemetrySdk.builder();
 
-    // SDK CONFIGURATION PROPERTIES
-    autoConfiguredSdkBuilder.addPropertiesSupplier(
-        () -> {
-          // Change default of "otel.traces.exporter" from "otlp" to "none"
-          // The impacts are
-          // * If no otel exporter settings are passed, then the Maven extension will not export
-          //   rather than exporting on OTLP GRPC to http://localhost:4317
-          // * If OTEL_EXPORTER_OTLP_ENDPOINT is defined but OTEL_TRACES_EXPORTER is not, then don't
-          //   export
-          return Collections.singletonMap("otel.traces.exporter", "none");
-        });
+    // Change default of "otel.traces.exporter" from "otlp" to "none"
+    // The impacts are
+    // * If no otel exporter settings are passed, then the Maven extension will not export
+    //   rather than exporting on OTLP GRPC to http://localhost:4317
+    // * If OTEL_EXPORTER_OTLP_ENDPOINT is defined but OTEL_TRACES_EXPORTER is not, then don't
+    //   export
+    Map<String, String> properties = Collections.singletonMap("otel.traces.exporter", "none");
 
-    // SDK RESOURCE
-    // Don't use the `io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider` framework because we
-    // need to get the `RuntimeInformation` component injected by Plexus
-    autoConfiguredSdkBuilder.addResourceCustomizer(
-        (resource, configProperties) ->
-            Resource.builder()
-                .put(
-                    ResourceAttributes.SERVICE_NAME, MavenOtelSemanticAttributes.SERVICE_NAME_VALUE)
-                .put(ResourceAttributes.SERVICE_VERSION, runtimeInformation.getMavenVersion())
-                .putAll(resource)
-                .build());
+    this.autoConfiguredOpenTelemetrySdk =
+        AutoConfiguredOpenTelemetrySdk.builder()
+            .setServiceClassLoader(getClass().getClassLoader())
+            .addPropertiesSupplier(() -> properties)
+            .build();
 
-    // BUILD SDK
-    AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk =
-        autoConfiguredSdkBuilder.build();
     if (logger.isDebugEnabled()) {
       logger.debug(
           "OpenTelemetry: OpenTelemetry SDK initialized with  "

--- a/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.maven.resources;
+
+import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.maven.rtinfo.RuntimeInformation;
+import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+
+public class MavenResourceProvider implements ResourceProvider {
+  @Override
+  public Resource createResource(ConfigProperties config) {
+    // TODO verify if there is solution to retrieve the RuntimeInformation instance loaded by the
+    //  Maven Plexus Launcher
+    RuntimeInformation runtimeInformation = new DefaultRuntimeInformation();
+    return Resource.builder()
+        .put(ResourceAttributes.SERVICE_NAME, MavenOtelSemanticAttributes.SERVICE_NAME_VALUE)
+        .put(ResourceAttributes.SERVICE_VERSION, runtimeInformation.getMavenVersion())
+        .build();
+  }
+}

--- a/maven-extension/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
+++ b/maven-extension/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.maven.resources.MavenResourceProvider

--- a/maven-extension/src/test/java/io/opentelemetry/maven/OpenTelemetrySdkServiceTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/OpenTelemetrySdkServiceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.maven;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.junit.jupiter.api.Test;
+
+public class OpenTelemetrySdkServiceTest {
+
+  /** Verify default `service.name` */
+  @Test
+  public void testDefaultConfiguration() {
+    testConfiguration("maven");
+  }
+
+  /** Verify overwritten `service.name` */
+  @Test
+  public void testOverwrittenConfiguration() {
+    System.setProperty("otel.service.name", "my-maven");
+    try {
+      testConfiguration("my-maven");
+    } finally {
+      System.clearProperty("otel.service.name");
+    }
+  }
+
+  void testConfiguration(String expectedServiceName) {
+    OpenTelemetrySdkService openTelemetrySdkService = new OpenTelemetrySdkService();
+    openTelemetrySdkService.initialize();
+    try {
+      Resource resource = openTelemetrySdkService.autoConfiguredOpenTelemetrySdk.getResource();
+      assertThat(resource.getAttribute(ResourceAttributes.SERVICE_NAME))
+          .isEqualTo(expectedServiceName);
+    } finally {
+      openTelemetrySdkService.dispose();
+      GlobalOpenTelemetry.resetForTest();
+    }
+  }
+}


### PR DESCRIPTION
**Description:**

Fix default `service.name` + simplify configuration using Otel AutoConfig SDK 1.10 ResourceProvider SPI improvements (enable specifying the classloader making it compatible with Maven Plexus)

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/183


**Testing:**

Introduced tests with `OpenTelemetrySdkServiceTest`

**Documentation:**

NONE

**Outstanding items:**

NONE
