### PR TITLE
jmx gatherer: Remove manual exporter flush 

### DIFF
--- a/jmx-metrics/README.md
+++ b/jmx-metrics/README.md
@@ -73,6 +73,7 @@ mutually exclusive with `otel.jmx.groovy.script`. The currently supported target
 | [`kafka`](./docs/target-systems/kafka.md) |
 | [`kafka-consumer`](./docs/target-systems/kafka-consumer.md) |
 | [`kafka-producer`](./docs/target-systems/kafka-producer.md) |
+| [`tomcat`](./docs/target-systems/tomcat.md) |
 
 ### JMX Query Helpers
 

--- a/jmx-metrics/README.md
+++ b/jmx-metrics/README.md
@@ -219,7 +219,7 @@ file contents can also be provided via stdin on startup when using `-config -` a
 | `otel.jmx.service.url` | **yes** | The service URL for the JMX RMI/JMXMP endpoint (generally of the form `service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi` or `service:jmx:jmxmp://<host>:<port>`).|
 | `otel.jmx.groovy.script` | if not using `otel.jmx.target.system` | The path for the desired Groovy script. |
 | `otel.jmx.target.system` | if not using `otel.jmx.groovy.script` | A comma-separated list of the supported target applications with built in Groovy scripts. |
-| `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run and its resulting metrics exported. 10000 by default. |
+| `otel.jmx.interval.milliseconds` | no | How often, in milliseconds, the Groovy script should be run. Value will also be used for `otel.metric.export.interval`, if unset, to control asynchronous updates and metric exporting. 10000 by default. |
 | `otel.jmx.username` | no | Username for JMX authentication, if applicable. |
 | `otel.jmx.password` | no | Password for JMX authentication, if applicable. |
 | `otel.jmx.remote.profile` | no | Supported JMX remote profiles are TLS in combination with SASL profiles: SASL/PLAIN, SASL/DIGEST-MD5 and SASL/CRAM-MD5. Thus valid `jmxRemoteProfiles` values are: `SASL/PLAIN`, `SASL/DIGEST-MD5`, `SASL/CRAM-MD5`, `TLS SASL/PLAIN`, `TLS SASL/DIGEST-MD5` and `TLS SASL/CRAM-MD5`. |

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
@@ -104,6 +104,7 @@ public abstract class AbstractIntegrationTest {
   @SuppressWarnings("FutureReturnValueIgnored")
   void afterAll() {
     otlpServer.stop();
+    scraper.stop();
   }
 
   @BeforeEach

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -135,15 +135,6 @@ public class GroovyRunner {
     for (final Script script : scripts) {
       script.run();
     }
-    flush();
-  }
-
-  public void flush() {
-    groovyMetricEnvironment.flush();
-  }
-
-  public void shutdown() {
-    flush();
   }
 
   // Visible for testing

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -20,7 +20,7 @@ class JmxConfig {
   static final String METRICS_EXPORTER_TYPE = PREFIX + "metrics.exporter";
   static final String EXPORTER = PREFIX + "exporter.";
 
-  static final String EXPORTER_INTERVAL = PREFIX + "imr.export.interval";
+  static final String EXPORTER_INTERVAL = PREFIX + "metric.export.interval";
 
   static final String OTLP_ENDPOINT = EXPORTER + "otlp.endpoint";
 

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxMetrics.java
@@ -58,7 +58,6 @@ class JmxMetrics {
   private void shutdown() {
     logger.info("Shutting down JmxMetrics Groovy runner and exporting final metrics.");
     exec.shutdown();
-    runner.shutdown();
   }
 
   private static JmxConfig getConfigFromArgs(final String[] args) {

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/GroovyRunnerTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.management.ObjectName;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
@@ -28,8 +27,6 @@ class GroovyRunnerTest {
 
     assertThatCode(config::validate).doesNotThrowAnyException();
 
-    AtomicBoolean exportCalled = new AtomicBoolean();
-
     JmxClient stub =
         new JmxClient(config) {
           @Override
@@ -38,20 +35,10 @@ class GroovyRunnerTest {
           }
         };
 
-    GroovyRunner runner =
-        new GroovyRunner(
-            config,
-            stub,
-            new GroovyMetricEnvironment(config) {
-              @Override
-              public void flush() {
-                exportCalled.set(true);
-              }
-            });
+    GroovyRunner runner = new GroovyRunner(config, stub, new GroovyMetricEnvironment(config));
 
     assertThat(runner.getScripts()).hasSize(1);
     runner.run();
-    assertThat(exportCalled).isTrue();
   }
 
   @Test

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 class JmxConfigTest {
@@ -20,13 +21,12 @@ class JmxConfigTest {
   }
 
   @Test
+  @ClearSystemProperty(key = "otel.metric.export.interval")
   void defaultValues() {
     JmxConfig config = new JmxConfig();
 
     assertThat(config.serviceUrl).isNull();
-    ;
     assertThat(config.groovyScript).isNull();
-    ;
     assertThat(config.targetSystem).isEmpty();
     assertThat(config.targetSystems).isEmpty();
     assertThat(config.intervalMilliseconds).isEqualTo(10000);
@@ -38,6 +38,7 @@ class JmxConfigTest {
     assertThat(config.password).isNull();
     assertThat(config.remoteProfile).isNull();
     assertThat(config.realm).isNull();
+    assertThat(config.properties.getProperty("otel.metric.export.interval")).isEqualTo("10000");
   }
 
   @Test
@@ -115,5 +116,13 @@ class JmxConfigTest {
         .hasMessage(
             "[jvm, unavailabletargetsystem] must specify targets from "
                 + "[cassandra, jvm, kafka, kafka-consumer, kafka-producer, tomcat]");
+  }
+
+  @Test
+  @SetSystemProperty(key = "otel.metric.export.interval", value = "123")
+  void otelMetricExportIntervalRespected() {
+    JmxConfig config = new JmxConfig();
+    assertThat(config.intervalMilliseconds).isEqualTo(10000);
+    assertThat(config.properties.getProperty("otel.metric.export.interval")).isEqualTo("123");
   }
 }


### PR DESCRIPTION
**Description:**
Bug fix  - More recent changes to the sdk have made manual meter provider collection and exporter functionality management unnecessary by the metric gatherer's groovy script runner. The existing runner functionality also now conflicts with the deprecated `otel.imr.export.interval` property that was being set.

These changes remove manual flushing and update the target property to `otel.metric.export.interval`, but still respect its value if set.

Credit to @cpheps and @sophieyfang for tracking this down.*

**Existing Issue(s):**
https://github.com/open-telemetry/opentelemetry-java-contrib/issues/153 

**Testing:**
Added applicable unit test and made required updates for runner functional change.

**Documentation:**
Documented functionality and `otel.metric.export.interval` property treatment.

Also adding unrelated tomcat target system link that was missing.