### PR TITLE
[Maven Extension] Add Tracer instrumentationVersion (ie `otel.library.version`)

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -49,6 +49,9 @@ configure<PublishingExtension> {
 
 tasks {
   shadowJar {
+    manifest {
+      attributes["Implementation-Version"] = project.version
+    }
     archiveClassifier.set("")
   }
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -7,7 +7,6 @@ package io.opentelemetry.maven;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -25,6 +24,9 @@ import org.slf4j.LoggerFactory;
 /** Service to configure the {@link OpenTelemetry} instance. */
 @Component(role = OpenTelemetrySdkService.class, hint = "opentelemetry-service")
 public final class OpenTelemetrySdkService implements Initializable, Disposable {
+
+  public static final String VERSION =
+      OpenTelemetrySdkService.class.getPackage().getImplementationVersion();
 
   private static final Logger logger = LoggerFactory.getLogger(OpenTelemetrySdkService.class);
 
@@ -77,7 +79,7 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
 
   @Override
   public void initialize() {
-    logger.debug("OpenTelemetry: initialize OpenTelemetrySdkService...");
+    logger.debug("OpenTelemetry: Initialize OpenTelemetrySdkService v{}...", VERSION);
 
     // Change default of "otel.traces.exporter" from "otlp" to "none"
     // The impacts are
@@ -107,12 +109,7 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
             .getBoolean("otel.instrumentation.maven.mojo.enabled");
     this.mojosInstrumentationEnabled = mojoSpansEnabled == null ? true : mojoSpansEnabled;
 
-    TracerBuilder tracerBuilder = openTelemetry.tracerBuilder("io.opentelemetry.contrib.maven");
-    String otelMavenExtensionVersion = this.getClass().getPackage().getImplementationVersion();
-    if (otelMavenExtensionVersion != null) {
-      tracerBuilder.setInstrumentationVersion(otelMavenExtensionVersion);
-    }
-    this.tracer = tracerBuilder.build();
+    this.tracer = openTelemetry.getTracer("io.opentelemetry.contrib.maven", VERSION);
   }
 
   public Tracer getTracer() {

--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -7,6 +7,7 @@ package io.opentelemetry.maven;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
@@ -106,7 +107,12 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
             .getBoolean("otel.instrumentation.maven.mojo.enabled");
     this.mojosInstrumentationEnabled = mojoSpansEnabled == null ? true : mojoSpansEnabled;
 
-    this.tracer = this.openTelemetry.getTracer("io.opentelemetry.contrib.maven");
+    TracerBuilder tracerBuilder = openTelemetry.tracerBuilder("io.opentelemetry.contrib.maven");
+    String otelMavenExtensionVersion = this.getClass().getPackage().getImplementationVersion();
+    if (otelMavenExtensionVersion != null) {
+      tracerBuilder.setInstrumentationVersion(otelMavenExtensionVersion);
+    }
+    this.tracer = tracerBuilder.build();
   }
 
   public Tracer getTracer() {


### PR DESCRIPTION
**Description:**

Add Tracer instrumentationVersion (ie `otel.library.version` attribute).

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/152

**Testing:**

Tested manually.
No unit test because algorithm relies on the jar manifest implementationVersion that is not available during the unit tests.

**Documentation:**

None

**Outstanding items:**

None
