### PR TITLE
Make `OpenTelemetrySdkService.VERSION` not public

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 @Component(role = OpenTelemetrySdkService.class, hint = "opentelemetry-service")
 public final class OpenTelemetrySdkService implements Initializable, Disposable {
 
-  public static final String VERSION =
+  static final String VERSION =
       OpenTelemetrySdkService.class.getPackage().getImplementationVersion();
 
   private static final Logger logger = LoggerFactory.getLogger(OpenTelemetrySdkService.class);


### PR DESCRIPTION
**Description:**

Make `OpenTelemetrySdkService.VERSION` not public as suggested by @anuraaga  in 
* https://github.com/open-telemetry/opentelemetry-java-contrib/pull/191#discussion_r785257216

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/pull/191#discussion_r785257216

**Testing:**

Non additional test needed. Already covered by unit test.

**Documentation:**

No

**Outstanding items:**

None