### PR TITLE
Update release naming

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
-          release_name: Release v${{ github.event.inputs.version }}
+          release_name: Version ${{ github.event.inputs.version }}
           draft: true
           prerelease: false
       - name: Upload jmx-metrics release asset

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.version }}
-          release_name: Release v${{ github.event.inputs.version }}
+          release_name: Version ${{ github.event.inputs.version }}
           draft: true
           prerelease: false
       - name: Upload jmx-metrics release asset


### PR DESCRIPTION
remove redundant "Release" word, and make consistent with core repo (and also similar change just now in instrumentation repo: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5173)