### PR TITLE
jmx metrics: Add test timeouts and mbean server status assertions

### DIFF
--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.jmxmetrics;
 import static io.opentelemetry.sdk.testing.assertj.MetricAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.attributeEntry;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import groovy.lang.Closure;
 import groovy.util.Eval;
@@ -38,10 +39,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@Timeout(value = 10, unit = SECONDS)
 class InstrumenterHelperTest {
 
   private static final MBeanServer mbeanServer = getPlatformMBeanServer();
@@ -76,6 +79,11 @@ class InstrumenterHelperTest {
   @AfterAll
   static void tearDown() throws Exception {
     jmxServer.stop();
+  }
+
+  @BeforeEach
+  void confirmServerIsActive() {
+    assertThat(jmxServer.isActive()).isTrue();
   }
 
   @BeforeEach

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/MBeanHelperTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.jmxmetrics;
 
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
@@ -24,8 +25,11 @@ import javax.management.remote.JMXServiceURL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(value = 10, unit = SECONDS)
 class MBeanHelperTest {
 
   private static final MBeanServer mbeanServer = getPlatformMBeanServer();
@@ -54,6 +58,11 @@ class MBeanHelperTest {
   @AfterAll
   static void tearDown() throws Exception {
     jmxServer.stop();
+  }
+
+  @BeforeEach
+  void confirmServerIsActive() {
+    assertThat(jmxServer.isActive()).isTrue();
   }
 
   @AfterEach

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.jmxmetrics;
 
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +29,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(value = 10, unit = SECONDS)
 class OtelHelperJmxTest {
 
   private static final String thingName =
@@ -48,8 +51,13 @@ class OtelHelperJmxTest {
 
   @AfterAll
   static void tearDown() throws Exception {
-    jmxServer.stop();
     mbeanServer.unregisterMBean(new ObjectName(thingName));
+  }
+
+  @AfterEach
+  void stopServer() throws Exception {
+    // each test stands up its own server
+    jmxServer.stop();
   }
 
   @AfterEach


### PR DESCRIPTION
**Description:**
Some builds are taking exceedingly long and this appears to be based on platform mbean connector server access flake:

```
WARNING: Could not connect to remote JMX server: 
java.rmi.ConnectException: Connection refused to host: 10.1.1.133; nested exception is: 
	java.net.ConnectException: Connection timed out
	at java.rmi/sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:626)
```

These changes add 10s timeouts to all suites w/ mbean server tests and an assertion before each test that the server is active, which is said to reflect the connector status though I wasn't able to verify this directly. Hopefully they will provide more information about the underlying issue.