### PR TITLE
jmx-metrics: thoroughly wait for test containers

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/AbstractIntegrationTest.java
@@ -112,6 +112,19 @@ public abstract class AbstractIntegrationTest {
     otlpServer.reset();
   }
 
+  protected static GenericContainer<?> cassandraContainer() {
+    return new GenericContainer<>("cassandra:3.11")
+        .withNetwork(Network.SHARED)
+        .withEnv("LOCAL_JMX", "no")
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("cassandra/jmxremote.password", 0400),
+            "/etc/cassandra/jmxremote.password")
+        .withNetworkAliases("cassandra")
+        .withExposedPorts(7199)
+        .withStartupTimeout(Duration.ofMinutes(2))
+        .waitingFor(Wait.forLogMessage(".*Startup complete.*", 1));
+  }
+
   @SafeVarargs
   protected final void waitAndAssertMetrics(Consumer<Metric>... assertions) {
     await()

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/OtlpIntegrationTest.java
@@ -9,31 +9,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.MountableFile;
 
 abstract class OtlpIntegrationTest extends AbstractIntegrationTest {
   OtlpIntegrationTest(boolean configFromStdin) {
     super(configFromStdin, "otlp_config.properties");
   }
 
-  @Container
-  GenericContainer<?> cassandra =
-      new GenericContainer<>("cassandra:3.11")
-          .withNetwork(Network.SHARED)
-          .withEnv("LOCAL_JMX", "no")
-          .withCopyFileToContainer(
-              MountableFile.forClasspathResource("cassandra/jmxremote.password", 0400),
-              "/etc/cassandra/jmxremote.password")
-          .withNetworkAliases("cassandra")
-          .withExposedPorts(7199)
-          .withStartupTimeout(Duration.ofMinutes(2))
-          .waitingFor(Wait.forListeningPort());
+  @Container GenericContainer<?> cassandra = cassandraContainer();
 
   @Test
   void endToEnd() {

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
@@ -8,17 +8,13 @@ package io.opentelemetry.contrib.jmxmetrics.target_systems;
 import static org.assertj.core.api.Assertions.entry;
 
 import io.opentelemetry.contrib.jmxmetrics.AbstractIntegrationTest;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import org.assertj.core.api.MapAssert;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.MountableFile;
 
 class CassandraIntegrationTest extends AbstractIntegrationTest {
 
@@ -26,18 +22,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
     super(/* configFromStdin= */ false, "target-systems/cassandra.properties");
   }
 
-  @Container
-  GenericContainer<?> cassandra =
-      new GenericContainer<>("cassandra:3.11")
-          .withNetwork(Network.SHARED)
-          .withEnv("LOCAL_JMX", "no")
-          .withCopyFileToContainer(
-              MountableFile.forClasspathResource("cassandra/jmxremote.password", 0400),
-              "/etc/cassandra/jmxremote.password")
-          .withNetworkAliases("cassandra")
-          .withExposedPorts(7199)
-          .withStartupTimeout(Duration.ofMinutes(2))
-          .waitingFor(Wait.forListeningPort());
+  @Container GenericContainer<?> cassandra = cassandraContainer();
 
   @Test
   void endToEnd() {

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
@@ -6,15 +6,11 @@
 package io.opentelemetry.contrib.jmxmetrics.target_systems;
 
 import io.opentelemetry.contrib.jmxmetrics.AbstractIntegrationTest;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.utility.MountableFile;
 
 class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
 
@@ -22,18 +18,7 @@ class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
     super(/* configFromStdin= */ false, "target-systems/jvm.properties");
   }
 
-  @Container
-  GenericContainer<?> cassandra =
-      new GenericContainer<>("cassandra:3.11")
-          .withNetwork(Network.SHARED)
-          .withEnv("LOCAL_JMX", "no")
-          .withCopyFileToContainer(
-              MountableFile.forClasspathResource("cassandra/jmxremote.password", 0400),
-              "/etc/cassandra/jmxremote.password")
-          .withNetworkAliases("cassandra")
-          .withExposedPorts(7199)
-          .withStartupTimeout(Duration.ofMinutes(2))
-          .waitingFor(Wait.forListeningPort());
+  @Container GenericContainer<?> cassandra = cassandraContainer();
 
   @Test
   void endToEnd() {

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
@@ -50,7 +50,8 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
           .withNetworkAliases("kafka")
           .withExposedPorts(7199)
           .withStartupTimeout(Duration.ofMinutes(2))
-          .waitingFor(Wait.forListeningPort())
+          .waitingFor(
+              Wait.forLogMessage(".*KafkaServer.*started \\(kafka.server.KafkaServer\\).*", 1))
           .dependsOn(zookeeper);
 
   Startable createTopics =
@@ -200,7 +201,7 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
                 "--max-messages",
                 "100")
             .withStartupTimeout(Duration.ofMinutes(2))
-            .waitingFor(Wait.forListeningPort())
+            .waitingFor(Wait.forLogMessage(".*Welcome to the Bitnami kafka container.*", 1))
             .dependsOn(createTopics);
 
     @Test
@@ -281,7 +282,7 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
             .withCommand("kafka-producer.sh")
             .withStartupTimeout(Duration.ofMinutes(2))
             .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka-producer")))
-            .waitingFor(Wait.forListeningPort())
+            .waitingFor(Wait.forLogMessage(".*Welcome to the Bitnami kafka container.*", 1))
             .dependsOn(createTopics);
 
     @Test


### PR DESCRIPTION
**Description:**
Bug fix  - The jmx metric gatherer integration tests are flakey without overpowered instances per https://github.com/open-telemetry/opentelemetry-java-contrib/issues/200. These changes unify the cassandra image uses and wait for a more definitive log statement to denote the container is ready to pull from.

edit: Also waiting for kafka container startup messages.

**Outstanding items:**
In the future we may want to build/distribute our own lean mbean-producing docker image, but this seems like an adequate solution given the current test content.
