### PR TITLE
Fixes Solr metric by using alternate attribute

### DIFF
--- a/jmx-metrics/src/main/resources/target-systems/solr.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/solr.groovy
@@ -78,4 +78,4 @@ otel.instrument(beanSolrCoreQueryResultsCache, "solr.cache.lookup.count", "The n
 otel.instrument(beanSolrCoreQueryResultsCache, "solr.cache.size", "The size of the cache occupied in memory.", "by",
   ["core" : { mbean -> mbean.name().getKeyProperty("dom2") },
    "cache" : { mbean -> mbean.name().getKeyProperty("scope") }],
-  "size", otel.&longUpDownCounterCallback)
+  "ramBytesUsed", otel.&longUpDownCounterCallback)


### PR DESCRIPTION
**Description:**
solr.cache.size was using the size attribute which actually keeps track of how many "items" are in the cache. Instead we should be using ramBytesUsed to keep track of the size in bytes.