### PR TITLE
Change jmx-metrics jar classifier so shadowJar isn't rebuilt even whe…

### DIFF
--- a/jmx-metrics/build.gradle.kts
+++ b/jmx-metrics/build.gradle.kts
@@ -74,9 +74,32 @@ tasks {
     archiveClassifier.set("")
   }
 
+  jar {
+    archiveClassifier.set("noshadow")
+  }
+
   withType<Test>().configureEach {
     dependsOn(shadowJar)
     systemProperty("shadow.jar.path", shadowJar.get().archiveFile.get().asFile.absolutePath)
     systemProperty("gradle.project.version", "${project.version}")
+  }
+
+  // Because we reconfigure publishing to only include the shadow jar, the Gradle metadata is not correct.
+  // Since we are fully bundled and have no dependencies, Gradle metadata wouldn't provide any advantage over
+  // the POM anyways so in practice we shouldn't be losing anything.
+  withType<GenerateModuleMetadata>().configureEach {
+    enabled = false
+  }
+}
+
+// Don't publish non-shadowed jar (shadowJar is in shadowRuntimeElements)
+with(components["java"] as AdhocComponentWithVariants) {
+  configurations.forEach {
+    withVariantsFromConfiguration(configurations["apiElements"]) {
+      skip()
+    }
+    withVariantsFromConfiguration(configurations["runtimeElements"]) {
+      skip()
+    }
   }
 }


### PR DESCRIPTION
…n nothing changed.

Because both jar and shadowJar have the same output file, Gradle cannot mark it up-to-date ever. While inconceivable in practice because shadowing takes a long time, it seems theoretically possible to publish the non-shadowed JAR to Maven Central based on timing if for some reason shadow finished before jar.

We've tried many patterns for publishing shadow jars, I think this may finally be the one that solves all the problems.