### PR TITLE
Updates jmx-metrics WildFly integration with replacement MBean

### DIFF
--- a/jmx-metrics/src/main/resources/target-systems/wildfly.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/wildfly.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-def beanWildflyDeployment = otel.mbeans("jboss.as.expr:deployment=*,subsystem=undertow")
+def beanWildflyDeployment = otel.mbeans("jboss.as:deployment=*,subsystem=undertow")
 otel.instrument(beanWildflyDeployment, "wildfly.session.count", "The number of sessions created.", "{sessions}",
   ["deployment": { mbean -> mbean.name().getKeyProperty("deployment")}],
   "sessionsCreated", otel.&longCounterCallback)


### PR DESCRIPTION

**Description:**

Updates jmx-metrics WildFly integration to point to integer attributes for some metrics. The session metrics previously pointed at attributes that were Strings and caused errors.
