### PR TITLE
Update Hadoop deprecated metric name

### DIFF
--- a/jmx-metrics/src/main/resources/target-systems/hadoop.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/hadoop.groovy
@@ -35,7 +35,7 @@ otel.instrument(beanHadoopNameNodeFS, "hadoop.name_node.volume.failed", "The num
   "VolumeFailuresTotal", otel.&longUpDownCounterCallback)
 otel.instrument(beanHadoopNameNodeFS, "hadoop.name_node.file.count", "The total number of files being tracked by the name node.", "{files}",
   ["node_name" : { mbean -> mbean.getProperty("tag.Hostname") }],
-  "TotalFiles", otel.&longUpDownCounterCallback)
+  "FilesTotal", otel.&longUpDownCounterCallback)
 otel.instrument(beanHadoopNameNodeFS, "hadoop.name_node.file.load", "The current number of concurrent file accesses.", "{operations}",
   ["node_name" : { mbean -> mbean.getProperty("tag.Hostname") }],
   "TotalLoad", otel.&longUpDownCounterCallback)


### PR DESCRIPTION
The `TotalFiles` metric states that it is `Deprecated: Use FilesTotal instead` at [hadoop documentation](https://hadoop.apache.org/docs/r2.8.2/hadoop-project-dist/hadoop-common/Metrics.html). The metric gather is the same and the documentation can remain unchanged.

Later Hadoop versions will be able to collect the total file if  `FilesTotal` is used instead.