### PR TITLE
Fix release notes automation

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -101,6 +101,7 @@ jobs:
           EOF
 
           sed -n '/^## Version ${{ github.event.inputs.version }}/,/^## Version /p' CHANGELOG.md \
+            | tail -n +2 \
             | head -n -1 \
             | perl -0pe 's/^\n+//g' \
             | perl -0pe 's/\n+$/\n/g' \


### PR DESCRIPTION
`tail -n +2` to start printing from the second line, prevent it from copying over the starting `## Version` header (and the `head -n -1` prevents it from copying over the ending `## Version` header)