### PR TITLE
[Docs] Add the Otel Maven Extension to the list of provided libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feature or via instrumentation, this project is hopefully for you.
 
 * [AWS X-Ray Support](./aws-xray/README.md)
 * [JMX Metric Gatherer](./jmx-metrics/README.md)
-* [OpenTelemetry Maven Extension](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension)
+* [OpenTelemetry Maven Extension](./maven-extension/README.md)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ feature or via instrumentation, this project is hopefully for you.
 
 * [AWS X-Ray Support](./aws-xray/README.md)
 * [JMX Metric Gatherer](./jmx-metrics/README.md)
+* [OpenTelemetry Maven Extension](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension)
 
 ## Getting Started
 


### PR DESCRIPTION
**Description:**

Documentation: Add the Otel Maven Extension to the list of provided libraries in README.md

