### PR TITLE
Switch from unmaintained actions

### DIFF
--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -1,5 +1,3 @@
-# Releases a patch by cherrypicking commits into a release branch based on the previous
-# release tag.
 name: Patch Release Build
 on:
   workflow_dispatch:
@@ -7,11 +5,9 @@ on:
       version:
         description: The version to tag the release with, e.g., 1.2.1, 1.2.2
         required: true
-      commits:
-        description: Comma separated list of commit shas to cherrypick
-        required: false
 
 jobs:
+  # TODO (trask) remove this after 1.13.0 since release branch is now created proactively
   prepare-release-branch:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/patch-release-build.yml
+++ b/.github/workflows/patch-release-build.yml
@@ -153,25 +153,14 @@ jobs:
 
           EOF
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ github.event.inputs.version }}
-          release_name: Version ${{ github.event.inputs.version }}
-          draft: true
-          prerelease: false
-          body_path: release-notes.txt
-
-      - name: Upload jmx-metrics release asset
-        id: upload-release-asset-jmx-metrics
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: jmx-metrics/build/libs/opentelemetry-jmx-metrics-${{ github.event.inputs.version }}.jar
-          asset_name: opentelemetry-jmx-metrics.jar
-          asset_content_type: application/java-archive
+        run: |
+          cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-${{ github.event.inputs.version }}.jar opentelemetry-jmx-metrics.jar
+          gh release create --target ${{ github.ref_name }} \
+                            --title "Version ${{ github.event.inputs.version }}" \
+                            --notes-file release-notes.txt \
+                            --discussion-category announcements \
+                            v${{ github.event.inputs.version }} \
+                            opentelemetry-javaagent.jar

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,3 +124,9 @@ jobs:
                             --discussion-category announcements \
                             v${{ github.event.inputs.version }} \
                             opentelemetry-javaagent.jar
+
+        # proactively create release branch so that contributors can suggest patches more easily
+      - name: Create release branch
+        run: |
+          git checkout -b v${{ github.event.inputs.version }}
+          git push origin v${{ github.event.inputs.version }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -113,25 +113,14 @@ jobs:
 
           EOF
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1.1.4
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ github.event.inputs.version }}
-          release_name: Version ${{ github.event.inputs.version }}
-          draft: true
-          prerelease: false
-          body_path: release-notes.txt
-
-      - name: Upload jmx-metrics release asset
-        id: upload-release-asset-jmx-metrics
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: jmx-metrics/build/libs/opentelemetry-jmx-metrics-${{ github.event.inputs.version }}.jar
-          asset_name: opentelemetry-jmx-metrics.jar
-          asset_content_type: application/java-archive
+        run: |
+          cp jmx-metrics/build/libs/opentelemetry-jmx-metrics-${{ github.event.inputs.version }}.jar opentelemetry-jmx-metrics.jar
+          gh release create --target ${{ github.ref_name }} \
+                            --title "Version ${{ github.event.inputs.version }}" \
+                            --notes-file release-notes.txt \
+                            --discussion-category announcements \
+                            v${{ github.event.inputs.version }} \
+                            opentelemetry-javaagent.jar

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -128,5 +128,6 @@ jobs:
         # proactively create release branch so that contributors can suggest patches more easily
       - name: Create release branch
         run: |
-          git checkout -b v${{ github.event.inputs.version }}
-          git push origin v${{ github.event.inputs.version }}
+          branch_name=$(echo ${{ github.event.inputs.version }} | sed -E 's/([0-9]+)\.([0-9]+)\.0/v\1.\2.x/')
+          git checkout -b $branch_name
+          git push origin $branch_name

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,46 +37,17 @@ When cutting a new release, the relevant integration tests for components in oth
 
 All patch releases should include only bug-fixes, and must avoid adding/modifying the public APIs.
 
+In general, patch releases are only made for bug-fixes for the following types of issues:
+* Regressions
+* Memory leaks
+* Deadlocks
+
+Merge PR(s) containing the desired patches to the release branch.
+
 Open the [Patch release workflow](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/patch-release-build.yml).
 
-You will see a button that says "Run workflow". Press the button, enter the version number you want
-to release in the input field for version that pops up and the commits you want to cherrypick for the
-patch as a comma-separated list. Then, press "Run workflow".
+Press the "Run workflow" button, then select the release branch from the dropdown list,
+e.g. `v1.9.x`, and click the "Run workflow" button below that.
 
-If the commits cannot be cleanly applied to the release branch, for example because it has diverged
-too much from main, then the workflow will fail before building. In this case, you will need to
-prepare the release branch manually.
-
-This example will assume patching into release branch `v1.2.x` from a git repository with remotes
-named `origin` and `upstream`.
-
-```
-$ git remote -v
-origin	git@github.com:username/opentelemetry-java-contrib.git (fetch)
-origin	git@github.com:username/opentelemetry-java-contrib.git (push)
-upstream	git@github.com:open-telemetry/opentelemetry-java-contrib.git (fetch)
-upstream	git@github.com:open-telemetry/opentelemetry-java-contrib.git (push)
-```
-
-First, checkout the release branch
-
-```
-git fetch upstream v1.2.x
-git checkout upstream/v1.2.x
-```
-
-Apply cherrypicks manually and commit. It is ok to apply multiple cherrypicks in a single commit.
-Use a commit message such as "Manual cherrypick for commits commithash1, commithash2".
-
-After committing the change, push to your fork's branch.
-
-```
-git push origin v1.2.x
-```
-
-Create a PR to have code review and merge this into upstream's release branch. As this was not
-applied automatically, we need to do code review to make sure the manual cherrypick is correct.
-
-After it is merged, Run the patch release workflow again, but leave the commits input field blank.
-The release will be made with the current state of the release branch, which is what you prepared
-above.
+This workflow will publish the artifacts to maven central and will publish a github release with
+release notes based on the change log.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,7 +42,10 @@ In general, patch releases are only made for bug-fixes for the following types o
 * Memory leaks
 * Deadlocks
 
-Merge PR(s) containing the desired patches to the release branch.
+Before making the release:
+
+* Merge PR(s) containing the desired patches to the release branch
+* Merge a PR to the release branch updating the `CHANGELOG.md`
 
 Open the [Patch release workflow](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/patch-release-build.yml).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,23 +15,17 @@ next _minor_ release version. This means version `vX.(Y+1).0-SNAPSHOT`.
 
 ## Starting the Release
 
-Before making the release, merge a PR to `main` updating the `CHANGELOG.md`. You can use the script
-at `buildscripts/draft-change-log-entries.sh` to help create an initial draft. We typically only
-include end-user facing changes in the change log.
+Before making the release, merge a PR to `main` updating the `CHANGELOG.md`.
+You can use the script at `buildscripts/draft-change-log-entries.sh` to help create an initial draft.
+Typically only end-user facing changes are included in the change log.
 
-Open the release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/release-build.yml).
+Open the [Release workflow](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/release-build.yml).
 
-You will see a button that says "Run workflow". Press the button, enter the version number you want
-to release in the input field that pops up, and then press "Run workflow".
+Press the "Run workflow" button, then select the release branch from the dropdown list,
+e.g. `v1.9.x`, and click the "Run workflow" button below that.
 
-This triggers the release process, which builds the artifacts, publishes the artifacts, and creates
-and pushes a git tag with the version number.
-
-Once the GitHub workflow completes, go to Github
-[release page](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases),
-find the draft release created by the release workflow, and
-* Select the checkbox for "Create a discussion for this release"
-* Press the "Publish release" button
+This workflow will publish the artifacts to maven central and will publish a github release with the
+javaagent jar attached and release notes based on the change log.
 
 ### Notifying other OpenTelemetry projects
 
@@ -41,10 +35,9 @@ When cutting a new release, the relevant integration tests for components in oth
 
 ## Patch Release
 
-All patch releases should include only bug-fixes, and must avoid
-adding/modifying the public APIs.
+All patch releases should include only bug-fixes, and must avoid adding/modifying the public APIs.
 
-Open the patch release build workflow in your browser [here](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/patch-release-build.yml).
+Open the [Patch release workflow](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/workflows/patch-release-build.yml).
 
 You will see a button that says "Run workflow". Press the button, enter the version number you want
 to release in the input field for version that pops up and the commits you want to cherrypick for the
@@ -87,9 +80,3 @@ applied automatically, we need to do code review to make sure the manual cherryp
 After it is merged, Run the patch release workflow again, but leave the commits input field blank.
 The release will be made with the current state of the release branch, which is what you prepared
 above.
-
-Once the GitHub workflow completes, go to Github
-[release page](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases),
-find the draft release created by the release workflow, and
-* Select the checkbox for "Create a discussion for this release"
-* Press the "Publish release" button


### PR DESCRIPTION
And a few other things:

* Now that the release notes are generated from the change log, remove a couple of more manual steps
* Cleaned up some of the patch release docs since the patch release workflow doesn't support cherry picks anymore (I like the manual cherry-pick proposal/review process)
* Added a step to always create release branch after minor release, to make it easier for contributors to propose patch candidates without having to get a maintainer to create the release branch first