### PR TITLE
Remove unused labels from template

### DIFF
--- a/.github/templates/workflow-failed.md
+++ b/.github/templates/workflow-failed.md
@@ -1,6 +1,6 @@
 ---
 title: "{{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }} failed"
-labels: bug, area:build, priority:p1
+labels: bug
 ---
 <a href="https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}">
 {{ env.GITHUB_WORKFLOW }} #{{ env.GITHUB_RUN_NUMBER }}</a> failed. Please take a look and fix it ASAP.


### PR DESCRIPTION
This was copied from instrumentation repo where these labels are used. It looks like this caused these two labels to get created in this repo, will remove them.