### PR TITLE
Add @jack-berg as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Approvers ([@open-telemetry/java-contrib-approvers](https://github.com/orgs/open
 Maintainers ([@open-telemetry/java-contrib-maintainers](https://github.com/orgs/open-telemetry/teams/java-contrib-maintainers)):
 
 - [Anuraag Agrawal](https://github.com/anuraaga), AWS
+- [Jack Berg](https://github.com/jack-berg), New Relic
 - [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
 - [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Splunk
 - [Ryan Fitzpatrick](https://github.com/rmfitzpatrick), Splunk


### PR DESCRIPTION
(maintainers of this repo are generally a superset of maintainers for core and instrumentation repos, based on an individual's preference)