### PR TITLE
Remove --stacktrace from gradle builds

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         name: Build
         with:
-          arguments: --stacktrace build
+          arguments: build
           cache-read-only: true
 
       - uses: actions/upload-artifact@v2
@@ -42,7 +42,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         name: Integration test
         with:
-          arguments: --stacktrace integrationTest
+          arguments: integrationTest
           cache-read-only: true
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --stacktrace build
+          arguments: build
 
       - name: Save unit test results
         uses: actions/upload-artifact@v2
@@ -45,7 +45,7 @@ jobs:
       - name: Integration test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --stacktrace integrationTest
+          arguments: integrationTest
 
       - name: Save integration test results
         uses: actions/upload-artifact@v2
@@ -84,7 +84,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         name: Publish
         with:
-          arguments: --stacktrace snapshot
+          arguments: snapshot
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         name: Build
         with:
-          arguments: --stacktrace build
+          arguments: build
 
       - uses: actions/upload-artifact@v2
         name: Save unit test results
@@ -40,7 +40,7 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         name: Integration test
         with:
-          arguments: --stacktrace integrationTest
+          arguments: integrationTest
 
       - uses: actions/upload-artifact@v2
         name: Save integration test results


### PR DESCRIPTION
Similar to @iNikem's https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/4470:

> Every time I look at the failed build, I have to scroll several screens up to find out the root case. Gradle failure stacktrace is useful when we have a problem within gradle tool itself, which happens very seldom.