### PR TITLE
Static instrumenter - logic

### DIFF
--- a/static-instrumenter/README.md
+++ b/static-instrumenter/README.md
@@ -6,7 +6,28 @@
 
 Module enhancing OpenTelemetry Java Agent for static instrumentation. The modified agent is capable of instrumenting and saving a new JAR with all relevant instrumentations applied and necessary helper class-code included.
 
-In order to statically instrument a JAR, modified agent needs to be both attached (`-javaagent:`) and run as the main method (`io.opentelemetry.contrib.staticinstrumenter.Main` class).
+To instrument the agent, first build agent-instrumenter using:
+
+`./gradlew :static-instrumenter:agent-instrumenter:assemble`
+
+Executable agent-instrumenter will be located under `build/libs/opentelemetry-agent-instrumenter.jar`
+
+Then, instrument the agent (supported versions 1.10+):
+
+`java -jar opentelemetry-agent-instrumenter.jar [path-to-agent] [output-dir]`
+
+Output consists of two jars:
+
+* `opentelemetry-javaagent.jar` - agent capable of static instrumentation
+* `classpath-agent.jar` - agent's classes to be placed on instrumented application's classpath
+
+To in order to statically instrument a JAR, run (using modified agent):
+
+`java -Dota.static.instrumenter=true -javaagent:opentelemetry-javaagent.jar -cp your-app.jar io.opentelemetry.contrib.staticinstrumenter.internals.Main [output-dir]`
+
+Finally, run the instrumented application:
+
+`java -Dio.opentelemetry.javaagent.shaded.io.opentelemetry.context.contextStorageProvider=default -cp your-instrumented-app.jar:classpath-agent.jar org.example.MainClass`
 
 ### Gradle plugin
 

--- a/static-instrumenter/agent-instrumenter/build.gradle.kts
+++ b/static-instrumenter/agent-instrumenter/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 description = "OpenTelemetry Java Static Instrumentation Agent"
 
 dependencies {
-  implementation("commons-io:commons-io:2.11.0")
   implementation("net.bytebuddy:byte-buddy-dep:1.12.8")
   implementation("org.slf4j:slf4j-api")
   runtimeOnly("org.slf4j:slf4j-simple")

--- a/static-instrumenter/agent-instrumenter/build.gradle.kts
+++ b/static-instrumenter/agent-instrumenter/build.gradle.kts
@@ -1,12 +1,21 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id("otel.java-conventions")
+  id("com.github.johnrengelman.shadow")
+  application
 }
 
 description = "OpenTelemetry Java Static Instrumentation Agent"
 
 dependencies {
+  implementation("commons-io:commons-io:2.11.0")
+  implementation("net.bytebuddy:byte-buddy-dep:1.12.8")
   implementation("org.slf4j:slf4j-api")
   runtimeOnly("org.slf4j:slf4j-simple")
+
+  // Used by byte-buddy but not brought in as a transitive dependency.
+  compileOnly("com.google.code.findbugs:annotations")
 }
 
 tasks {
@@ -16,3 +25,11 @@ tasks {
     }
   }
 }
+
+// this is necessary to be able to use logging tools already present in the agent
+tasks.withType<ShadowJar>().configureEach {
+  relocate("org.slf4j", "io.opentelemetry.javaagent.slf4j")
+  archiveFileName.set("opentelemetry-agent-instrumenter.jar")
+}
+
+application.mainClass.set("io.opentelemetry.contrib.staticinstrumenter.AgentModificationMain")

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/AgentInstrumenter.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/AgentInstrumenter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter;
+
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import io.opentelemetry.contrib.staticinstrumenter.advices.AgentAdvices;
+import io.opentelemetry.contrib.staticinstrumenter.advices.HelperInjectorAdvice;
+import io.opentelemetry.contrib.staticinstrumenter.internals.ArchiveEntry;
+import io.opentelemetry.contrib.staticinstrumenter.internals.ClassArchive;
+import io.opentelemetry.contrib.staticinstrumenter.internals.CurrentClass;
+import io.opentelemetry.contrib.staticinstrumenter.internals.Main;
+import io.opentelemetry.contrib.staticinstrumenter.internals.PostTransformer;
+import io.opentelemetry.contrib.staticinstrumenter.internals.PreTransformer;
+import io.opentelemetry.contrib.staticinstrumenter.internals.TransformedClass;
+import io.opentelemetry.contrib.staticinstrumenter.util.AgentCreator;
+import io.opentelemetry.contrib.staticinstrumenter.util.AgentExtractor;
+import io.opentelemetry.contrib.staticinstrumenter.util.TmpDirManager;
+import io.opentelemetry.contrib.staticinstrumenter.util.path.IdentityPathGetter;
+import io.opentelemetry.contrib.staticinstrumenter.util.path.SimplePathGetter;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.dynamic.DynamicType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsible for loading and instrumenting the OpenTelemetry javaagent JAR file */
+final class AgentInstrumenter {
+  private static final Logger logger = LoggerFactory.getLogger(AgentInstrumenter.class);
+  private final Map<String, byte[]> classesToInject;
+  private final File otelJar;
+  private final Path finalJarDir;
+
+  AgentInstrumenter(String otelJarPath, String finalJarDir) {
+    this.classesToInject = new HashMap<>();
+    this.otelJar = new File(otelJarPath);
+    this.finalJarDir = Paths.get(finalJarDir);
+  }
+
+  /** Conducts the process of OpenTelemetry javaagent JAR instrumentation */
+  void instrument() {
+    try {
+
+      TmpDirManager tmpDirManager = new TmpDirManager("static-instrumenter-");
+
+      AgentExtractor agentExtractor = new AgentExtractor(tmpDirManager);
+      Path tmpDir = agentExtractor.extractAgent(otelJar);
+
+      URL url = tmpDir.toUri().toURL();
+      URLClassLoader otelClassLoader = new URLClassLoader(new URL[] {url});
+
+      Class<?> openTelemetryAgentClass =
+          otelClassLoader.loadClass("io.opentelemetry.javaagent.OpenTelemetryAgent");
+      Class<?> helperInjectorClass =
+          otelClassLoader.loadClass("io.opentelemetry.javaagent.tooling.HelperInjector");
+
+      rebaseOpenTelemetryAgent(openTelemetryAgentClass);
+      rebaseHelperInjector(helperInjectorClass);
+
+      prepareAdditionalClasses();
+
+      new AgentCreator(tmpDirManager, new IdentityPathGetter())
+          .create(finalJarDir.resolve("opentelemetry-javaagent.jar"), otelJar, classesToInject);
+
+      new AgentCreator(tmpDirManager, new SimplePathGetter())
+          .create(finalJarDir.resolve("classpath-agent.jar"), otelJar, classesToInject);
+
+    } catch (IOException | ClassNotFoundException e) {
+      logger.error(
+          "The classes required for static instrumentation with OpenTelemetry Agent were not added properly.",
+          e);
+    }
+  }
+
+  private void rebaseOpenTelemetryAgent(Class<?> openTelemetryAgentClass) {
+
+    DynamicType.Unloaded<?> openTelemetryAgentType =
+        new ByteBuddy()
+            .rebase(openTelemetryAgentClass)
+            .visit(
+                Advice.to(AgentAdvices.AgentMainAdvice.class)
+                    .on(isMethod().and(named("startAgent"))))
+            .visit(
+                Advice.to(AgentAdvices.InstallBootstrapJarAdvice.class)
+                    .on(isMethod().and(named("installBootstrapJar"))))
+            .make();
+
+    classesToInject.put(
+        openTelemetryAgentType.getTypeDescription().getInternalName() + ".class",
+        openTelemetryAgentType.getBytes());
+  }
+
+  private void rebaseHelperInjector(Class<?> helperInjectorClass) {
+
+    DynamicType.Unloaded<?> helperInjectorType =
+        new ByteBuddy()
+            .rebase(helperInjectorClass)
+            .visit(
+                Advice.to(HelperInjectorAdvice.class)
+                    .on(isMethod().and(named("injectBootstrapClassLoader"))))
+            .make();
+
+    classesToInject.put(
+        "inst/" + helperInjectorType.getTypeDescription().getInternalName() + ".classdata",
+        helperInjectorType.getBytes());
+  }
+
+  private void prepareAdditionalClasses() {
+    List<Class<?>> additionalClasses =
+        new ArrayList<>(
+            Arrays.asList(
+                ArchiveEntry.class,
+                ClassArchive.class,
+                ClassArchive.Factory.class,
+                CurrentClass.class,
+                Main.class,
+                PreTransformer.class,
+                PostTransformer.class,
+                TransformedClass.class));
+
+    ByteBuddy byteBuddy = new ByteBuddy();
+
+    for (Class<?> clazz : additionalClasses) {
+      DynamicType.Unloaded<?> type = byteBuddy.rebase(clazz).make();
+
+      classesToInject.put(getClassEntryName(type), type.getBytes());
+    }
+  }
+
+  private static String getClassEntryName(DynamicType.Unloaded<?> unloadedType) {
+    return unloadedType.getTypeDescription().getInternalName() + ".class";
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/AgentModificationMain.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/AgentModificationMain.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter;
+
+import java.io.File;
+
+public final class AgentModificationMain {
+
+  /**
+   * The main method of agent-instrumenter module. It begins the process of instrumentation of the
+   * agent.
+   *
+   * @param args First argument is the path to the OpenTelemetry javaagent JAR file. Second argument
+   *     is the path to the output folder, where resulting modified agent JARs will be placed.
+   */
+  public static void main(String[] args) {
+
+    String otelJarPath;
+    String outDirPath;
+
+    if (args.length >= 2) {
+      otelJarPath = args[0];
+      outDirPath = args[1];
+    } else {
+      otelJarPath = "opentelemetry-javaagent.jar";
+      outDirPath = "outjars";
+    }
+
+    File outDir = new File(outDirPath);
+    if (!outDir.exists()) {
+      outDir.mkdir();
+    }
+
+    AgentInstrumenter agentInstrumenter = new AgentInstrumenter(otelJarPath, outDirPath);
+    agentInstrumenter.instrument();
+  }
+
+  private AgentModificationMain() {}
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/AgentAdviceClasses.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/AgentAdviceClasses.java
@@ -9,14 +9,12 @@ import io.opentelemetry.contrib.staticinstrumenter.internals.Main;
 import java.lang.instrument.Instrumentation;
 import net.bytebuddy.asm.Advice;
 
-@SuppressWarnings({"SystemOut", "CatchAndPrintStackTrace"})
-public final class AgentAdvices {
+public final class AgentAdviceClasses {
   @SuppressWarnings("unused")
   public static final class InstallBootstrapJarAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    static void enterInstallBoostrapJar(
-        @Advice.Argument(value = 0, readOnly = false) Instrumentation inst) {
+    static void enterInstallBoostrapJar(@Advice.Argument(value = 0) Instrumentation inst) {
       inst.addTransformer(Main.getPreTransformer());
     }
 
@@ -27,12 +25,12 @@ public final class AgentAdvices {
   public static final class AgentMainAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    static void exitStartAgent(@Advice.Argument(value = 0, readOnly = false) Instrumentation inst) {
+    static void exitStartAgent(@Advice.Argument(value = 0) Instrumentation inst) {
       inst.addTransformer(Main.getPostTransformer(), true);
     }
 
     private AgentMainAdvice() {}
   }
 
-  private AgentAdvices() {}
+  private AgentAdviceClasses() {}
 }

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/AgentAdvices.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/AgentAdvices.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.advices;
+
+import io.opentelemetry.contrib.staticinstrumenter.internals.Main;
+import java.lang.instrument.Instrumentation;
+import net.bytebuddy.asm.Advice;
+
+@SuppressWarnings({"SystemOut", "CatchAndPrintStackTrace"})
+public final class AgentAdvices {
+  @SuppressWarnings("unused")
+  public static final class InstallBootstrapJarAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    static void enterInstallBoostrapJar(
+        @Advice.Argument(value = 0, readOnly = false) Instrumentation inst) {
+      inst.addTransformer(Main.getPreTransformer());
+    }
+
+    private InstallBootstrapJarAdvice() {}
+  }
+
+  @SuppressWarnings("unused")
+  public static final class AgentMainAdvice {
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    static void exitStartAgent(@Advice.Argument(value = 0, readOnly = false) Instrumentation inst) {
+      inst.addTransformer(Main.getPostTransformer(), true);
+    }
+
+    private AgentMainAdvice() {}
+  }
+
+  private AgentAdvices() {}
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/HelperInjectorAdvice.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/advices/HelperInjectorAdvice.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.advices;
+
+import io.opentelemetry.contrib.staticinstrumenter.internals.Main;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+
+@SuppressWarnings("unused")
+public final class HelperInjectorAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void enter(@Advice.Argument(value = 0) Map<String, byte[]> classnameToBytes) {
+
+    for (String className : classnameToBytes.keySet()) {
+      String modifiedClassName = className.replace(".", "/") + ".class";
+
+      Main.getInstance()
+          .getAdditionalClasses()
+          .put(modifiedClassName, classnameToBytes.get(className));
+    }
+  }
+
+  private HelperInjectorAdvice() {}
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/ArchiveEntry.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/ArchiveEntry.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
-class ArchiveEntry {
+public class ArchiveEntry {
 
   private static final ArchiveEntry NOT_CLASS =
       new ArchiveEntry("", "", /* shouldInstrument= */ false);

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/ClassArchive.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/ClassArchive.java
@@ -72,11 +72,15 @@ public class ClassArchive {
     if (entry.shouldInstrument()) {
       String className = entry.getName();
       try {
+        // This line triggers the instrumentation of by forcefully loading the class.
+        // We have to "feed" the class to the agent ourselves,
+        // since during static instrumentation process the classes in user's app
+        // have no guarantee of getting loaded otherwise.
         // TODO: load classes on archive's separate classloader
         Class.forName(className, false, ClassLoader.getSystemClassLoader());
         byte[] modified = instrumentedClasses.get(entry.getPath());
         if (modified != null) {
-          logger.debug("Found instrumented class: " + className);
+          logger.debug("Found instrumented class: {}", className);
           entryIn = new ByteArrayInputStream(modified);
           outEntry.setSize(modified.length);
         }

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/CurrentClass.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/CurrentClass.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
-class CurrentClass {
+public class CurrentClass {
 
   private static final ThreadLocal<TransformedClass> currentClass = new ThreadLocal<>();
 

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/Main.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/Main.java
@@ -42,7 +42,7 @@ public class Main {
     }
 
     String classPath = System.getProperty("java.class.path");
-    logger.debug("Classpath (jars list): " + classPath);
+    logger.debug("Classpath (jars list): {}", classPath);
     String[] jarsList = classPath.split(File.pathSeparator);
 
     getInstance().saveTransformedJarsTo(jarsList, outDir);

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/Main.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/Main.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/PreTransformer.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/PreTransformer.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
 import javax.annotation.Nullable;
 
-public class PostTransformer implements ClassFileTransformer {
+public class PreTransformer implements ClassFileTransformer {
+
   @Override
   @Nullable
   public byte[] transform(
@@ -20,13 +20,7 @@ public class PostTransformer implements ClassFileTransformer {
       ProtectionDomain protectionDomain,
       byte[] classfileBuffer) {
 
-    TransformedClass pre = CurrentClass.getAndRemove();
-
-    if (pre != null
-        && pre.getName().equals(className)
-        && !Arrays.equals(pre.getClasscode(), classfileBuffer)) {
-      Main.getInstance().getInstrumentedClasses().put(className, classfileBuffer);
-    }
+    CurrentClass.set(new TransformedClass(className, classfileBuffer));
     return null;
   }
 }

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/TransformedClass.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/internals/TransformedClass.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
 public class TransformedClass {
   private final byte[] classcode;

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentCreator.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentCreator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import io.opentelemetry.contrib.staticinstrumenter.util.path.AgentPathGetter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates a new agent JAR. */
+public final class AgentCreator {
+
+  private static final Logger logger = LoggerFactory.getLogger(AgentCreator.class);
+  private final TmpDirManager dirManager;
+  private final AgentPathGetter pathGetter;
+
+  public AgentCreator(TmpDirManager dirManager, AgentPathGetter pathGetter) {
+    this.dirManager = dirManager;
+    this.pathGetter = pathGetter;
+  }
+
+  public void create(Path finalJarPath, File otelJar, Map<String, byte[]> classesToInstrument)
+      throws IOException {
+
+    String tmpPath = dirManager.getTmpFile("agent-jars", "agent-", ".jar").toString();
+
+    Map<String, byte[]> classesToInstrumentCopy = new HashMap<>(classesToInstrument);
+
+    // following code mimics ByteBuddy's DynamicType.inject()
+    // we don't use it directly, since it would mean copying jar every time we add one class
+    try (JarInputStream in = new JarInputStream(new FileInputStream(otelJar))) {
+
+      Manifest manifest = in.getManifest();
+
+      try (JarOutputStream zout =
+          manifest == null
+              ? new JarOutputStream(new FileOutputStream(tmpPath))
+              : new JarOutputStream(new FileOutputStream(tmpPath), manifest)) {
+        JarEntry entry;
+        // find class that we want to replace
+        while ((entry = in.getNextJarEntry()) != null) {
+
+          byte[] replacement = classesToInstrumentCopy.remove(entry.getName());
+
+          String newName = pathGetter.getPath(entry);
+
+          try {
+            zout.putNextEntry(new JarEntry(newName));
+            if (replacement == null) {
+              in.transferTo(zout);
+            } else {
+              zout.write(replacement);
+              logger.debug("Instrumented " + entry.getName());
+            }
+          } catch (IOException e) {
+            // ignore duplicate entries
+          }
+
+          in.closeEntry();
+          zout.closeEntry();
+        }
+
+        // add extra classes
+        for (Map.Entry<String, byte[]> mapEntry : classesToInstrumentCopy.entrySet()) {
+          zout.putNextEntry(new JarEntry(mapEntry.getKey()));
+          zout.write(mapEntry.getValue());
+          zout.closeEntry();
+
+          logger.debug("Instrumented " + mapEntry.getKey());
+        }
+      }
+    }
+    Files.copy(Paths.get(tmpPath), finalJarPath, REPLACE_EXISTING);
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentExtractor.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentExtractor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util;
+
+import io.opentelemetry.contrib.staticinstrumenter.util.path.AgentPathGetter;
+import io.opentelemetry.contrib.staticinstrumenter.util.path.SimplePathGetter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Extracts the agent to a temporary directory. This is done to enable simple loading of agent
+ * classes that need to be modified.
+ */
+public final class AgentExtractor {
+
+  private final Path extractedAgent;
+
+  public AgentExtractor(TmpDirManager tmpDirManager) throws IOException {
+    this.extractedAgent = tmpDirManager.createDir("opentelemetry-javaagent");
+  }
+
+  /**
+   * Extracts the agent JAR entry to a temporary directory.
+   *
+   * @param agentFile File object representing the OpenTelemetry javaagent file
+   * @throws IOException If process of writing to file encounters problems
+   */
+  public Path extractAgent(File agentFile) throws IOException {
+    JarFile otelJarFile = new JarFile(agentFile);
+
+    Enumeration<JarEntry> entries = otelJarFile.entries();
+
+    AgentPathGetter pathGetter = new SimplePathGetter();
+
+    while (entries.hasMoreElements()) {
+
+      JarEntry entry = entries.nextElement();
+
+      String sanitizedName = pathGetter.getPath(entry);
+
+      if (!entry.isDirectory()) {
+        extractEntry(otelJarFile, entry, sanitizedName);
+      }
+    }
+
+    return extractedAgent;
+  }
+
+  /**
+   * Extracts the agent JAR entry to temporary directory under new, sanitized name.
+   *
+   * @param otelJarFile JarFile object representing the OpenTelemetry javaagent file
+   * @param entryToSave JAR entry that is extracted
+   * @param sanitized Sanitized JAR entry name
+   * @throws IOException If process of writing to file encounters problems
+   */
+  private void extractEntry(JarFile otelJarFile, JarEntry entryToSave, String sanitized)
+      throws IOException {
+    int lastSlashIdx = sanitized.lastIndexOf("/");
+    String path =
+        sanitized.substring(0, lastSlashIdx).replace("/", System.getProperty("file.separator"));
+    String className = sanitized.substring(lastSlashIdx + 1);
+
+    Path classPackage = Files.createDirectories(extractedAgent.resolve(path));
+
+    Files.write(
+        classPackage.resolve(className),
+        IOUtils.toByteArray(otelJarFile.getInputStream(entryToSave)));
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentExtractor.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/AgentExtractor.java
@@ -30,9 +30,9 @@ public final class AgentExtractor {
   }
 
   /**
-   * Extracts the agent JAR entry to a temporary directory. It removes the inst/ prefix and
-   * changes .classdata format to .class in appropriate agent classes so that they could be normally
-   * loaded and modified.
+   * Extracts the agent JAR entry to a temporary directory. It removes the inst/ prefix and changes
+   * .classdata format to .class in appropriate agent classes so that they could be normally loaded
+   * and modified.
    */
   public Path extractAgent(Path agentFile) throws IOException {
     JarFile otelJarFile = new JarFile(agentFile.toString());

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/TmpDirManager.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/TmpDirManager.java
@@ -8,7 +8,6 @@ package io.opentelemetry.contrib.staticinstrumenter.util;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,9 +24,9 @@ public final class TmpDirManager {
             new Thread(
                 () -> {
                   try {
-                    FileUtils.deleteDirectory(tmpDir.toFile());
+                    Files.delete(tmpDir);
                   } catch (IOException e) {
-                    logger.debug("Could not create shutdown hook.");
+                    logger.debug("Could delete the temporary directory.");
                   }
                 }));
   }

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/TmpDirManager.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/TmpDirManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates and removes temporary directories. */
+public final class TmpDirManager {
+
+  private static final Logger logger = LoggerFactory.getLogger(TmpDirManager.class);
+  private final Path tmpDir;
+
+  public TmpDirManager(String rootDirPrefix) throws IOException {
+    this.tmpDir = Files.createTempDirectory(rootDirPrefix);
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    FileUtils.deleteDirectory(tmpDir.toFile());
+                  } catch (IOException e) {
+                    logger.debug("Could not create shutdown hook.");
+                  }
+                }));
+  }
+
+  public Path createDir(String path) throws IOException {
+    return Files.createDirectories(tmpDir.resolve(path));
+  }
+
+  public Path getTmpFile(String dir, String prefix, String suffix) throws IOException {
+    return Files.createTempFile(createDir(dir), prefix, suffix);
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/AgentPathGetter.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/AgentPathGetter.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util.path;
+
+import java.util.jar.JarEntry;
+
+/** Supplies a new path of a given entry inside modified agent JAR. */
+public interface AgentPathGetter {
+  String getPath(JarEntry entry);
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/IdentityPathGetter.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/IdentityPathGetter.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util.path;
+
+import java.util.jar.JarEntry;
+
+public class IdentityPathGetter implements AgentPathGetter {
+  @Override
+  public String getPath(JarEntry entry) {
+    return entry.getName();
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/SimplePathGetter.java
+++ b/static-instrumenter/agent-instrumenter/src/main/java/io/opentelemetry/contrib/staticinstrumenter/util/path/SimplePathGetter.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util.path;
+
+import java.util.jar.JarEntry;
+
+public class SimplePathGetter implements AgentPathGetter {
+  @Override
+  public String getPath(JarEntry entry) {
+    String name = entry.getName();
+    if (name.startsWith("inst/")) {
+      return name.replaceFirst("inst/", "").replaceAll("\\.classdata$", ".class");
+    }
+    return name;
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/ClassArchiveTest.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/ClassArchiveTest.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
-import static io.opentelemetry.contrib.staticinstrumenter.JarTestUtil.getResourcePath;
+import static io.opentelemetry.contrib.staticinstrumenter.internals.JarTestUtil.getResourcePath;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/JarTestUtil.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/JarTestUtil.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/MainTest.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/MainTest.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter;
+package io.opentelemetry.contrib.staticinstrumenter.internals;
 
-import static io.opentelemetry.contrib.staticinstrumenter.JarTestUtil.getResourcePath;
+import static io.opentelemetry.contrib.staticinstrumenter.internals.JarTestUtil.getResourcePath;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/TestClass.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/TestClass.java
@@ -1,4 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.contrib.staticinstrumenter.internals;
 
-public class TestClass {
-}
+public class TestClass {}

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/TestClass.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/internals/TestClass.java
@@ -1,0 +1,4 @@
+package io.opentelemetry.contrib.staticinstrumenter.internals;
+
+public class TestClass {
+}

--- a/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/util/path/PathGetterTest.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/io/opentelemetry/contrib/staticinstrumenter/util/path/PathGetterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.staticinstrumenter.util.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.jar.JarEntry;
+import org.junit.jupiter.api.Test;
+
+public class PathGetterTest {
+
+  @Test
+  public void testInst() {
+
+    SimplePathGetter pathGetter = new SimplePathGetter();
+
+    String newName = pathGetter.getPath(new JarEntry("inst/aaa/bbb/ccc.class"));
+
+    assertThat(newName).isEqualTo("aaa/bbb/ccc.class");
+  }
+
+  @Test
+  public void instInTheMiddle() {
+
+    SimplePathGetter pathGetter = new SimplePathGetter();
+
+    String newName = pathGetter.getPath(new JarEntry("aaa/inst/ccc.class"));
+    String newName2 = pathGetter.getPath(new JarEntry("inst/aaa/inst/ccc.class"));
+
+    assertThat(newName).isEqualTo("aaa/inst/ccc.class");
+    assertThat(newName2).isEqualTo("aaa/inst/ccc.class");
+  }
+
+  @Test
+  public void classData() {
+
+    SimplePathGetter pathGetter = new SimplePathGetter();
+
+    String newName = pathGetter.getPath(new JarEntry("inst/aaa/inst/ccc.classdata"));
+
+    assertThat(newName).isEqualTo("aaa/inst/ccc.class");
+  }
+
+  @Test
+  public void simpleEntry() {
+
+    SimplePathGetter pathGetter = new SimplePathGetter();
+
+    String newName = pathGetter.getPath(new JarEntry("classdata/aaa/inst/ccc.class"));
+
+    assertThat(newName).isEqualTo("classdata/aaa/inst/ccc.class");
+  }
+
+  @Test
+  public void testIdentityPathGetter() {
+
+    IdentityPathGetter pathGetter = new IdentityPathGetter();
+
+    String newName = pathGetter.getPath(new JarEntry("inst/aaa/inst.classdata/ccc.classdata"));
+
+    assertThat(newName).isEqualTo("inst/aaa/inst.classdata/ccc.classdata");
+  }
+}

--- a/static-instrumenter/agent-instrumenter/src/test/java/test/TestClass.java
+++ b/static-instrumenter/agent-instrumenter/src/test/java/test/TestClass.java
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.staticinstrumenter.internals;
+package test;
 
 public class TestClass {}


### PR DESCRIPTION
**Description:**

Another part of `agent-instrumenter`. Now, it provides a tool for modifying the opentelemetry-javaagent.jar so that it is capable of performing static instrumentation.

Modification of the agent classes can be divided into two aspects:
* Adding new classes - all classes located in `io.opentelemetry.contrib.staticinstrumenter.internal` are injected into the agent jar. Most importantly, we add the class `Main`, which provides a main method of the process of static instrumentation, responsible for saving transformed classes to the user's jar.
* Rebasing two classes already present in the agent :
  * We modify `OpenTelemetryAgent` so that it adds two new transformers to the `premain`/`agentmain`’s Instrumentation instance. Those transformers pass classes instrumented by the agent to the Main singleton, which then saves those classes in the user's jar. 
  * We rebase `HelperInjector` to be able to save helper classes created by the agent in a similar manner (via passing them to `Main`).

It's also worth noting that we create two modified agent jars. 
* First one (saved as `opentelemetry-javaagent.jar`) contains only the changes mentroned above and is used only for the process of static instrumentation.
* The second one (saved as `classpath-agent.jar`) has an additional change to the structure of the agent -  the `inst/` prefix is removed and `.classdata` format is changed back to `.class`. When a user wants to start their statically instrumented application, they should add this jar to the classpath. 

While working on our Maven plugin [in this repo](https://github.com/agh-static-x/Maven-Plugin), we were injecting necessary agent classes into the user's jar, so the `classspath-agent.jar` was not necessary. I think it's best to discuss which approach we want to use in the future.

**Existing Issue(s):**

Part of #156

**Testing:**

A small unit test. More to come in following PRs. 

**Documentation:**

README updated

**Outstanding items:**

* more tests, especially a dockerized test involving the whole process of static instrumentation
* separate classloaders for user classes ([this](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/236#discussion_r820366365) had to be added back to the core code to be able to instrument user classes)

