### PR TITLE
Fix prepare patch release workflow

### DIFF
--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Bump version
         env:
-          VERSION: ${{ needs.set-versions.outputs.release-version }}
-          PRIOR_VERSION: ${{ needs.set-versions.outputs.prior-release-version }}
+          VERSION: ${{ steps.set-versions.outputs.release-version }}
+          PRIOR_VERSION: ${{ steps.set-versions.outputs.prior-release-version }}
         run: |
           sed -ri "s/$PRIOR_VERSION/$VERSION/" version.gradle.kts
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Create pull request
         env:
-          VERSION: ${{ needs.set-versions.outputs.release-version }}
+          VERSION: ${{ steps.set-versions.outputs.release-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           msg="Prepare patch release $VERSION"


### PR DESCRIPTION
I was testing another github action and realized I got the syntax wrong for inter-step variables (the existing syntax `needs.` is for inter-job variables)