### PR TITLE
Update jackson library to fix vulnerability

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -12,7 +12,7 @@ val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
 val DEPENDENCY_BOMS = listOf(
-    "com.fasterxml.jackson:jackson-bom:2.13.1",
+    "com.fasterxml.jackson:jackson-bom:2.13.2.20220328",
     "com.google.guava:guava-bom:31.0.1-jre",
     "com.linecorp.armeria:armeria-bom:1.14.0",
     "org.junit:junit-bom:5.8.2",


### PR DESCRIPTION
This PR is to update the Jackson library vulnerability. By updating the version, the databind nested dependency will be updated to version `2.13.2.2`, 

Vulnerability : https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518


Reference Link : https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.13.1

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/41936996/162327420-0787ef06-4e6e-41f3-b370-9b141ef65968.png">
