### PR TITLE
Initial update of JXM's JVM metrics.

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
@@ -31,7 +31,20 @@ class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
             "Metaspace",
             "Par Survivor Space");
     waitAndAssertMetrics(
-        metric -> assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "1"),
+        metric ->
+            assertSum(
+                metric,
+                "process.runtime.jvm.classes.loaded",
+                "Number of classes currently loaded",
+                "{classes}",
+                false),
+        metric ->
+            assertSum(
+                metric,
+                "process.runtime.jvm.classes.unloaded",
+                "Number of classes unloaded since JVM start",
+                "{classes}",
+                false),
         metric ->
             assertTypedSum(
                 metric,
@@ -67,6 +80,12 @@ class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
         metric ->
             assertTypedGauge(
                 metric, "jvm.memory.pool.used", "current memory pool usage", "by", gcLabels),
-        metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "1"));
+        metric ->
+            assertSum(
+                metric,
+                "process.runtime.jvm.threads.count",
+                "number of threads",
+                "{threads}",
+                false));
   }
 }

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
@@ -371,7 +371,20 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
       List<Consumer<Metric>> assertions = new ArrayList<>(kafkaBrokerAssertions());
       assertions.addAll(
           Arrays.asList(
-              metric -> assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "1"),
+              metric ->
+                  assertSum(
+                      metric,
+                      "process.runtime.jvm.classes.loaded",
+                      "Number of classes currently loaded",
+                      "{classes}",
+                      false),
+              metric ->
+                  assertSum(
+                      metric,
+                      "process.runtime.jvm.classes.unloaded",
+                      "Number of classes unloaded since JVM start",
+                      "{classes}",
+                      false),
               metric ->
                   assertTypedSum(
                       metric,
@@ -416,7 +429,13 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
               metric ->
                   assertTypedGauge(
                       metric, "jvm.memory.pool.used", "current memory pool usage", "by", gcLabels),
-              metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "1")));
+              metric ->
+                  assertSum(
+                      metric,
+                      "process.runtime.jvm.threads.count",
+                      "Number of executing threads",
+                      "{threads}",
+                      false)));
 
       waitAndAssertMetrics(assertions);
     }

--- a/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/jvm.groovy
@@ -16,9 +16,9 @@
 
 def classLoading = otel.mbean("java.lang:type=ClassLoading")
 otel.instrument(classLoading, "process.runtime.jvm.classes.loaded", "Number of classes currently loaded",
-        "1", "LoadedClassCount", otel.&longUpDownCounterCallback)
+        "{classes}", "LoadedClassCount", otel.&longUpDownCounterCallback)
 otel.instrument(classLoading, "process.runtime.jvm.classes.unloaded", "Number of classes unloaded since JVM start",
-        "1", "UnloadedClassCount", otel.&longUpDownCounterCallback)
+        "{classes}", "UnloadedClassCount", otel.&longUpDownCounterCallback)
 
 def garbageCollector = otel.mbeans("java.lang:type=GarbageCollector,*")
 otel.instrument(garbageCollector, "jvm.gc.collections.count", "total number of collections that have occurred",
@@ -42,4 +42,4 @@ otel.instrument(memoryPool, "jvm.memory.pool", "current memory pool usage",
 
 def threading = otel.mbean("java.lang:type=Threading")
 otel.instrument(threading, "process.runtime.jvm.threads.count", "Number of executing threads",
-        "1", "ThreadCount", otel.&longUpDownCounterCallback)
+        "{threads}", "ThreadCount", otel.&longUpDownCounterCallback)

--- a/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/jvm.groovy
@@ -15,8 +15,10 @@
  */
 
 def classLoading = otel.mbean("java.lang:type=ClassLoading")
-otel.instrument(classLoading, "jvm.classes.loaded", "number of loaded classes",
-        "1", "LoadedClassCount", otel.&longValueCallback)
+otel.instrument(classLoading, "process.runtime.jvm.classes.loaded", "Number of classes currently loaded",
+        "1", "LoadedClassCount", otel.&longUpDownCounterCallback)
+otel.instrument(classLoading, "process.runtime.jvm.classes.unloaded", "Number of classes unloaded since JVM start",
+        "1", "UnloadedClassCount", otel.&longUpDownCounterCallback)
 
 def garbageCollector = otel.mbeans("java.lang:type=GarbageCollector,*")
 otel.instrument(garbageCollector, "jvm.gc.collections.count", "total number of collections that have occurred",
@@ -39,5 +41,5 @@ otel.instrument(memoryPool, "jvm.memory.pool", "current memory pool usage",
         "Usage", otel.&longValueCallback)
 
 def threading = otel.mbean("java.lang:type=Threading")
-otel.instrument(threading, "jvm.threads.count", "number of threads",
-        "1", "ThreadCount", otel.&longValueCallback)
+otel.instrument(threading, "process.runtime.jvm.threads.count", "Number of executing threads",
+        "1", "ThreadCount", otel.&longUpDownCounterCallback)


### PR DESCRIPTION
Initial pass for a few semantic convention updates:

* Loaded classes.
* Unloaded classes.
* Active threads.

Will update the rest in a second pass:

* Still to be decided whether the GC are Java specific or not.
* Memory ones need to be updated and refactored to be reported differently (not simply a rename).
