### PR TITLE
Runtime attachment additions

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -58,6 +58,7 @@ val DEPENDENCY_SETS = listOf(
 )
 
 val DEPENDENCIES = listOf(
+    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.14.0",
     "com.google.code.findbugs:annotations:3.0.1u2",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.squareup.okhttp3:okhttp:4.9.3",

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -18,7 +18,7 @@ public class SpringBootApp {
 
     public static void main(String[] args) {
         RuntimeAttach.attachJavaagentToCurrentJVM();
-        SpringApplication.run();
+        SpringApplication.run(SpringBootApp.class, args);
     }
 
 }

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -1,6 +1,6 @@
 # Runtime attachment
 
-If you can't update the JVM arguments to attach the [OpenTelemetry Javaagent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
+If you can't update the JVM arguments to attach the [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
 
 The `io.opentelemetry.contrib.attach.RuntimeAttach` class has an `attachJavaagentToCurrentJVM` method allowing to trigger the attachment of the OTel agent for Java.
 

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -1,3 +1,29 @@
+# Runtime attachment
+
+If you can't update the JVM arguments to attach [OTel agent for Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
+
+The ```io.opentelemetry.contrib.attach.RuntimeAttach``` class has an ```attachJavaagentToCurrentJVM``` method allowing to trigger the attachment of the OTel agent for Java.
+
+The attachment will not be initiated in the following cases:
+* The  ```otel.javaagent.enabled ``` property is set to ```false```
+* The  ```OTEL_JAVAAGENT_ENABLED ``` environment variable is set to ```false```
+* The attachment is not requested from the _main_ thread
+* The agent is already attached
+
+_The attachment must be requested at the beginning of the ```main``` method._ We give below an example for Spring Boot applications:
+
+```java
+@SpringBootApplication
+public class SpringBootApp {
+
+    public static void main(String[] args) {
+        RuntimeAttach.attachJavaagentToCurrentJVM();
+        SpringApplication.run();
+    }
+
+}
+```
+
 ## Component owners
 
 - [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Splunk

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -1,6 +1,6 @@
 # Runtime attachment
 
-If you can't update the JVM arguments to attach [OTel agent for Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
+If you can't update the JVM arguments to attach the [OpenTelemetry Javaagent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
 
 The ```io.opentelemetry.contrib.attach.RuntimeAttach``` class has an ```attachJavaagentToCurrentJVM``` method allowing to trigger the attachment of the OTel agent for Java.
 

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -8,9 +8,10 @@ The attachment will not be initiated in the following cases:
 * The `otel.javaagent.enabled` property is set to `false`
 * The `OTEL_JAVAAGENT_ENABLED` environment variable is set to `false`
 * The attachment is not requested from the _main_ thread
+* The attachment is not requested from the `public static void main(String[] args)` method
 * The agent is already attached
 
-_The attachment must be requested at the beginning of the `main` method._ We give below an example for Spring Boot applications:
+_The attachment must be requested at the beginning of the `public static void main(String[] args)` method._ We give below an example for Spring Boot applications:
 
 ```java
 @SpringBootApplication

--- a/runtime-attach/README.md
+++ b/runtime-attach/README.md
@@ -2,15 +2,15 @@
 
 If you can't update the JVM arguments to attach the [OpenTelemetry Javaagent](https://github.com/open-telemetry/opentelemetry-java-instrumentation) (_-javaagent:path/to/opentelemetry-javaagent.jar_), this project allows you to do attachment programmatically.
 
-The ```io.opentelemetry.contrib.attach.RuntimeAttach``` class has an ```attachJavaagentToCurrentJVM``` method allowing to trigger the attachment of the OTel agent for Java.
+The `io.opentelemetry.contrib.attach.RuntimeAttach` class has an `attachJavaagentToCurrentJVM` method allowing to trigger the attachment of the OTel agent for Java.
 
 The attachment will not be initiated in the following cases:
-* The  ```otel.javaagent.enabled ``` property is set to ```false```
-* The  ```OTEL_JAVAAGENT_ENABLED ``` environment variable is set to ```false```
+* The `otel.javaagent.enabled` property is set to `false`
+* The `OTEL_JAVAAGENT_ENABLED` environment variable is set to `false`
 * The attachment is not requested from the _main_ thread
 * The agent is already attached
 
-_The attachment must be requested at the beginning of the ```main``` method._ We give below an example for Spring Boot applications:
+_The attachment must be requested at the beginning of the `main` method._ We give below an example for Spring Boot applications:
 
 ```java
 @SpringBootApplication

--- a/runtime-attach/build.gradle.kts
+++ b/runtime-attach/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")
 
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.13.1")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.14.0")
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit-pioneer:junit-pioneer")

--- a/runtime-attach/build.gradle.kts
+++ b/runtime-attach/build.gradle.kts
@@ -11,4 +11,15 @@ dependencies {
 
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")
+
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.13.1")
+  testImplementation("io.opentelemetry:opentelemetry-extension-annotations:1.14.0")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit-pioneer:junit-pioneer")
+  testImplementation("org.assertj:assertj-core")
+}
+
+tasks.test {
+  useJUnitPlatform()
+  setForkEvery(1) // One JVM by test class to avoid a test class launching a runtime attachment influences the behavior of another test class
 }

--- a/runtime-attach/build.gradle.kts
+++ b/runtime-attach/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")
 
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.14.0")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent")
   testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit-pioneer:junit-pioneer")

--- a/runtime-attach/build.gradle.kts
+++ b/runtime-attach/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   compileOnly("com.google.code.findbugs:annotations")
 
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.13.1")
-  testImplementation("io.opentelemetry:opentelemetry-extension-annotations:1.14.0")
+  testImplementation("io.opentelemetry:opentelemetry-extension-annotations")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.junit-pioneer:junit-pioneer")
   testImplementation("org.assertj:assertj-core")

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -13,7 +13,7 @@ import net.bytebuddy.agent.ByteBuddyAgent;
 /** This class allows you to attach the OpenTelemetry Javaagent at runtime. */
 public final class RuntimeAttach {
 
-  private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
+  private static final Logger logger = Logger.getLogger(RuntimeAttach.class.getName());
   private static final String AGENT_ENABLED_PROPERTY = "otel.javaagent.enabled";
   private static final String AGENT_ENABLED_ENV_VAR = "OTEL_JAVAAGENT_ENABLED";
   static final String MAIN_THREAD_CHECK_PROP =
@@ -32,25 +32,25 @@ public final class RuntimeAttach {
     ByteBuddyAgent.attach(javaagentFile, getPid());
 
     if (!agentIsAttached()) {
-      LOGGER.warning("Agent was not attached. An unexpected issue has happened.");
+      logger.warning("Agent was not attached. An unexpected issue has happened.");
     }
   }
 
   private static boolean shouldAttach() {
     if (agentIsDisabledWithProp()) {
-      LOGGER.fine("Agent was disabled with " + AGENT_ENABLED_PROPERTY + " property.");
+      logger.fine("Agent was disabled with " + AGENT_ENABLED_PROPERTY + " property.");
       return false;
     }
     if (agentIsDisabledWithEnvVar()) {
-      LOGGER.fine("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
+      logger.fine("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
       return false;
     }
     if (agentIsAttached()) {
-      LOGGER.fine("Agent is already attached. It is not attached a second time.");
+      logger.fine("Agent is already attached. It is not attached a second time.");
       return false;
     }
     if (mainThreadCheckIsEnabled() && !isMainThread()) {
-      LOGGER.warning(
+      logger.warning(
           "Agent is not attached because runtime attachment was not requested from main thread.");
       return false;
     }

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -10,7 +10,7 @@ import java.lang.management.ManagementFactory;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
-/** This class allows you to attach the OpenTelemetry Javaagent at runtime. */
+/** This class allows you to attach the OpenTelemetry Java agent at runtime. */
 public final class RuntimeAttach {
 
   private static final Logger logger = Logger.getLogger(RuntimeAttach.class.getName());

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -50,7 +50,7 @@ public final class RuntimeAttach {
     }
     if (mainThreadCheckIsEnabled() && !isMainThread()) {
       LOGGER.warning(
-          "Agent is not attached because runtime attachment was requested from main thread.");
+          "Agent is not attached because runtime attachment was not requested from main thread.");
       return false;
     }
     return true;

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -7,22 +7,43 @@ package io.opentelemetry.contrib.attach;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;
+import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
 public final class RuntimeAttach {
 
+  private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
+  private static final String AGENT_ENABLED_PROPERTY = "otel.javaagent.enabled";
+  private static final String AGENT_ENABLED_ENV_VAR = "OTEL_JAVAAGENT_ENABLED";
+
   public static void attachJavaagentToCurrentJVM() {
-    if (agentIsDisabled()) {
+    if (!shouldAttach()) {
       return;
     }
     File javaagentFile = AgentFileLocator.locateAgentFile();
     ByteBuddyAgent.attach(javaagentFile, getPid());
   }
 
-  private static boolean agentIsDisabled() {
-    String enabledProperty =
-        System.getProperty("otel.javaagent.enabled", System.getenv("OTEL_JAVAAGENT_ENABLED"));
-    return "false".equals(enabledProperty);
+  private static boolean shouldAttach() {
+    if (agentIsDisabledWithProp()) {
+      LOGGER.warning("Agent was disabled with " + AGENT_ENABLED_PROPERTY + " property.");
+      return false;
+    }
+    if (agentIsDisabledWithEnvVar()) {
+      LOGGER.warning("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean agentIsDisabledWithProp() {
+    String agentEnabledPropValue = System.getProperty(AGENT_ENABLED_PROPERTY);
+    return "false".equals(agentEnabledPropValue);
+  }
+
+  private static boolean agentIsDisabledWithEnvVar() {
+    String agentEnabledEnvVarValue = System.getenv(AGENT_ENABLED_ENV_VAR);
+    return "false".equals(agentEnabledEnvVarValue);
   }
 
   private static String getPid() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -21,8 +21,13 @@ public final class RuntimeAttach {
     if (!shouldAttach()) {
       return;
     }
+
     File javaagentFile = AgentFileLocator.locateAgentFile();
     ByteBuddyAgent.attach(javaagentFile, getPid());
+
+    if (!agentIsAttached()) {
+      LOGGER.warning("Agent was not attached. An unexpected issue has happened.");
+    }
   }
 
   private static boolean shouldAttach() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -10,6 +10,9 @@ import java.lang.management.ManagementFactory;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
+/**
+ * This class allows you to attach the OTel agent for Java at runtime.
+ */
 public final class RuntimeAttach {
 
   private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
@@ -17,6 +20,9 @@ public final class RuntimeAttach {
   private static final String AGENT_ENABLED_ENV_VAR = "OTEL_JAVAAGENT_ENABLED";
   static final String MAIN_THREAD_CHECK_PROP = "otel.javaagent.runtimeattach.mainthreadcheck";
 
+  /**
+   * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the beginning of the main method.
+   */
   public static void attachJavaagentToCurrentJVM() {
     if (!shouldAttach()) {
       return;

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -10,9 +10,7 @@ import java.lang.management.ManagementFactory;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
-/**
- * This class allows you to attach the OTel agent for Java at runtime.
- */
+/** This class allows you to attach the OTel agent for Java at runtime. */
 public final class RuntimeAttach {
 
   private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
@@ -21,7 +19,8 @@ public final class RuntimeAttach {
   static final String MAIN_THREAD_CHECK_PROP = "otel.javaagent.runtimeattach.mainthreadcheck";
 
   /**
-   * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the beginning of the main method.
+   * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the
+   * beginning of the main method.
    */
   public static void attachJavaagentToCurrentJVM() {
     if (!shouldAttach()) {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -99,8 +99,7 @@ public final class RuntimeAttach {
 
   private static StackTraceElement findBottomOfStack(Thread thread) {
     StackTraceElement[] stackTrace = thread.getStackTrace();
-    StackTraceElement bottomOfStackStrace = stackTrace[stackTrace.length - 1];
-    return bottomOfStackStrace;
+    return stackTrace[stackTrace.length - 1];
   }
 
   private static String getPid() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -16,7 +16,8 @@ public final class RuntimeAttach {
   private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
   private static final String AGENT_ENABLED_PROPERTY = "otel.javaagent.enabled";
   private static final String AGENT_ENABLED_ENV_VAR = "OTEL_JAVAAGENT_ENABLED";
-  static final String MAIN_THREAD_CHECK_PROP = "otel.javaagent.testing.runtime-attach.main-thread-check";
+  static final String MAIN_THREAD_CHECK_PROP =
+      "otel.javaagent.testing.runtime-attach.main-thread-check";
 
   /**
    * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the
@@ -37,19 +38,19 @@ public final class RuntimeAttach {
 
   private static boolean shouldAttach() {
     if (agentIsDisabledWithProp()) {
-      LOGGER.warning("Agent was disabled with " + AGENT_ENABLED_PROPERTY + " property.");
+      LOGGER.fine("Agent was disabled with " + AGENT_ENABLED_PROPERTY + " property.");
       return false;
     }
     if (agentIsDisabledWithEnvVar()) {
-      LOGGER.warning("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
+      LOGGER.fine("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
       return false;
     }
     if (agentIsAttached()) {
-      LOGGER.warning("Agent is already attached. It is not attached a second time.");
+      LOGGER.fine("Agent is already attached. It is not attached a second time.");
       return false;
     }
     if (mainThreadCheckIsEnabled() && !isMainThread()) {
-      LOGGER.warning(
+      LOGGER.fine(
           "Agent is not attached because runtime attachment was not requested from main thread.");
       return false;
     }

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -20,7 +20,7 @@ public final class RuntimeAttach {
       "otel.javaagent.testing.runtime-attach.main-thread-check";
 
   /**
-   * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the
+   * Attach the OpenTelemetry Java agent to the current JVM. The attachment must be requested at the
    * beginning of the main method.
    */
   public static void attachJavaagentToCurrentJVM() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -33,6 +33,10 @@ public final class RuntimeAttach {
       LOGGER.warning("Agent was disabled with " + AGENT_ENABLED_ENV_VAR + " environment variable.");
       return false;
     }
+    if (agentIsAttached()) {
+      LOGGER.warning("Agent is already attached. It is not attached a second time.");
+      return false;
+    }
     return true;
   }
 
@@ -44,6 +48,15 @@ public final class RuntimeAttach {
   private static boolean agentIsDisabledWithEnvVar() {
     String agentEnabledEnvVarValue = System.getenv(AGENT_ENABLED_ENV_VAR);
     return "false".equals(agentEnabledEnvVarValue);
+  }
+
+  private static boolean agentIsAttached() {
+    try {
+      Class.forName("io.opentelemetry.javaagent.OpenTelemetryAgent", false, null);
+      return true;
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
   }
 
   private static String getPid() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -59,7 +59,7 @@ public final class RuntimeAttach {
 
   private static boolean agentIsDisabledWithProp() {
     String agentEnabledPropValue = System.getProperty(AGENT_ENABLED_PROPERTY);
-    return "false".equals(agentEnabledPropValue);
+    return "false".equalsIgnoreCase(agentEnabledPropValue);
   }
 
   private static boolean agentIsDisabledWithEnvVar() {

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -50,7 +50,7 @@ public final class RuntimeAttach {
       return false;
     }
     if (mainThreadCheckIsEnabled() && !isMainThread()) {
-      LOGGER.fine(
+      LOGGER.warning(
           "Agent is not attached because runtime attachment was not requested from main thread.");
       return false;
     }

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -16,7 +16,7 @@ public final class RuntimeAttach {
   private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());
   private static final String AGENT_ENABLED_PROPERTY = "otel.javaagent.enabled";
   private static final String AGENT_ENABLED_ENV_VAR = "OTEL_JAVAAGENT_ENABLED";
-  static final String MAIN_THREAD_CHECK_PROP = "otel.javaagent.runtimeattach.mainthreadcheck";
+  static final String MAIN_THREAD_CHECK_PROP = "otel.javaagent.testing.runtime-attach.main-thread-check";
 
   /**
    * Attach the OTel agent for Java to the current JVM. The attachment must be requested at the

--- a/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
+++ b/runtime-attach/src/main/java/io/opentelemetry/contrib/attach/RuntimeAttach.java
@@ -10,7 +10,7 @@ import java.lang.management.ManagementFactory;
 import java.util.logging.Logger;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
-/** This class allows you to attach the OTel agent for Java at runtime. */
+/** This class allows you to attach the OpenTelemetry Javaagent at runtime. */
 public final class RuntimeAttach {
 
   private static final Logger LOGGER = Logger.getLogger(RuntimeAttach.class.getName());

--- a/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
+++ b/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.attach;
+
+import io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.Span;
+
+public class AbstractAttachmentTest {
+
+  boolean isAttached() {
+    return Span.current().getSpanContext().isValid();
+  }
+}

--- a/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
+++ b/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
@@ -12,7 +12,7 @@ public class AbstractAttachmentTest {
 
   @BeforeAll
   static void disableMainThreadCheck() {
-    System.setProperty(RuntimeAttach.MAIN_THREAD_CHECK_PROP, "false");
+    System.setProperty(RuntimeAttach.MAIN_METHOD_CHECK_PROP, "false");
   }
 
   boolean isAttached() {

--- a/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
+++ b/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AbstractAttachmentTest.java
@@ -6,8 +6,14 @@
 package io.opentelemetry.contrib.attach;
 
 import io.opentelemetry.javaagent.shaded.io.opentelemetry.api.trace.Span;
+import org.junit.jupiter.api.BeforeAll;
 
 public class AbstractAttachmentTest {
+
+  @BeforeAll
+  static void disableMainThreadCheck() {
+    System.setProperty(RuntimeAttach.MAIN_THREAD_CHECK_PROP, "false");
+  }
 
   boolean isAttached() {
     return Span.current().getSpanContext().isValid();

--- a/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AgentDisabledTest.java
+++ b/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/AgentDisabledTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.attach;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.extension.annotations.WithSpan;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+public class AgentDisabledTest extends AbstractAttachmentTest {
+
+  @SetEnvironmentVariable(key = "OTEL_JAVAAGENT_ENABLED", value = "false")
+  @Test
+  void shouldNotAttachWhenAgentDisabledWithEnvVariable() {
+    RuntimeAttach.attachJavaagentToCurrentJVM();
+    verifyNoAttachment();
+  }
+
+  @WithSpan
+  void verifyNoAttachment() {
+    assertThat(isAttached()).as("Agent should not be attached").isFalse();
+  }
+
+  @SetSystemProperty(key = "otel.javaagent.enabled", value = "false")
+  @Test
+  void shouldNotAttachWhenAgentDisabledWithProperty() {
+    RuntimeAttach.attachJavaagentToCurrentJVM();
+    verifyNoAttachment();
+  }
+}

--- a/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/RunTimeAttachBasicTest.java
+++ b/runtime-attach/src/test/java/io/opentelemetry/contrib/attach/RunTimeAttachBasicTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.attach;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.extension.annotations.WithSpan;
+import org.junit.jupiter.api.Test;
+
+public class RunTimeAttachBasicTest extends AbstractAttachmentTest {
+
+  @Test
+  void shouldAttach() {
+    RuntimeAttach.attachJavaagentToCurrentJVM();
+    verifyAttachment();
+  }
+
+  @WithSpan
+  void verifyAttachment() {
+    assertThat(isAttached()).as("Agent should be attached").isTrue();
+  }
+}


### PR DESCRIPTION
**Description:**

Runtime attachment additions

* Add tests
* Add log when agent is disabled with otel.javaagent.enabled property
* Add log when agent is disabled with OTEL_JAVAAGENT_ENABLED environment variable
* Do not try to attach if agent is already attached
* Do not try to attach if attachment is requested from the _main_ thread
* Do not try to attach if attachment is requested from the _main_ method
*  Add log if an unexpected issue has happened during attachment
* Add javadoc
*  Add information to the Readme