### PR TITLE
Change bot account user

### DIFF
--- a/.github/scripts/set-git-user.sh
+++ b/.github/scripts/set-git-user.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-git config user.name opentelemetry-java-bot
-git config user.email 97938252+opentelemetry-java-bot@users.noreply.github.com
+git config user.name opentelemetrybot
+git config user.email 107717825+opentelemetrybot@users.noreply.github.com


### PR DESCRIPTION
Planning to share this one across OTel repos.

Didn't just rename current bot user so that it would not affect patch releases if needed which are still pointing to the old bot.