### PR TITLE
Inline set-git-user.sh

### DIFF
--- a/.github/scripts/set-git-user.sh
+++ b/.github/scripts/set-git-user.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-
-git config user.name opentelemetrybot
-git config user.email 107717825+opentelemetrybot@users.noreply.github.com

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,7 +22,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set git user
-        run: .github/scripts/set-git-user.sh
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
       - name: Create pull request
         env:

--- a/.github/workflows/prepare-patch-release.yml
+++ b/.github/workflows/prepare-patch-release.yml
@@ -40,7 +40,9 @@ jobs:
           sed -Ei "s/^## Unreleased$/## Version $VERSION ($date)/" CHANGELOG.md
 
       - name: Set git user
-        run: .github/scripts/set-git-user.sh
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
       - name: Create pull request
         env:

--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -50,7 +50,9 @@ jobs:
           sed -Ei "s/^## Unreleased$/## Version $VERSION ($date)/" CHANGELOG.md
 
       - name: Set git user
-        run: .github/scripts/set-git-user.sh
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
       - name: Create pull request against the release branch
         env:
@@ -98,7 +100,9 @@ jobs:
           sed -Ei "s/^## Unreleased$/## Unreleased\n\n## Version $VERSION ($date)/" CHANGELOG.md
 
       - name: Set git user
-        run: .github/scripts/set-git-user.sh
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
       - name: Create pull request against main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,9 @@ jobs:
           fi
 
       - name: Set git user
-        run: .github/scripts/set-git-user.sh
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
       - name: Create pull request against main
         env:


### PR DESCRIPTION
Now that we have a common otel bot, no need to extract this part of the workflow out.