### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           fi
 
       - id: create-github-release
-      - name: Create GitHub release
+        name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
It looks like github just started flagging this

> every step must define a `uses` or `run` key

https://github.com/open-telemetry/opentelemetry-java-contrib/actions/runs/2620008794
