### PR TITLE
Remove hardcoded agent version

### DIFF
--- a/runtime-attach/runtime-attach/build.gradle.kts
+++ b/runtime-attach/runtime-attach/build.gradle.kts
@@ -5,11 +5,14 @@ plugins {
 
 description = "To runtime attach the OpenTelemetry Java Instrumentation agent"
 
-val agent: Configuration by configurations.creating
+val agent: Configuration by configurations.creating {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+}
 
 dependencies {
   implementation(project(":runtime-attach:runtime-attach-core"))
-  agent("io.opentelemetry.javaagent:opentelemetry-javaagent:1.15.0")
+  agent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")


### PR DESCRIPTION
alternative to #389

now I (partly) understand the point of `isCanBeResolved` and `isCanBeConsumed` in:

```
... by configurations.creating {
  isCanBeResolved = true
  isCanBeConsumed = false
}
```

see https://github.com/open-telemetry/opentelemetry-java-contrib/blob/7d19e674f301838a528266a7be4f3778e77c795b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts#L94-L96