### PR TITLE
Update maven plugin metadata

### DIFF
--- a/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/io.opentelemetry.contrib/maven-plugin/plugin-help.xml
+++ b/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/io.opentelemetry.contrib/maven-plugin/plugin-help.xml
@@ -7,7 +7,7 @@
   <description>Maven3 plugin for static instrumentation of projects code and dependencies</description>
   <groupId>io.opentelemetry.contrib</groupId>
   <artifactId>static-instrumentation-maven-plugin</artifactId>
-  <version>1.15.0-alpha-SNAPSHOT</version>
+  <version>1.16.0-alpha</version>
   <goalPrefix>static-instrumentation</goalPrefix>
   <mojos>
     <mojo>

--- a/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -7,7 +7,7 @@
   <description>Maven3 plugin for static instrumentation of projects code and dependencies</description>
   <groupId>io.opentelemetry.contrib</groupId>
   <artifactId>static-instrumentation-maven-plugin</artifactId>
-  <version>1.15.0-alpha-SNAPSHOT</version>
+  <version>1.16.0-alpha</version>
   <goalPrefix>static-instrumentation</goalPrefix>
   <isolatedRealm>false</isolatedRealm>
   <inheritedByDefault>true</inheritedByDefault>


### PR DESCRIPTION
cc @kubawach @anosek-an can these be generated at build time? maybe see how this is implemented for [maven-extension](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension) in this repo?