### PR TITLE
Add component owner for jfr-events

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -18,6 +18,8 @@ components:
   samplers:
     - iNikem
     - trask
+  jfr-events:
+    - sfriberg
   jfr-streaming:
     - breedx-splk
     - jack-berg

--- a/jfr-events/README.md
+++ b/jfr-events/README.md
@@ -21,3 +21,9 @@ Create JFR events that can be recorded and viewed in Java Mission Control (JMC).
 
 [javadoc-image]: https://www.javadoc.io/badge/io.opentelemetry/opentelemetry-sdk-extension-jfr-events.svg
 [javadoc-url]: https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-jfr-events
+
+## Component owners
+
+- [Staffan Friberg](https://github.com/sfriberg)
+
+Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
@sfriberg can you request membership in the OpenTelemetry org, so that we can auto-assign you as reviewer for jfr-events PRs?

https://github.com/open-telemetry/community/blob/main/community-membership.md#member

you can tag myself and @jack-berg as "sponsors"