### PR TITLE
Ability to build the Maven plugin of static instrumentation for dev

### DIFF
--- a/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/io.opentelemetry.contrib/maven-plugin/plugin-help.xml
+++ b/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/io.opentelemetry.contrib/maven-plugin/plugin-help.xml
@@ -7,7 +7,7 @@
   <description>Maven3 plugin for static instrumentation of projects code and dependencies</description>
   <groupId>io.opentelemetry.contrib</groupId>
   <artifactId>static-instrumentation-maven-plugin</artifactId>
-  <version>1.17.0-alpha-SNAPSHOT</version>
+  <version>1.19.0-alpha-SNAPSHOT</version>
   <goalPrefix>static-instrumentation</goalPrefix>
   <mojos>
     <mojo>

--- a/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/static-instrumenter/maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -7,7 +7,7 @@
   <description>Maven3 plugin for static instrumentation of projects code and dependencies</description>
   <groupId>io.opentelemetry.contrib</groupId>
   <artifactId>static-instrumentation-maven-plugin</artifactId>
-  <version>1.17.0-alpha-SNAPSHOT</version>
+  <version>1.19.0-alpha-SNAPSHOT</version>
   <goalPrefix>static-instrumentation</goalPrefix>
   <isolatedRealm>false</isolatedRealm>
   <inheritedByDefault>true</inheritedByDefault>


### PR DESCRIPTION
See #495

This PR allows to build the Maven plugin of static instrumentation for 1.19.0-alpha-SNAPSHOT version.