### PR TITLE
Fix release contributors script

### DIFF
--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -72,8 +72,8 @@ query($q: String!, $endCursor: String) {
   }
 }
 ' --jq '.data.search.edges.[].node.body' \
-  | grep -oE "#[0-9]{4,}|$GITHUB_REPOSITORY/issues/[0-9]{4,}" \
-  | grep -oE "[0-9]{4,}" \
+  | grep -oE "#[0-9]{3,}$|#[0-9]{3,}[^0-9<]|$GITHUB_REPOSITORY/issues/[0-9]{3,}" \
+  | grep -oE "[0-9]{3,}" \
   | xargs -I{} gh issue view {} --json 'author,url' --jq '[.author.login,.url]' \
   | grep -v '/pull/' \
   | sed 's/^\["//' \


### PR DESCRIPTION
I noticed tons of

```
GraphQL: Could not resolve to an issue or pull request with the number of XXXX. (repository.issue)
```

because the dependabot PR descriptions include references to lots of Issues/PRs in other repos.