### PR TITLE
Populate log group in EKS Resource Detector

### DIFF
--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EksResource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EksResource.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -72,6 +73,9 @@ public final class EksResource {
     String clusterName = getClusterName(httpClient);
     if (clusterName != null && !clusterName.isEmpty()) {
       attrBuilders.put(ResourceAttributes.K8S_CLUSTER_NAME, clusterName);
+
+      String logGroupName = String.format("/aws/containerinsights/%s/application", clusterName);
+      attrBuilders.put(ResourceAttributes.AWS_LOG_GROUP_NAMES, Arrays.asList(logGroupName));
     }
 
     String containerId = dockerHelper.getContainerId();

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EksResourceTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EksResourceTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,7 +66,10 @@ public class EksResourceTest {
             entry(ResourceAttributes.CLOUD_PROVIDER, "aws"),
             entry(ResourceAttributes.CLOUD_PLATFORM, "aws_eks"),
             entry(ResourceAttributes.K8S_CLUSTER_NAME, "my-cluster"),
-            entry(ResourceAttributes.CONTAINER_ID, "0123456789A"));
+            entry(ResourceAttributes.CONTAINER_ID, "0123456789A"),
+            entry(
+                ResourceAttributes.AWS_LOG_GROUP_NAMES,
+                Arrays.asList("/aws/containerinsights/my-cluster/application")));
   }
 
   @Test


### PR DESCRIPTION
**Description:**

Populate log group in the EKS resource detector.

**Existing Issue(s):**

https://github.com/aws-observability/aws-otel-java-instrumentation/issues/205

**Testing:**

Unit tests were updated.

**Documentation:**

NA

**Outstanding items:**

NA
