### PR TITLE
Minor build improvements

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
 spotless {
   kotlinGradle {
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports"))
     target("**/*.gradle.kts")
   }
 }

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -22,10 +22,12 @@ java {
 }
 
 tasks {
+  compileJava {
+    options.release.set(8)
+  }
+
   withType<JavaCompile>().configureEach {
     with(options) {
-      release.set(8)
-
       if (name != "jmhCompileGeneratedClasses") {
         compilerArgs.addAll(
           listOf(

--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -22,12 +22,12 @@ spotless {
   }
   plugins.withId("org.jetbrains.kotlin.jvm") {
     kotlin {
-      ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+      ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports"))
       licenseHeaderFile(rootProject.file("buildscripts/spotless.license.java"), "(package|import|class|// Includes work from:)")
     }
   }
   kotlinGradle {
-    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "disabled_rules" to "no-wildcard-imports"))
+    ktlint().editorConfigOverride(mapOf("indent_size" to "2", "continuation_indent_size" to "2", "ktlint_disabled_rules" to "no-wildcard-imports"))
   }
   format("misc") {
     // not using "**/..." to help keep spotless fast


### PR DESCRIPTION
With some other work here I noticed some kotlin related warnings coming from the build. The change from `disabled_rules` to `ktlint_ disabled_rules` fixes that.

The other change relaxes where we are setting `options.release.set(8)` to only the `compileJava` tasks. The previous `  withType<JavaCompile>().configureEach {...}` seemed to be also matching on the test compilation, which meant that Java 11+ syntax could not be used in tests. With that change, it can be allowed.