### PR TITLE
Use dependabot to update OTel SDK and Instrumentation dependencies

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -1,3 +1,8 @@
 {
-  "retryOn429": true
+  "retryOn429" : true,
+  "ignorePatterns" : [
+    {
+      "pattern" : "^https://github\\.com/open-telemetry/opentelemetry-java-contrib/network/updates$"
+    }
+  ]
 }

--- a/.github/scripts/update-instrumentation-version.sh
+++ b/.github/scripts/update-instrumentation-version.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-version=$1
-
-sed -Ei "s/val otelInstrumentationVersion = \"[^\"]*\"/val otelInstrumentationVersion = \"$version\"/" dependencyManagement/build.gradle.kts

--- a/.github/scripts/update-sdk-version.sh
+++ b/.github/scripts/update-sdk-version.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-version=$1
-
-sed -Ei "s/val otelVersion = \"[^\"]*\"/val otelVersion = \"$version\"/" dependencyManagement/build.gradle.kts

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,9 @@ the second Monday of the month (roughly a couple of days after the monthly minor
 
 ## Preparing a new major or minor release
 
+* Check that [dependabot has run](https://github.com/open-telemetry/opentelemetry-java-contrib/network/updates)
+  sometime in the past day.
+  * Check that SDK and instrumentation dependency versions have been updated to the latest release.
 * Close the [release milestone](https://github.com/open-telemetry/opentelemetry-java-contrib/milestones)
   if there is one.
 * Merge a pull request to `main` updating the `CHANGELOG.md`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,7 @@ the second Monday of the month (roughly a couple of days after the monthly minor
 
 * Check that [dependabot has run](https://github.com/open-telemetry/opentelemetry-java-contrib/network/updates)
   sometime in the past day.
-  * Check that SDK and instrumentation dependency versions have been updated to the latest release.
+  * Check that the OpenTelemetry SDK and Instrumentation versions have been updated to the latest release.
 * Close the [release milestone](https://github.com/open-telemetry/opentelemetry-java-contrib/milestones)
   if there is one.
 * Merge a pull request to `main` updating the `CHANGELOG.md`.

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -11,20 +11,14 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
-// this line is managed by .github/scripts/update-sdk-version.sh
-val otelSdkVersion = "1.19.0"
-// this line is managed by .github/scripts/update-instrumentation-version.sh
-val otelInstrumentationVersion = "1.19.0"
-
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.13.4.20221013",
   "com.google.guava:guava-bom:31.1-jre",
   "com.linecorp.armeria:armeria-bom:1.20.1",
   "org.junit:junit-bom:5.9.1",
   "io.grpc:grpc-bom:1.50.2",
-  "io.opentelemetry:opentelemetry-bom:$otelSdkVersion",
-  "io.opentelemetry:opentelemetry-bom-alpha:${otelSdkVersion}-alpha",
-  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}-alpha",
+  "io.opentelemetry:opentelemetry-bom-alpha:1.19.0-alpha",
+  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.19.0-alpha",
   "org.testcontainers:testcontainers-bom:1.17.5"
 )
 
@@ -48,7 +42,7 @@ val CORE_DEPENDENCIES = listOf(
 )
 
 val DEPENDENCIES = listOf(
-  "io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion",
+  "io.opentelemetry.javaagent:opentelemetry-javaagent:1.19.0",
   "com.google.code.findbugs:annotations:3.0.1u2",
   "com.google.code.findbugs:jsr305:3.0.2",
   "com.squareup.okhttp3:okhttp:4.10.0",


### PR DESCRIPTION
Seems simpler and more scalable to other repos, see https://github.com/open-telemetry/opentelemetry-collector-releases/issues/196#issuecomment-1258428187