### PR TITLE
Add remaining app server service name detectors

### DIFF
--- a/resource-providers/README.md
+++ b/resource-providers/README.md
@@ -16,8 +16,13 @@ from `WEB-INF/web.xml`. For `.ear` files the `<application>` element of `META-IN
 
 It is capable of detecting common scenarios among the popular application servers listed below:
 
+* Apache Tomcat
+* Apache TomEE
+* Eclipse Jetty
 * GlassFish
-* _remaining are tbd_
+* IBM Websphere
+* IBM Websphere Liberty
+* Wildfly
 
 ## Component owners
 

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/CommonAppServersServiceNameDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/CommonAppServersServiceNameDetector.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.resourceproviders;
 
 import java.net.URL;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -24,8 +24,14 @@ final class CommonAppServersServiceNameDetector {
 
   private static List<ServiceNameDetector> detectors() {
     ResourceLocator locator = new ResourceLocatorImpl();
-    // Additional implementations will be added to this list.
-    return Collections.singletonList(detectorFor(new GlassfishAppServer(locator)));
+    return Arrays.asList(
+        detectorFor(new TomeeAppServer(locator)),
+        detectorFor(new TomcatAppServer(locator)),
+        detectorFor(new JettyAppServer(locator)),
+        detectorFor(new LibertyAppService(locator)),
+        detectorFor(new WildflyAppServer(locator)),
+        detectorFor(new GlassfishAppServer(locator)),
+        new WebSphereServiceNameDetector(new WebSphereAppServer(locator)));
   }
 
   private static AppServerServiceNameDetector detectorFor(AppServer appServer) {

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import javax.annotation.Nullable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+
+class JettyAppServer implements AppServer {
+
+  private static final Logger logger = Logger.getLogger(JettyAppServer.class.getName());
+  private static final String SERVER_CLASS_NAME = "org.eclipse.jetty.start.Main";
+  private final ResourceLocator locator;
+
+  JettyAppServer(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Override
+  public boolean isValidAppName(Path path) {
+    // jetty deployer ignores directories ending with ".d"
+    if (Files.isDirectory(path)) {
+      return !path.getFileName().toString().endsWith(".d");
+    }
+    return true;
+  }
+
+  @Override
+  public Path getDeploymentDir() {
+    // Jetty expects the webapps directory to be in the directory where jetty was started from.
+    // Alternatively the location of webapps directory can be specified by providing jetty base
+    // directory as an argument to jetty e.g. java -jar start.jar jetty.base=/dir where webapps
+    // would be located in /dir/webapps.
+
+    String programArguments = System.getProperty("sun.java.command");
+    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    if (programArguments != null) {
+      Path jettyBase = parseJettyBase(programArguments);
+      if (jettyBase != null) {
+        logger.log(FINE, "Using jetty.base '{0}'.", jettyBase);
+        return jettyBase.resolve("webapps");
+      }
+    }
+
+    return Paths.get("webapps").toAbsolutePath();
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVER_CLASS_NAME);
+  }
+
+  @Nullable
+  @VisibleForTesting
+  static Path parseJettyBase(String programArguments) {
+    if (programArguments == null) {
+      return null;
+    }
+    int start = programArguments.indexOf("jetty.base=");
+    if (start == -1) {
+      return null;
+    }
+    start += "jetty.base=".length();
+    if (start == programArguments.length()) {
+      return null;
+    }
+    // Take the path until the first space. If the path doesn't exist extend it up to the next
+    // space. Repeat until a path that exists is found or input runs out.
+    int next = start;
+    while (true) {
+      int nextSpace = programArguments.indexOf(' ', next);
+      if (nextSpace == -1) {
+        Path candidate = Paths.get(programArguments.substring(start));
+        return Files.exists(candidate) ? candidate : null;
+      }
+      Path candidate = Paths.get(programArguments.substring(start, nextSpace));
+      next = nextSpace + 1;
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  @Override
+  public boolean supportsEar() {
+    return false;
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
@@ -1,30 +1,18 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
 
-import com.google.common.annotations.VisibleForTesting;
+import static java.util.logging.Level.FINE;
 
-import javax.annotation.Nullable;
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Logger;
-
-import static java.util.logging.Level.FINE;
+import javax.annotation.Nullable;
 
 class JettyAppServer implements AppServer {
 

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
@@ -1,32 +1,20 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
-
-import javax.annotation.Nullable;
 
 import static java.util.logging.Level.FINE;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 class LibertyAppService implements AppServer {
 
-  private final static String SERVICE_CLASS_NAME = "com.ibm.ws.kernel.boot.cmdline.EnvCheck";
+  private static final String SERVICE_CLASS_NAME = "com.ibm.ws.kernel.boot.cmdline.EnvCheck";
 
   private static final Logger logger = Logger.getLogger(LibertyAppService.class.getName());
   private final ResourceLocator locator;

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+
+import static java.util.logging.Level.FINE;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Logger;
+
+class LibertyAppService implements AppServer {
+
+  private final static String SERVICE_CLASS_NAME = "com.ibm.ws.kernel.boot.cmdline.EnvCheck";
+
+  private static final Logger logger = Logger.getLogger(LibertyAppService.class.getName());
+  private final ResourceLocator locator;
+
+  LibertyAppService(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Override
+  public Path getDeploymentDir() {
+    // default installation has
+    // WLP_OUTPUT_DIR - libertyDir/usr/servers
+    // WLP_USER_DIR - libertyDir/usr
+    // docker image has
+    // WLP_USER_DIR - /opt/ol/wlp/usr
+    // WLP_OUTPUT_DIR - /opt/ol/wlp/output
+
+    // liberty server sets current directory to $WLP_OUTPUT_DIR/serverName we need
+    // $WLP_USER_DIR/servers/serverName
+    // in default installation we already have the right directory and don't need to do anything
+    Path serverDir = Paths.get("").toAbsolutePath();
+    String wlpUserDir = System.getenv("WLP_USER_DIR");
+    String wlpOutputDir = System.getenv("WLP_OUTPUT_DIR");
+    if (logger.isLoggable(FINE)) {
+      logger.log(
+          FINE,
+          "Using WLP_USER_DIR '{0}', WLP_OUTPUT_DIR '{1}'.",
+          new Object[] {wlpUserDir, wlpOutputDir});
+    }
+    if (wlpUserDir != null
+        && wlpOutputDir != null
+        && !Paths.get(wlpOutputDir).equals(Paths.get(wlpUserDir, "servers"))) {
+      Path serverName = serverDir.getFileName();
+      serverDir = Paths.get(wlpUserDir, "servers").resolve(serverName);
+    }
+
+    // besides dropins applications can also be deployed via server.xml using <webApplication>,
+    // <enterpriseApplication> and <application> tags, see
+    // https://openliberty.io/docs/latest/reference/config/server-configuration-overview.html
+    return serverDir.resolve("dropins");
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVICE_CLASS_NAME);
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomcatAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomcatAppServer.java
@@ -1,27 +1,16 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
 
-import javax.annotation.Nullable;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.annotation.Nullable;
 
 class TomcatAppServer implements AppServer {
 
@@ -66,7 +55,7 @@ class TomcatAppServer implements AppServer {
     // if neither catalina.base nor catalina.home is set try to deduce the location of webapps based
     // on the loaded server class.
     Class<?> serverClass = getServerClass();
-    if(serverClass == null){
+    if (serverClass == null) {
       return null;
     }
     URL jarUrl = locator.getClassLocation(serverClass);

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomcatAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomcatAppServer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class TomcatAppServer implements AppServer {
+
+  private static final String SERVER_CLASS_NAME = "org.apache.catalina.startup.Bootstrap";
+  private final ResourceLocator locator;
+
+  TomcatAppServer(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Override
+  public boolean isValidAppName(Path path) {
+    if (Files.isDirectory(path)) {
+      String name = path.getFileName().toString();
+      return !"docs".equals(name)
+          && !"examples".equals(name)
+          && !"host-manager".equals(name)
+          && !"manager".equals(name);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isValidResult(Path path, @Nullable String result) {
+    String name = path.getFileName().toString();
+    return !"ROOT".equals(name) || !"Welcome to Tomcat".equals(result);
+  }
+
+  @Nullable
+  @Override
+  public Path getDeploymentDir() throws URISyntaxException {
+    String catalinaBase = System.getProperty("catalina.base");
+    if (catalinaBase != null) {
+      return Paths.get(catalinaBase, "webapps");
+    }
+
+    String catalinaHome = System.getProperty("catalina.home");
+    if (catalinaHome != null) {
+      return Paths.get(catalinaHome, "webapps");
+    }
+
+    // if neither catalina.base nor catalina.home is set try to deduce the location of webapps based
+    // on the loaded server class.
+    Class<?> serverClass = getServerClass();
+    if(serverClass == null){
+      return null;
+    }
+    URL jarUrl = locator.getClassLocation(serverClass);
+    Path jarPath = Paths.get(jarUrl.toURI());
+    // jar is in bin/. First call to getParent strips jar name and the second bin/. We'll end up
+    // with a path to server root to which we append the autodeploy directory.
+    return getWebappsDir(jarPath);
+  }
+
+  @Nullable
+  private static Path getWebappsDir(Path jarPath) {
+    Path parent = jarPath.getParent();
+    if (parent == null) {
+      return null;
+    }
+    Path grandparent = parent.getParent();
+    return grandparent == null ? null : grandparent.resolve("webapps");
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVER_CLASS_NAME);
+  }
+
+  @Override
+  public boolean supportsEar() {
+    return false;
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomeeAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomeeAppServer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class TomeeAppServer implements AppServer {
+
+  private static final String SERVER_CLASS_NAME = "org.apache.catalina.startup.Bootstrap";
+  private final ResourceLocator locator;
+
+  TomeeAppServer(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Nullable
+  @Override
+  public Path getDeploymentDir() throws URISyntaxException {
+    Path rootDir = getRootDir();
+    if(rootDir == null){
+      return null;
+    }
+
+    // check for presence of tomee configuration file, if it doesn't exist then we have tomcat not
+    // tomee
+    if (!Files.isRegularFile(rootDir.resolve("conf/tomee.xml"))) {
+      return null;
+    }
+
+    // tomee deployment directory is configurable, we'll only look at the default 'apps' directory
+    // to get the actual deployment directory (or see whether it is enabled at all) we would need to
+    // parse conf/tomee.xml
+    // tomee also deploys applications from webapps directory, detecting them is handled by
+    // TomcatServiceNameDetector
+    return rootDir.resolve("apps");
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVER_CLASS_NAME);
+  }
+
+  @Nullable
+  private Path getRootDir() throws URISyntaxException {
+    String catalinaBase = System.getProperty("catalina.base");
+    if (catalinaBase != null) {
+      return Paths.get(catalinaBase);
+    }
+
+    String catalinaHome = System.getProperty("catalina.home");
+    if (catalinaHome != null) {
+      return Paths.get(catalinaHome);
+    }
+
+    // if neither catalina.base nor catalina.home is set try to deduce the location of based on the
+    // loaded server class.
+    Class<?> serverClass = getServerClass();
+    if(serverClass == null){
+      return null;
+    }
+    URL jarUrl = locator.getClassLocation(serverClass);
+    Path jarPath = Paths.get(jarUrl.toURI());
+    // jar is in bin/. First call to getParent strips jar name and the second bin/. We'll end up
+    // with a path to server root.
+    Path parent = jarPath.getParent();
+    if(parent == null){
+      return null;
+    }
+    return parent.getParent();
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomeeAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/TomeeAppServer.java
@@ -1,27 +1,16 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
 
-import javax.annotation.Nullable;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.annotation.Nullable;
 
 class TomeeAppServer implements AppServer {
 
@@ -36,7 +25,7 @@ class TomeeAppServer implements AppServer {
   @Override
   public Path getDeploymentDir() throws URISyntaxException {
     Path rootDir = getRootDir();
-    if(rootDir == null){
+    if (rootDir == null) {
       return null;
     }
 
@@ -75,7 +64,7 @@ class TomeeAppServer implements AppServer {
     // if neither catalina.base nor catalina.home is set try to deduce the location of based on the
     // loaded server class.
     Class<?> serverClass = getServerClass();
-    if(serverClass == null){
+    if (serverClass == null) {
       return null;
     }
     URL jarUrl = locator.getClassLocation(serverClass);
@@ -83,7 +72,7 @@ class TomeeAppServer implements AppServer {
     // jar is in bin/. First call to getParent strips jar name and the second bin/. We'll end up
     // with a path to server root.
     Path parent = jarPath.getParent();
-    if(parent == null){
+    if (parent == null) {
       return null;
     }
     return parent.getParent();

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereAppServer.java
@@ -1,23 +1,12 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
 
-import javax.annotation.Nullable;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
 
 class WebSphereAppServer implements AppServer {
 

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereAppServer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+
+class WebSphereAppServer implements AppServer {
+
+  private static final String SERVER_CLASS_NAME = "com.ibm.wsspi.bootstrap.WSPreLauncher";
+  private final ResourceLocator locator;
+
+  WebSphereAppServer(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Override
+  public boolean isValidAppName(Path path) {
+    // query.ear is bundled with websphere
+    String name = path.getFileName().toString();
+    return !"query.ear".equals(name);
+  }
+
+  @Nullable
+  @Override
+  public Path getDeploymentDir() {
+    // not used
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVER_CLASS_NAME);
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.logging.Level.FINE;
+
+class WebSphereServiceNameDetector implements ServiceNameDetector {
+
+  private static final Pattern COMMANDLINE_PARSE_PATTERN = Pattern.compile(
+      "com\\.ibm\\.wsspi\\.bootstrap\\.WSPreLauncher (.*) com\\.ibm\\.ws\\.runtime\\.WsServer (.+) ([^ ]+) ([^ ]+) ([^ ]+)");
+  private static final Logger logger =
+      Logger.getLogger(WebSphereServiceNameDetector.class.getName());
+  private final WebSphereAppServer appServer;
+
+  WebSphereServiceNameDetector(WebSphereAppServer appServer) {
+    this.appServer = appServer;
+  }
+
+  @Nullable
+  @Override
+  public String detect() throws Exception {
+    if (appServer.getServerClass() == null) {
+      return null;
+    }
+
+    String programArguments = System.getProperty("sun.java.command");
+    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    if (programArguments == null) {
+      return null;
+    }
+
+    Matcher matcher = COMMANDLINE_PARSE_PATTERN.matcher(programArguments);
+    if (!matcher.matches()) {
+      logger.fine("Failed to parse arguments.");
+      return null;
+    }
+
+    // in docker image it is /opt/IBM/WebSphere/AppServer/profiles/AppSrv01/config
+    Path configDirectory = Paths.get(matcher.group(2));
+    if (!Files.isDirectory(configDirectory)) {
+      logger.log(FINE, "Missing configuration directory '{0}'.", configDirectory);
+      return null;
+    }
+
+    String cell = matcher.group(3);
+    String node = matcher.group(4);
+    String server = matcher.group(5);
+
+    if (logger.isLoggable(FINE)) {
+      logger.log(
+          FINE,
+          "Parsed arguments: cell '{0}', node '{1}', server '{2}', configuration directory '{3}'.",
+          new Object[] {cell, node, server, configDirectory});
+    }
+
+    // construct installedApps directory path based on the config path
+    // in docker image it is
+    // /opt/IBM/WebSphere/AppServer/profiles/AppSrv01/installedApps/DefaultCell01
+    // NOTE: installedApps directory location is configurable
+    Path parent = configDirectory.getParent();
+    if(parent == null){
+      return null;
+    }
+    Path cellApplications = parent.resolve("installedApps").resolve(cell);
+    if (Files.isDirectory(cellApplications)) {
+      logger.log(FINE, "Looking for deployments in '{0}'.", cellApplications);
+
+      try (Stream<Path> stream = Files.list(cellApplications)) {
+        for (Path path : stream.collect(Collectors.toList())) {
+          String fullName = path.getFileName().toString();
+          // websphere deploys all applications as ear
+          if (!fullName.endsWith(".ear") || !appServer.isValidAppName(path)) {
+            logger.log(FINE, "Skipping '{0}'.", path);
+            continue;
+          }
+          logger.log(FINE, "Attempting service name detection in '{0}'.", path);
+
+          // strip ear suffix
+          String name = fullName.substring(0, fullName.length() - 4);
+          // if there is only one war file with the same name as the ear then the app was probably
+          // really a war file and the surrounding ear was generated during deployment
+          List<Path> wars;
+          try (Stream<Path> warStream = Files.list(path)) {
+            wars =
+                warStream
+                    .filter(p -> p.getFileName().toString().endsWith(".war"))
+                    .collect(Collectors.toList());
+          }
+          boolean maybeWarDeployment =
+              wars.size() == 1 && wars.get(0).getFileName().toString().equals(name + ".war");
+          ParseBuddy parseBuddy = new ParseBuddy(appServer);
+          if (maybeWarDeployment) {
+            String result = parseBuddy.handleExplodedWar(wars.get(0));
+            if (result != null) {
+              return result;
+            }
+          }
+          String result = parseBuddy.handleExplodedEar(path);
+          // Auto-generated display-name in our testapp is app182ceb797ea, ignore similar names
+          if (result != null && (!maybeWarDeployment || !result.startsWith(name))) {
+            return result;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
@@ -1,22 +1,12 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
 
-import javax.annotation.Nullable;
+import static java.util.logging.Level.FINE;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -26,13 +16,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.logging.Level.FINE;
+import javax.annotation.Nullable;
 
 class WebSphereServiceNameDetector implements ServiceNameDetector {
 
-  private static final Pattern COMMANDLINE_PARSE_PATTERN = Pattern.compile(
-      "com\\.ibm\\.wsspi\\.bootstrap\\.WSPreLauncher (.*) com\\.ibm\\.ws\\.runtime\\.WsServer (.+) ([^ ]+) ([^ ]+) ([^ ]+)");
+  private static final Pattern COMMANDLINE_PARSE_PATTERN =
+      Pattern.compile(
+          "com\\.ibm\\.wsspi\\.bootstrap\\.WSPreLauncher (.*) com\\.ibm\\.ws\\.runtime\\.WsServer (.+) ([^ ]+) ([^ ]+) ([^ ]+)");
   private static final Logger logger =
       Logger.getLogger(WebSphereServiceNameDetector.class.getName());
   private final WebSphereAppServer appServer;
@@ -83,7 +73,7 @@ class WebSphereServiceNameDetector implements ServiceNameDetector {
     // /opt/IBM/WebSphere/AppServer/profiles/AppSrv01/installedApps/DefaultCell01
     // NOTE: installedApps directory location is configurable
     Path parent = configDirectory.getParent();
-    if(parent == null){
+    if (parent == null) {
       return null;
     }
     Path cellApplications = parent.resolve("installedApps").resolve(cell);

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import javax.annotation.Nullable;
+
+import static java.util.logging.Level.FINE;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Logger;
+
+class WildflyAppServer implements AppServer {
+
+  private static final Logger logger = Logger.getLogger(WildflyAppServer.class.getName());
+  private static final String SERVICE_CLASS_NAME = "org.jboss.modules.Main";
+
+  private final ResourceLocator locator;
+
+  WildflyAppServer(ResourceLocator locator) {
+    this.locator = locator;
+  }
+
+  @Nullable
+  @Override
+  public Path getDeploymentDir() throws URISyntaxException {
+    String programArguments = System.getProperty("sun.java.command");
+    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    if (programArguments == null) {
+      return null;
+    }
+    if (!programArguments.contains("org.jboss.as.standalone")) {
+      // only standalone mode is supported
+      return null;
+    }
+
+    // base dir is also passed as program argument (not vm argument) -Djboss.server.base.dir we use
+    // environment variable JBOSS_BASE_DIR to avoid parsing program arguments
+    String jbossBaseDir = System.getenv("JBOSS_BASE_DIR");
+    if (jbossBaseDir != null) {
+      logger.log(FINE, "Using JBOSS_BASE_DIR '{0}'.", jbossBaseDir);
+      return Paths.get(jbossBaseDir, "deployments");
+    }
+
+    Class<?> serverClass = getServerClass();
+    if(serverClass == null){
+      return null;
+    }
+    URL jarUrl = locator.getClassLocation(serverClass);
+    Path jarPath = Paths.get(jarUrl.toURI());
+    Path parent = jarPath.getParent();
+    if(parent == null){
+      return null;
+    }
+    return parent.resolve("standalone/deployments");
+  }
+
+  @Override
+  public boolean isValidAppName(Path path) {
+    // For exploded applications we should be checking for the presence of ".dodeploy" or
+    // ".deployed" marker files to ensure that we are scanning only applications that are actually
+    // deployed, see
+    // https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/6/html/administration_and_configuration_guide/reference_for_deployment_scanner_marker_files1
+    return AppServer.super.isValidAppName(path);
+  }
+
+  @Nullable
+  @Override
+  public Class<?> getServerClass() {
+    return locator.findClass(SERVICE_CLASS_NAME);
+  }
+}

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
@@ -1,22 +1,9 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
-
-import javax.annotation.Nullable;
 
 import static java.util.logging.Level.FINE;
 
@@ -25,6 +12,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 class WildflyAppServer implements AppServer {
 
@@ -59,13 +47,13 @@ class WildflyAppServer implements AppServer {
     }
 
     Class<?> serverClass = getServerClass();
-    if(serverClass == null){
+    if (serverClass == null) {
       return null;
     }
     URL jarUrl = locator.getClassLocation(serverClass);
     Path jarPath = Paths.get(jarUrl.toURI());
     Path parent = jarPath.getParent();
-    if(parent == null){
+    if (parent == null) {
       return null;
     }
     return parent.resolve("standalone/deployments");

--- a/resource-providers/src/test/java/io/opentelemetry/resourceproviders/JettyServiceNameDetectorTest.java
+++ b/resource-providers/src/test/java/io/opentelemetry/resourceproviders/JettyServiceNameDetectorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opentelemetry.resourceproviders;
+
+import static io.opentelemetry.resourceproviders.JettyAppServer.parseJettyBase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JettyServiceNameDetectorTest {
+
+  @Test
+  void testJettyBase(@TempDir Path tempDir) throws IOException {
+    assertNull(parseJettyBase(null));
+    assertNull(parseJettyBase(""));
+    assertNull(parseJettyBase("jetty.base="));
+    assertEquals(tempDir.toString(), parseJettyBase("jetty.base=" + tempDir).toString());
+    assertEquals(
+        tempDir.toString(), parseJettyBase("foo jetty.base=" + tempDir + " bar").toString());
+
+    Path otherDir = tempDir.resolve("jetty test");
+    Files.createDirectory(otherDir);
+    assertEquals(otherDir.toString(), parseJettyBase("jetty.base=" + otherDir).toString());
+    assertEquals(
+        otherDir.toString(), parseJettyBase("foo jetty.base=" + otherDir + " bar").toString());
+  }
+}

--- a/resource-providers/src/test/java/io/opentelemetry/resourceproviders/JettyServiceNameDetectorTest.java
+++ b/resource-providers/src/test/java/io/opentelemetry/resourceproviders/JettyServiceNameDetectorTest.java
@@ -1,17 +1,6 @@
 /*
- * Copyright Splunk Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package io.opentelemetry.resourceproviders;
@@ -23,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 


### PR DESCRIPTION
This builds on #579 (and will be rebased when that merges). It adds the remaining service name detectors for various app servers.