### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,8 +182,8 @@ jobs:
                             v$VERSION \
                             opentelemetry-jmx-metrics.jar
 
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=jmx-metrics-version::$jmx_metrics_version"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "jmx-metrics-version=$jmx_metrics_version" >> $GITHUB_OUTPUT
 
   merge-change-log-to-main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:**

This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

CHANGELOG entry is not required

