### PR TITLE
Update handlers in jfr-streaming to match spec

### DIFF
--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -17,7 +17,6 @@ public final class Constants {
   public static final String PERCENTAGE = "%age";
   public static final String USER = "user";
   public static final String SYSTEM = "system";
-  public static final String MACHINE = "machine.total";
   public static final String G1 = "g1";
   public static final String TOTAL_USED = "total.used";
   public static final String EDEN_USED = "eden.used";

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -12,7 +12,7 @@ public final class Constants {
 
   public static final String ONE = "1";
   public static final String HERTZ = "Hz";
-  public static final String BYTES = "B";
+  public static final String BYTES = "By";
   public static final String MILLISECONDS = "ms";
   public static final String PERCENTAGE = "%age";
   public static final String USER = "user";
@@ -27,15 +27,26 @@ public final class Constants {
   public static final String REGION_COUNT = "region.count";
   public static final String COMMITTED = "committed";
   public static final String RESERVED = "reserved";
+  public static final String USED = "used";
+  public static final String COMMITTED_SIZE = "committedSize";
+
   public static final String DAEMON = "daemon";
+  public static final String HEAP = "heap";
 
   public static final String METRIC_NAME_NETWORK_BYTES = "process.runtime.jvm.network.io";
   public static final String METRIC_DESCRIPTION_NETWORK_BYTES = "Network read/write bytes";
   public static final String METRIC_NAME_NETWORK_DURATION = "process.runtime.jvm.network.time";
   public static final String METRIC_DESCRIPTION_NETWORK_DURATION = "Network read/write duration";
+  public static final String METRIC_NAME_COMMITTED = "process.runtime.jvm.memory.committed";
+  public static final String METRIC_DESCRIPTION_COMMITTED = "Measure of memory committed";
   public static final String NETWORK_MODE_READ = "read";
   public static final String NETWORK_MODE_WRITE = "write";
-
+  public static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.usage";
+  public static final String METRIC_NAME_MEMORY_AFTER =
+      "process.runtime.jvm.memory.usage_after_last_gc";
+  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
+  public static final String METRIC_DESCRIPTION_MEMORY_AFTER =
+      "Measure of memory used, as measured after the most recent garbage collection event on this pool";
   public static final String METRIC_NAME_MEMORY_ALLOCATION =
       "process.runtime.jvm.memory.allocation";
   public static final String METRIC_DESCRIPTION_MEMORY_ALLOCATION = "Allocation";
@@ -43,8 +54,10 @@ public final class Constants {
   public static final AttributeKey<String> ATTR_THREAD_NAME = AttributeKey.stringKey("thread.name");
   public static final AttributeKey<String> ATTR_ARENA_NAME = AttributeKey.stringKey("arena");
   public static final AttributeKey<String> ATTR_NETWORK_MODE = AttributeKey.stringKey("mode");
-  public static final AttributeKey<String> ATTR_USAGE = AttributeKey.stringKey("usage.type");
+  public static final AttributeKey<String> ATTR_TYPE = AttributeKey.stringKey("type");
+  public static final AttributeKey<String> ATTR_POOL = AttributeKey.stringKey("pool");
   public static final AttributeKey<Boolean> ATTR_DAEMON = AttributeKey.booleanKey(DAEMON);
   public static final String UNIT_CLASSES = "{classes}";
   public static final String UNIT_THREADS = "{threads}";
+  public static final String UNIT_UTILIZATION = "1";
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.contrib.jfr.metrics.internal.cpu;
 
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MACHINE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_UTILIZATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
@@ -59,7 +58,7 @@ public final class OverallCPULoadHandler implements RecordedEventHandler {
       process = ev.getDouble(JVM_USER) + ev.getDouble(JVM_SYSTEM);
     }
     if (ev.hasField(MACHINE_TOTAL)) {
-      machine = ev.getDouble(MACHINE);
+      machine = ev.getDouble(MACHINE_TOTAL);
     }
   }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/cpu/OverallCPULoadHandler.java
@@ -5,15 +5,10 @@
 
 package io.opentelemetry.contrib.jfr.metrics.internal.cpu;
 
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_USAGE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MACHINE;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.PERCENTAGE;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.SYSTEM;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.USER;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_UTILIZATION;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
@@ -21,18 +16,18 @@ import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class OverallCPULoadHandler implements RecordedEventHandler {
-  private static final String METRIC_NAME = "process.runtime.jvm.cpu.used";
-  private static final String METRIC_DESCRIPTION = "CPU Utilization";
+  private static final String METRIC_NAME_PROCESS = "process.runtime.jvm.cpu.utilization";
+  private static final String METRIC_NAME_MACHINE = "process.runtime.jvm.system.cpu.utilization";
+  private static final String METRIC_DESCRIPTION_PROCESS = "Recent CPU utilization for the process";
+  private static final String METRIC_DESCRIPTION_MACHINE =
+      "Recent CPU utilization for the whole system";
+
   private static final String EVENT_NAME = "jdk.CPULoad";
   private static final String JVM_USER = "jvmUser";
   private static final String JVM_SYSTEM = "jvmSystem";
   private static final String MACHINE_TOTAL = "machineTotal";
-
-  private static final Attributes ATTR_USER = Attributes.of(ATTR_USAGE, USER);
-  private static final Attributes ATTR_SYSTEM = Attributes.of(ATTR_USAGE, SYSTEM);
-  private static final Attributes ATTR_MACHINE = Attributes.of(ATTR_USAGE, MACHINE);
-
-  private DoubleHistogram histogram;
+  private volatile double process = 0;
+  private volatile double machine = 0;
 
   public OverallCPULoadHandler() {
     initializeMeter(defaultMeter());
@@ -40,24 +35,31 @@ public final class OverallCPULoadHandler implements RecordedEventHandler {
 
   @Override
   public void initializeMeter(Meter meter) {
-    histogram =
-        meter
-            .histogramBuilder(METRIC_NAME)
-            .setDescription(METRIC_DESCRIPTION)
-            .setUnit(PERCENTAGE)
-            .build();
+    meter
+        .gaugeBuilder(METRIC_NAME_PROCESS)
+        .setDescription(METRIC_DESCRIPTION_PROCESS)
+        .setUnit(UNIT_UTILIZATION)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(process);
+            });
+    meter
+        .gaugeBuilder(METRIC_NAME_MACHINE)
+        .setDescription(METRIC_DESCRIPTION_MACHINE)
+        .setUnit(UNIT_UTILIZATION)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(machine);
+            });
   }
 
   @Override
   public void accept(RecordedEvent ev) {
-    if (ev.hasField(JVM_USER)) {
-      histogram.record(ev.getDouble(JVM_USER), ATTR_USER);
-    }
-    if (ev.hasField(JVM_SYSTEM)) {
-      histogram.record(ev.getDouble(JVM_SYSTEM), ATTR_SYSTEM);
+    if (ev.hasField(JVM_USER) && ev.hasField(JVM_SYSTEM)) {
+      process = ev.getDouble(JVM_USER) + ev.getDouble(JVM_SYSTEM);
     }
     if (ev.hasField(MACHINE_TOTAL)) {
-      histogram.record(ev.getDouble(MACHINE_TOTAL), ATTR_MACHINE);
+      machine = ev.getDouble(MACHINE);
     }
   }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1HeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1HeapSummaryHandler.java
@@ -96,7 +96,7 @@ public final class G1HeapSummaryHandler implements RecordedEventHandler {
       logger.fine(String.format("G1 GC Event seen without GC ID: %s", ev));
       return;
     }
-    recordValues(ev, when != null ? when.equals(BEFORE) : false);
+    recordValues(ev, BEFORE.equals(when));
   }
 
   private void recordValues(RecordedEvent event, boolean before) {

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1HeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/G1HeapSummaryHandler.java
@@ -5,21 +5,19 @@
 
 package io.opentelemetry.contrib.jfr.metrics.internal.memory;
 
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_USAGE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_TYPE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.EDEN_SIZE;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.EDEN_SIZE_DELTA;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.EDEN_USED;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.REGION_COUNT;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.SURVIVOR_SIZE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.HEAP;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY_AFTER;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_AFTER;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Logger;
 import jdk.jfr.consumer.RecordedEvent;
 
@@ -30,24 +28,24 @@ import jdk.jfr.consumer.RecordedEvent;
 public final class G1HeapSummaryHandler implements RecordedEventHandler {
   private static final Logger logger = Logger.getLogger(G1HeapSummaryHandler.class.getName());
 
-  private static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.used";
-  private static final String METRIC_DESCRIPTION_MEMORY = "Heap utilization";
   private static final String EVENT_NAME = "jdk.G1HeapSummary";
   private static final String BEFORE = "Before GC";
   private static final String AFTER = "After GC";
   private static final String GC_ID = "gcId";
+  private static final String EDEN_USED_SIZE = "edenUsedSize";
+  private static final String SURVIVOR_USED_SIZE = "survivorUsedSize";
   private static final String WHEN = "when";
-  private static final Attributes ATTR_MEMORY_EDEN_USED = Attributes.of(ATTR_USAGE, EDEN_USED);
-  private static final Attributes ATTR_MEMORY_EDEN_SIZE = Attributes.of(ATTR_USAGE, EDEN_SIZE);
-  private static final Attributes ATTR_MEMORY_EDEN_SIZE_DELTA =
-      Attributes.of(ATTR_USAGE, EDEN_SIZE_DELTA);
-  private static final Attributes ATTR_MEMORY_SURVIVOR_SIZE =
-      Attributes.of(ATTR_USAGE, SURVIVOR_SIZE);
-  private static final Attributes ATTR_MEMORY_REGIONS = Attributes.of(ATTR_USAGE, REGION_COUNT);
+  private static final Attributes ATTR_MEMORY_EDEN_USED =
+      Attributes.of(ATTR_TYPE, HEAP, ATTR_POOL, "G1 Eden Space");
+  private static final Attributes ATTR_MEMORY_SURVIVOR_USED =
+      Attributes.of(ATTR_TYPE, HEAP, ATTR_POOL, "G1 Survivor Space");
+  //  private static final Attributes ATTR_MEMORY_OLD_USED =
+  //      Attributes.of(ATTR_TYPE, HEAP, ATTR_POOL, "G1 Old Gen"); // TODO needs jdk JFR support
 
-  private final Map<Long, RecordedEvent> awaitingPairs = new HashMap<>();
-
-  private LongHistogram memoryHistogram;
+  private volatile long usageEden = 0;
+  private volatile long usageEdenAfter = 0;
+  private volatile long usageSurvivor = 0;
+  private volatile long usageSurvivorAfter = 0;
 
   public G1HeapSummaryHandler() {
     initializeMeter(defaultMeter());
@@ -55,13 +53,24 @@ public final class G1HeapSummaryHandler implements RecordedEventHandler {
 
   @Override
   public void initializeMeter(Meter meter) {
-    memoryHistogram =
-        meter
-            .histogramBuilder(METRIC_NAME_MEMORY)
-            .setDescription(METRIC_DESCRIPTION_MEMORY)
-            .setUnit(BYTES)
-            .ofLongs()
-            .build();
+    meter
+        .upDownCounterBuilder(METRIC_NAME_MEMORY)
+        .setDescription(METRIC_DESCRIPTION_MEMORY)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(usageEden, ATTR_MEMORY_EDEN_USED);
+              measurement.record(usageSurvivor, ATTR_MEMORY_SURVIVOR_USED);
+            });
+    meter
+        .upDownCounterBuilder(METRIC_NAME_MEMORY_AFTER)
+        .setDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(usageEdenAfter, ATTR_MEMORY_EDEN_USED);
+              measurement.record(usageSurvivorAfter, ATTR_MEMORY_SURVIVOR_USED);
+            });
   }
 
   @Override
@@ -87,37 +96,24 @@ public final class G1HeapSummaryHandler implements RecordedEventHandler {
       logger.fine(String.format("G1 GC Event seen without GC ID: %s", ev));
       return;
     }
-    long gcId = ev.getLong(GC_ID);
-
-    var pair = awaitingPairs.remove(gcId);
-    if (pair == null) {
-      awaitingPairs.put(gcId, ev);
-    } else {
-      if (when.equals(BEFORE)) {
-        recordValues(ev, pair);
-      } else { //  i.e. when.equals(AFTER)
-        recordValues(pair, ev);
-      }
-    }
+    recordValues(ev, when != null ? when.equals(BEFORE) : false);
   }
 
-  private void recordValues(RecordedEvent before, RecordedEvent after) {
-    if (after.hasField("edenUsedSize")) {
-      memoryHistogram.record(after.getLong("edenUsedSize"), ATTR_MEMORY_EDEN_USED);
-      if (before.hasField("edenUsedSize")) {
-        memoryHistogram.record(
-            after.getLong("edenUsedSize") - before.getLong("edenUsedSize"),
-            ATTR_MEMORY_EDEN_SIZE_DELTA);
+  private void recordValues(RecordedEvent event, boolean before) {
+    if (event.hasField(EDEN_USED_SIZE)) {
+      if (before) {
+        usageEden = event.getLong(EDEN_USED_SIZE);
+      } else {
+        usageEdenAfter = event.getLong(EDEN_USED_SIZE);
       }
     }
-    if (after.hasField("edenTotalSize")) {
-      memoryHistogram.record(after.getLong("edenTotalSize"), ATTR_MEMORY_EDEN_SIZE);
-    }
-    if (after.hasField("survivorUsedSize")) {
-      memoryHistogram.record(after.getLong("survivorUsedSize"), ATTR_MEMORY_SURVIVOR_SIZE);
-    }
-    if (after.hasField("numberOfRegions")) {
-      memoryHistogram.record(after.getLong("numberOfRegions"), ATTR_MEMORY_REGIONS);
+
+    if (event.hasField(SURVIVOR_USED_SIZE)) {
+      if (before) {
+        usageSurvivor = event.getLong(SURVIVOR_USED_SIZE);
+      } else {
+        usageSurvivorAfter = event.getLong(SURVIVOR_USED_SIZE);
+      }
     }
   }
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
@@ -5,32 +5,29 @@
 
 package io.opentelemetry.contrib.jfr.metrics.internal.memory;
 
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_USAGE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_TYPE;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.COMMITTED;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.RESERVED;
-import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.TOTAL_USED;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.COMMITTED_SIZE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.HEAP;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_COMMITTED;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY_AFTER;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_COMMITTED;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_AFTER;
 import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.DoubleHistogram;
-import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.contrib.jfr.metrics.internal.DurationUtil;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedObject;
 
 /** This class handles GCHeapSummary JFR events. For GC purposes they come in pairs. */
 public final class GCHeapSummaryHandler implements RecordedEventHandler {
-  private static final String METRIC_NAME_DURATION = "process.runtime.jvm.gc.time";
-  private static final String METRIC_DESCRIPTION_DURATION = "GC Duration";
-  private static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.used";
-  private static final String METRIC_DESCRIPTION_MEMORY = "Heap utilization";
   private static final String EVENT_NAME = "jdk.GCHeapSummary";
   private static final String BEFORE = "Before GC";
   private static final String AFTER = "After GC";
@@ -38,16 +35,12 @@ public final class GCHeapSummaryHandler implements RecordedEventHandler {
   private static final String WHEN = "when";
   private static final String HEAP_USED = "heapUsed";
   private static final String HEAP_SPACE = "heapSpace";
-  private static final String COMMITTED_SIZE = "committedSize";
-  private static final String RESERVED_SIZE = "reservedSize";
-  private static final Attributes ATTR_MEMORY_USED = Attributes.of(ATTR_USAGE, TOTAL_USED);
-  private static final Attributes ATTR_MEMORY_COMMITTED = Attributes.of(ATTR_USAGE, COMMITTED);
-  private static final Attributes ATTR_MEMORY_RESERVED = Attributes.of(ATTR_USAGE, RESERVED);
+  private static final Attributes ATTR =
+      Attributes.of(ATTR_TYPE, HEAP, ATTR_POOL, "Java heap space");
 
-  private final Map<Long, RecordedEvent> awaitingPairs = new HashMap<>();
-
-  private DoubleHistogram durationHistogram;
-  private LongHistogram memoryHistogram;
+  private volatile long usageBefore = 0;
+  private volatile long usageAfter = 0;
+  private volatile long committedSize = 0;
 
   public GCHeapSummaryHandler() {
     initializeMeter(defaultMeter());
@@ -55,19 +48,30 @@ public final class GCHeapSummaryHandler implements RecordedEventHandler {
 
   @Override
   public void initializeMeter(Meter meter) {
-    durationHistogram =
-        meter
-            .histogramBuilder(METRIC_NAME_DURATION)
-            .setDescription(METRIC_DESCRIPTION_DURATION)
-            .setUnit(MILLISECONDS)
-            .build();
-    memoryHistogram =
-        meter
-            .histogramBuilder(METRIC_NAME_MEMORY)
-            .setDescription(METRIC_DESCRIPTION_MEMORY)
-            .setUnit(BYTES)
-            .ofLongs()
-            .build();
+    meter
+        .upDownCounterBuilder(METRIC_NAME_MEMORY)
+        .setDescription(METRIC_DESCRIPTION_MEMORY)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(usageBefore, ATTR);
+            });
+    meter
+        .upDownCounterBuilder(METRIC_NAME_MEMORY_AFTER)
+        .setDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(usageAfter, ATTR);
+            });
+    meter
+        .upDownCounterBuilder(METRIC_NAME_COMMITTED)
+        .setDescription(METRIC_DESCRIPTION_COMMITTED)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(committedSize, ATTR);
+            });
   }
 
   @Override
@@ -90,38 +94,31 @@ public final class GCHeapSummaryHandler implements RecordedEventHandler {
     if (!ev.hasField(GC_ID)) {
       return;
     }
-    long gcId = ev.getLong(GC_ID);
+    recordValues(ev, when != null ? when.equals(BEFORE) : false);
+  }
 
-    var pair = awaitingPairs.get(gcId);
-    if (pair == null) {
-      awaitingPairs.put(gcId, ev);
-    } else {
-      awaitingPairs.remove(gcId);
-      if (when != null && when.equals(BEFORE)) {
-        recordValues(ev, pair);
-      } else { //  i.e. when.equals(AFTER)
-        recordValues(pair, ev);
+  private void recordValues(RecordedEvent event, boolean before) {
+
+    if (event.hasField(HEAP_USED)) {
+      if (before) {
+        usageBefore = event.getLong(HEAP_USED);
+      } else {
+        usageAfter = event.getLong(HEAP_USED);
+      }
+    }
+    if (event.hasField(HEAP_SPACE)) {
+      Object heapSpaceValue = event.getValue(HEAP_SPACE);
+      if (heapSpaceValue instanceof RecordedObject) {
+        RecordedObject heapSpace = (RecordedObject) heapSpaceValue;
+        if (heapSpace.hasField(COMMITTED_SIZE)) {
+          committedSize = heapSpace.getLong(COMMITTED_SIZE);
+        }
       }
     }
   }
 
-  private void recordValues(RecordedEvent before, RecordedEvent after) {
-    durationHistogram.record(
-        DurationUtil.toMillis(Duration.between(before.getStartTime(), after.getStartTime())));
-    if (after.hasField(HEAP_USED)) {
-      memoryHistogram.record(after.getLong(HEAP_USED), ATTR_MEMORY_USED);
-    }
-    if (after.hasField(HEAP_SPACE)) {
-      Object heapSpaceValue = after.getValue(HEAP_SPACE);
-      if (heapSpaceValue instanceof RecordedObject) {
-        RecordedObject heapSpace = (RecordedObject) heapSpaceValue;
-        if (heapSpace.hasField(COMMITTED_SIZE)) {
-          memoryHistogram.record(heapSpace.getLong(COMMITTED_SIZE), ATTR_MEMORY_COMMITTED);
-        }
-        if (heapSpace.hasField(RESERVED_SIZE)) {
-          memoryHistogram.record(heapSpace.getLong(RESERVED_SIZE), ATTR_MEMORY_RESERVED);
-        }
-      }
-    }
+  @Override
+  public Optional<Duration> getPollingDuration() {
+    return Optional.of(Duration.ofSeconds(1));
   }
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/GCHeapSummaryHandler.java
@@ -94,7 +94,7 @@ public final class GCHeapSummaryHandler implements RecordedEventHandler {
     if (!ev.hasField(GC_ID)) {
       return;
     }
-    recordValues(ev, when != null ? when.equals(BEFORE) : false);
+    recordValues(ev, BEFORE.equals(when));
   }
 
   private void recordValues(RecordedEvent event, boolean before) {

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ParallelHeapSummaryHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/memory/ParallelHeapSummaryHandler.java
@@ -119,7 +119,7 @@ public final class ParallelHeapSummaryHandler implements RecordedEventHandler {
       logger.fine(String.format("Parallel GC Event seen without GC ID: %s", ev));
       return;
     }
-    recordValues(ev, when != null ? when.equals(BEFORE) : false);
+    recordValues(ev, BEFORE.equals(when));
   }
 
   private void recordValues(RecordedEvent event, boolean before) {

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrCPULockTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrCPULockTest.java
@@ -9,10 +9,10 @@ import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECON
 
 import org.junit.jupiter.api.Test;
 
-public class JfrCPUTest extends AbstractMetricsTest {
+public class JfrCPULockTest extends AbstractMetricsTest {
 
   @Test
-  public void shouldHaveGcAndLockEvents() throws Exception {
+  public void shouldHaveLockEvents() throws Exception {
     // This should generate some events
     System.gc();
     synchronized (this) {
@@ -23,11 +23,6 @@ public class JfrCPUTest extends AbstractMetricsTest {
         metric ->
             metric
                 .hasName("process.runtime.jvm.cpu.longlock")
-                .hasUnit(MILLISECONDS)
-                .hasHistogramSatisfying(histogram -> {}),
-        metric ->
-            metric
-                .hasName("process.runtime.jvm.gc.time")
                 .hasUnit(MILLISECONDS)
                 .hasHistogramSatisfying(histogram -> {}));
   }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrGCHeapSummaryHandlerTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrGCHeapSummaryHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_TYPE;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.HEAP;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_COMMITTED;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_MEMORY_AFTER;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_COMMITTED;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_MEMORY_AFTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+
+public class JfrGCHeapSummaryHandlerTest extends AbstractMetricsTest {
+
+  static class AttributeCheck implements ThrowingConsumer<MetricData> {
+    @Override
+    public void acceptThrows(MetricData metricData) throws Throwable {
+      SumData<?> sumData = metricData.getLongSumData();
+      assertThat(sumData.getPoints())
+          .map(LongPointData.class::cast)
+          .anyMatch(
+              p ->
+                  p.getAttributes().get(ATTR_TYPE).equals(HEAP)
+                      && p.getAttributes().get(ATTR_POOL).equals("Java heap space"));
+    }
+  }
+
+  @Test
+  public void shouldHaveGCEvents() throws Exception {
+    System.gc();
+
+    waitAndAssertMetrics(
+        metric ->
+            metric
+                .hasName(METRIC_NAME_MEMORY)
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_MEMORY)
+                .satisfies(new AttributeCheck()),
+        metric ->
+            metric
+                .hasName(METRIC_NAME_MEMORY_AFTER)
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
+                .satisfies(new AttributeCheck()),
+        metric ->
+            metric
+                .hasName(METRIC_NAME_COMMITTED)
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_COMMITTED)
+                .satisfies(new AttributeCheck()));
+  }
+}

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrOverallCPULoadHandlerTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrOverallCPULoadHandlerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_UTILIZATION;
+
+import org.junit.jupiter.api.Test;
+
+public class JfrOverallCPULoadHandlerTest extends AbstractMetricsTest {
+
+  @Test
+  public void shouldHaveCPULoadEvents() throws Exception {
+    waitAndAssertMetrics(
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.cpu.utilization")
+                .hasUnit(UNIT_UTILIZATION)
+                .hasDescription("Recent CPU utilization for the process")
+                .hasDoubleGaugeSatisfying(gauge -> {}),
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.system.cpu.utilization")
+                .hasUnit(UNIT_UTILIZATION)
+                .hasDescription("Recent CPU utilization for the whole system")
+                .hasDoubleGaugeSatisfying(gauge -> {}));
+  }
+}


### PR DESCRIPTION
**Description:**
These changes try to update the existing JFR streaming handlers to match the [specification here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/runtime-environment-metrics.md#jvm-metrics).  I think this is needed because it seems as though the handler implementations and the spec have fallen a bit out of sync. 

**Testing:**

Tests were adjusted accordingly to match the updated handler implementations.

**Outstanding items and questions:**

Tests for specific GC implementations (G1, parallel) have been omitted. I am not sure of a good way to guarantee a specific implementation is used for specific tests. 

None of the metrics `process.runtime.jvm.memory.*` will include the`Attribute` pair  (`type`,`"nonheap"`).  Question: Doesn't non-heap memory fall under the `process.runtime.jvm.buffer.*` metrics? 

Not all of the pool names of the metrics `process.runtime.jvm.memory.*` are covered yet. This is in part because we require JDK JFR support to actually emit data for missing pools in JFR events, and partly because more handlers for other GC implementations need to be written in the future. 


