### PR TITLE
Add buffer handlers and implement buffer metrics

### DIFF
--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
@@ -7,8 +7,6 @@ package io.opentelemetry.contrib.jfr.metrics;
 
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.G1GarbageCollectionHandler;
-import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.OldGarbageCollectionHandler;
-import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.YoungGarbageCollectionHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.ThreadGrouper;
 import io.opentelemetry.contrib.jfr.metrics.internal.buffer.DirectBufferStatisticsHandler;
@@ -17,11 +15,8 @@ import io.opentelemetry.contrib.jfr.metrics.internal.container.ContainerConfigur
 import io.opentelemetry.contrib.jfr.metrics.internal.cpu.ContextSwitchRateHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.cpu.LongLockHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.cpu.OverallCPULoadHandler;
-import io.opentelemetry.contrib.jfr.metrics.internal.memory.CodeCacheConfigurationHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.memory.G1HeapSummaryHandler;
-import io.opentelemetry.contrib.jfr.metrics.internal.memory.GCHeapConfigurationHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.memory.GCHeapSummaryHandler;
-import io.opentelemetry.contrib.jfr.metrics.internal.memory.MetaspaceSummaryHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.memory.ObjectAllocationInNewTLABHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.memory.ObjectAllocationOutsideTLABHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.memory.ParallelHeapSummaryHandler;
@@ -85,8 +80,6 @@ public final class HandlerRegistry {
             new ClassesLoadedHandler(),
             new DirectBufferStatisticsHandler());
     handlers.addAll(basicHandlers);
-
-
 
     var meter =
         meterProvider

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.jfr.metrics;
 
 import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.G1GarbageCollectionHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.ThreadGrouper;
 import io.opentelemetry.contrib.jfr.metrics.internal.buffer.DirectBufferStatisticsHandler;
@@ -30,18 +29,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public final class HandlerRegistry {
+final class HandlerRegistry {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.contrib.jfr";
   private static final String INSTRUMENTATION_VERSION = "1.7.0-SNAPSHOT";
 
   private final List<RecordedEventHandler> mappers;
 
-  public static HashSet<String> garbageCollectors = new HashSet<String>();
-
   private static final Map<String, List<Supplier<RecordedEventHandler>>> HANDLERS_PER_GC =
       Map.of(
           "G1",
-          List.of(G1HeapSummaryHandler::new, G1GarbageCollectionHandler::new),
+          List.of(G1HeapSummaryHandler::new),
           "Parallel",
           List.of(ParallelHeapSummaryHandler::new));
 
@@ -54,7 +51,6 @@ public final class HandlerRegistry {
     var seen = new HashSet<String>();
     for (var bean : ManagementFactory.getGarbageCollectorMXBeans()) {
       var name = bean.getName();
-      garbageCollectors.add(name);
       for (var gcType : HANDLERS_PER_GC.keySet()) {
         if (name.contains(gcType)
             && !seen.contains(gcType)

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -26,11 +26,19 @@ public final class Constants {
   public static final String REGION_COUNT = "region.count";
   public static final String COMMITTED = "committed";
   public static final String RESERVED = "reserved";
+  public static final String INITIAL_SIZE = "initialSize";
   public static final String USED = "used";
   public static final String COMMITTED_SIZE = "committedSize";
+  public static final String RESERVED_SIZE = "reservedSize";
 
   public static final String DAEMON = "daemon";
   public static final String HEAP = "heap";
+  public static final String NON_HEAP = "nonheap";
+  public static final String NETWORK_MODE_READ = "read";
+  public static final String NETWORK_MODE_WRITE = "write";
+  public static final String DURATION = "duration";
+  public static final String END_OF_MINOR_GC = "end of minor GC";
+  public static final String END_OF_MAJOR_GC = "end of major GC";
 
   public static final String METRIC_NAME_NETWORK_BYTES = "process.runtime.jvm.network.io";
   public static final String METRIC_DESCRIPTION_NETWORK_BYTES = "Network read/write bytes";
@@ -38,25 +46,33 @@ public final class Constants {
   public static final String METRIC_DESCRIPTION_NETWORK_DURATION = "Network read/write duration";
   public static final String METRIC_NAME_COMMITTED = "process.runtime.jvm.memory.committed";
   public static final String METRIC_DESCRIPTION_COMMITTED = "Measure of memory committed";
-  public static final String NETWORK_MODE_READ = "read";
-  public static final String NETWORK_MODE_WRITE = "write";
   public static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.usage";
+  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_NAME_MEMORY_AFTER =
       "process.runtime.jvm.memory.usage_after_last_gc";
-  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_DESCRIPTION_MEMORY_AFTER =
       "Measure of memory used, as measured after the most recent garbage collection event on this pool";
   public static final String METRIC_NAME_MEMORY_ALLOCATION =
       "process.runtime.jvm.memory.allocation";
   public static final String METRIC_DESCRIPTION_MEMORY_ALLOCATION = "Allocation";
+  public static final String METRIC_NAME_MEMORY_INIT = "process.runtime.jvm.memory.init";
+  public static final String METRIC_DESCRIPTION_MEMORY_INIT = "Measure of initial memory requested";
+  public static final String METRIC_NAME_MEMORY_LIMIT = "process.runtime.jvm.memory.limit";
+  public static final String METRIC_DESCRIPTION_MEMORY_LIMIT = "Measure of max obtainable memory";
+  public static final String METRIC_NAME_GC_DURATION = "process.runtime.jvm.gc.duration";
+  public static final String METRIC_DESCRIPTION_GC_DURATION =
+      "Duration of JVM garbage collection actions";
 
   public static final AttributeKey<String> ATTR_THREAD_NAME = AttributeKey.stringKey("thread.name");
   public static final AttributeKey<String> ATTR_ARENA_NAME = AttributeKey.stringKey("arena");
   public static final AttributeKey<String> ATTR_NETWORK_MODE = AttributeKey.stringKey("mode");
   public static final AttributeKey<String> ATTR_TYPE = AttributeKey.stringKey("type");
   public static final AttributeKey<String> ATTR_POOL = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_GC = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_ACTION = AttributeKey.stringKey("action");
   public static final AttributeKey<Boolean> ATTR_DAEMON = AttributeKey.booleanKey(DAEMON);
   public static final String UNIT_CLASSES = "{classes}";
   public static final String UNIT_THREADS = "{threads}";
+  public static final String UNIT_BUFFERS = "{buffers}";
   public static final String UNIT_UTILIZATION = "1";
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/buffer/DirectBufferStatisticsHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/buffer/DirectBufferStatisticsHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics.internal.buffer;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_BUFFERS;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+public final class DirectBufferStatisticsHandler implements RecordedEventHandler {
+  private static final String METRIC_NAME_USAGE = "process.runtime.jvm.buffer.usage";
+  private static final String METRIC_NAME_LIMIT = "process.runtime.jvm.buffer.limit";
+  private static final String METRIC_NAME_COUNT = "process.runtime.jvm.buffer.count";
+  private static final String METRIC_DESCRIPTION_USAGE = "Measure of memory used by buffers";
+  private static final String METRIC_DESCRIPTION_LIMIT =
+      "Measure of total memory capacity of buffers";
+  private static final String METRIC_DESCRIPTION_COUNT = "Number of buffers in the pool";
+  private static final String COUNT = "count";
+  private static final String MAX_CAPACITY = "maxCapacity";
+  private static final String MEMORY_USED = "memoryUsed";
+
+  private static final String EVENT_NAME = "jdk.DirectBufferStatistics";
+  private static final Attributes ATTR = Attributes.of(ATTR_POOL, "direct");
+
+  private volatile long usage = 0;
+  private volatile long limit = 0;
+  private volatile long count = 0;
+
+  public DirectBufferStatisticsHandler() {
+    initializeMeter(defaultMeter());
+  }
+
+  @Override
+  public void accept(RecordedEvent ev) {
+    if (ev.hasField(COUNT)) {
+      count = ev.getLong(COUNT);
+    }
+    if (ev.hasField(MAX_CAPACITY)) {
+      limit = ev.getLong(MAX_CAPACITY);
+    }
+    if (ev.hasField(MEMORY_USED)) {
+      usage = ev.getLong(MEMORY_USED);
+    }
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void initializeMeter(Meter meter) {
+    meter
+        .upDownCounterBuilder(METRIC_NAME_USAGE)
+        .setDescription(METRIC_DESCRIPTION_USAGE)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(usage, ATTR);
+            });
+    meter
+        .upDownCounterBuilder(METRIC_NAME_LIMIT)
+        .setDescription(METRIC_DESCRIPTION_LIMIT)
+        .setUnit(BYTES)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(limit, ATTR);
+            });
+    meter
+        .upDownCounterBuilder(METRIC_NAME_COUNT)
+        .setDescription(METRIC_DESCRIPTION_COUNT)
+        .setUnit(UNIT_BUFFERS)
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(count, ATTR);
+            });
+  }
+
+  @Override
+  public Optional<Duration> getPollingDuration() {
+    return Optional.of(Duration.ofSeconds(1));
+  }
+}

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/buffer/DirectBufferStatisticsHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/buffer/DirectBufferStatisticsHandler.java
@@ -80,10 +80,7 @@ public final class DirectBufferStatisticsHandler implements RecordedEventHandler
         .upDownCounterBuilder(METRIC_NAME_COUNT)
         .setDescription(METRIC_DESCRIPTION_COUNT)
         .setUnit(UNIT_BUFFERS)
-        .buildWithCallback(
-            measurement -> {
-              measurement.record(count, ATTR);
-            });
+        .buildWithCallback(measurement -> measurement.record(count, ATTR));
   }
 
   @Override

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
@@ -8,11 +8,11 @@ package io.opentelemetry.contrib.jfr.metrics;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
 import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_BUFFERS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class BufferMetricTest extends AbstractMetricsTest {
@@ -29,7 +29,7 @@ class BufferMetricTest extends AbstractMetricsTest {
    * be added for those missing pools.
    */
   @Test
-  void shouldHaveJfrLoadedClassesCountEvents() throws Exception {
+  void shouldHaveJfrLoadedClassesCountEvents() {
     ByteBuffer buffer = ByteBuffer.allocateDirect(10000);
     buffer.put("test".getBytes(StandardCharsets.UTF_8));
 
@@ -45,11 +45,9 @@ class BufferMetricTest extends AbstractMetricsTest {
                             point ->
                                 point.satisfies(
                                     pointData -> {
-                                      Assertions.assertTrue(pointData.getValue() > 0);
-                                      Assertions.assertTrue(
-                                          pointData
-                                              .getAttributes()
-                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                      assertThat(pointData.getValue()).isGreaterThan(0);
+                                      assertThat(pointData.getAttributes())
+                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
                                     }))),
         metric ->
             metric
@@ -62,11 +60,9 @@ class BufferMetricTest extends AbstractMetricsTest {
                             point ->
                                 point.satisfies(
                                     pointData -> {
-                                      Assertions.assertTrue(pointData.getValue() > 0);
-                                      Assertions.assertTrue(
-                                          pointData
-                                              .getAttributes()
-                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                      assertThat(pointData.getValue()).isGreaterThan(0);
+                                      assertThat(pointData.getAttributes())
+                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
                                     }))),
         metric ->
             metric
@@ -79,11 +75,9 @@ class BufferMetricTest extends AbstractMetricsTest {
                             point ->
                                 point.satisfies(
                                     pointData -> {
-                                      Assertions.assertTrue(pointData.getValue() > 0);
-                                      Assertions.assertTrue(
-                                          pointData
-                                              .getAttributes()
-                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                      assertThat(pointData.getValue()).isGreaterThan(0);
+                                      assertThat(pointData.getAttributes())
+                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
                                     }))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
@@ -25,9 +25,8 @@ class BufferMetricTest extends AbstractMetricsTest {
    * Semantic Conventions.
    *
    * <p>Currently JFR only has support for the "direct" buffer pool. The "mapped" and "mapped -
-   * 'non-volatile memory'" pools do not have corresponding JFR events. TODO: In the future, events
-   * should be added for these, if there is a need to capture their data in the
-   * process.runtime.jvm.buffer.count metric.
+   * 'non-volatile memory'" pools do not have corresponding JFR events. In the future, events should
+   * be added for those missing pools.
    */
   @Test
   void shouldHaveJfrLoadedClassesCountEvents() throws Exception {

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/BufferMetricTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_POOL;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.BYTES;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.UNIT_BUFFERS;
+
+import io.opentelemetry.api.common.Attributes;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BufferMetricTest extends AbstractMetricsTest {
+
+  /**
+   * This is a basic test that allocates some buffers and tests to make sure the resulting JFR event
+   * was handled and turned into the expected metrics.
+   *
+   * <p>This test handles all 3 buffer related metrics defined in the OpenTelemetry Java runtime
+   * Semantic Conventions.
+   *
+   * <p>Currently JFR only has support for the "direct" buffer pool. The "mapped" and "mapped -
+   * 'non-volatile memory'" pools do not have corresponding JFR events. TODO: In the future, events
+   * should be added for these, if there is a need to capture their data in the
+   * process.runtime.jvm.buffer.count metric.
+   */
+  @Test
+  void shouldHaveJfrLoadedClassesCountEvents() throws Exception {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10000);
+    buffer.put("test".getBytes(StandardCharsets.UTF_8));
+
+    waitAndAssertMetrics(
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.buffer.count")
+                .hasDescription("Number of buffers in the pool")
+                .hasUnit(UNIT_BUFFERS)
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point.satisfies(
+                                    pointData -> {
+                                      Assertions.assertTrue(pointData.getValue() > 0);
+                                      Assertions.assertTrue(
+                                          pointData
+                                              .getAttributes()
+                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                    }))),
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.buffer.limit")
+                .hasDescription("Measure of total memory capacity of buffers")
+                .hasUnit(BYTES)
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point.satisfies(
+                                    pointData -> {
+                                      Assertions.assertTrue(pointData.getValue() > 0);
+                                      Assertions.assertTrue(
+                                          pointData
+                                              .getAttributes()
+                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                    }))),
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.buffer.usage")
+                .hasDescription("Measure of memory used by buffers")
+                .hasUnit(BYTES)
+                .hasLongSumSatisfying(
+                    sum ->
+                        sum.hasPointsSatisfying(
+                            point ->
+                                point.satisfies(
+                                    pointData -> {
+                                      Assertions.assertTrue(pointData.getValue() > 0);
+                                      Assertions.assertTrue(
+                                          pointData
+                                              .getAttributes()
+                                              .equals(Attributes.of(ATTR_POOL, "direct")));
+                                    }))));
+  }
+}


### PR DESCRIPTION
**Description:**
Add handlers for buffer metrics `process.runtime.jvm.buffer.limit`, `process.runtime.jvm.buffer.count`, and `process.runtime.jvm.buffer.usage`.

This was a part of a larger PR here:  https://github.com/open-telemetry/opentelemetry-java-contrib/pull/644.

`jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java` has been kept the same as it was in the larger PR because it's used in all of the smaller constituent PRs. This will hopefully also avoid some conflicts as the PRs are sequentially merged. As a result, there are some constants that are defined, but not used in this PR.