### PR TITLE
cpu handlers

### DIFF
--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -26,11 +26,19 @@ public final class Constants {
   public static final String REGION_COUNT = "region.count";
   public static final String COMMITTED = "committed";
   public static final String RESERVED = "reserved";
+  public static final String INITIAL_SIZE = "initialSize";
   public static final String USED = "used";
   public static final String COMMITTED_SIZE = "committedSize";
+  public static final String RESERVED_SIZE = "reservedSize";
 
   public static final String DAEMON = "daemon";
   public static final String HEAP = "heap";
+  public static final String NON_HEAP = "nonheap";
+  public static final String NETWORK_MODE_READ = "read";
+  public static final String NETWORK_MODE_WRITE = "write";
+  public static final String DURATION = "duration";
+  public static final String END_OF_MINOR_GC = "end of minor GC";
+  public static final String END_OF_MAJOR_GC = "end of major GC";
 
   public static final String METRIC_NAME_NETWORK_BYTES = "process.runtime.jvm.network.io";
   public static final String METRIC_DESCRIPTION_NETWORK_BYTES = "Network read/write bytes";
@@ -38,25 +46,33 @@ public final class Constants {
   public static final String METRIC_DESCRIPTION_NETWORK_DURATION = "Network read/write duration";
   public static final String METRIC_NAME_COMMITTED = "process.runtime.jvm.memory.committed";
   public static final String METRIC_DESCRIPTION_COMMITTED = "Measure of memory committed";
-  public static final String NETWORK_MODE_READ = "read";
-  public static final String NETWORK_MODE_WRITE = "write";
   public static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.usage";
+  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_NAME_MEMORY_AFTER =
       "process.runtime.jvm.memory.usage_after_last_gc";
-  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_DESCRIPTION_MEMORY_AFTER =
       "Measure of memory used, as measured after the most recent garbage collection event on this pool";
   public static final String METRIC_NAME_MEMORY_ALLOCATION =
       "process.runtime.jvm.memory.allocation";
   public static final String METRIC_DESCRIPTION_MEMORY_ALLOCATION = "Allocation";
+  public static final String METRIC_NAME_MEMORY_INIT = "process.runtime.jvm.memory.init";
+  public static final String METRIC_DESCRIPTION_MEMORY_INIT = "Measure of initial memory requested";
+  public static final String METRIC_NAME_MEMORY_LIMIT = "process.runtime.jvm.memory.limit";
+  public static final String METRIC_DESCRIPTION_MEMORY_LIMIT = "Measure of max obtainable memory";
+  public static final String METRIC_NAME_GC_DURATION = "process.runtime.jvm.gc.duration";
+  public static final String METRIC_DESCRIPTION_GC_DURATION =
+      "Duration of JVM garbage collection actions";
 
   public static final AttributeKey<String> ATTR_THREAD_NAME = AttributeKey.stringKey("thread.name");
   public static final AttributeKey<String> ATTR_ARENA_NAME = AttributeKey.stringKey("arena");
   public static final AttributeKey<String> ATTR_NETWORK_MODE = AttributeKey.stringKey("mode");
   public static final AttributeKey<String> ATTR_TYPE = AttributeKey.stringKey("type");
   public static final AttributeKey<String> ATTR_POOL = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_GC = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_ACTION = AttributeKey.stringKey("action");
   public static final AttributeKey<Boolean> ATTR_DAEMON = AttributeKey.booleanKey(DAEMON);
   public static final String UNIT_CLASSES = "{classes}";
   public static final String UNIT_THREADS = "{threads}";
+  public static final String UNIT_BUFFERS = "{buffers}";
   public static final String UNIT_UTILIZATION = "1";
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrOverallCPULoadHandlerTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/JfrOverallCPULoadHandlerTest.java
@@ -25,6 +25,12 @@ public class JfrOverallCPULoadHandlerTest extends AbstractMetricsTest {
                 .hasName("process.runtime.jvm.system.cpu.utilization")
                 .hasUnit(UNIT_UTILIZATION)
                 .hasDescription("Recent CPU utilization for the whole system")
+                .hasDoubleGaugeSatisfying(gauge -> {}),
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.system.cpu.load_1m")
+                .hasUnit(UNIT_UTILIZATION)
+                .hasDescription("Average CPU load of the whole system for the last minute")
                 .hasDoubleGaugeSatisfying(gauge -> {}));
   }
 }


### PR DESCRIPTION
**Description:**

This PR updates the existing CPU event handler to also implement the metric `process.runtime.jvm.system.cpu.load_1m`. 

This was a part of a [larger PR here](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/644). 

`jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java` has been kept the same as it was in the larger PR because it is used in all of the smaller constituent PRs.