### PR TITLE
Implement GC duration metric

### DIFF
--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
@@ -26,10 +26,9 @@ import io.opentelemetry.contrib.jfr.metrics.internal.network.NetworkWriteHandler
 import io.opentelemetry.contrib.jfr.metrics.internal.threads.ThreadCountHandler;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
-public final class HandlerRegistry {
+final class HandlerRegistry {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.contrib.jfr";
   private static final String INSTRUMENTATION_VERSION = "1.7.0-SNAPSHOT";
 
@@ -40,34 +39,37 @@ public final class HandlerRegistry {
   }
 
   static HandlerRegistry createDefault(MeterProvider meterProvider) {
-    HashSet<String> garbageCollectors = new HashSet<>();
-
     var handlers = new ArrayList<RecordedEventHandler>();
-    // Must gather all GC names before creating GC handlers that require the list of active GC names
-    for (var bean : ManagementFactory.getGarbageCollectorMXBeans()) {
-      garbageCollectors.add(bean.getName());
-    }
 
-    // Configure GC specific handlers
-    for (var name : garbageCollectors) {
+    for (var bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      var name = bean.getName();
       switch (name) {
         case "G1 Young Generation":
-          {
-            handlers.add(new G1HeapSummaryHandler());
-            handlers.add(new G1GarbageCollectionHandler());
-            break;
-          }
+          handlers.add(new G1HeapSummaryHandler());
+          handlers.add(new G1GarbageCollectionHandler());
+          break;
+
         case "Copy":
-          {
-            handlers.add(new YoungGarbageCollectionHandler(garbageCollectors));
-            break;
-          }
+          handlers.add(new YoungGarbageCollectionHandler(name));
+          break;
+
         case "PS Scavenge":
-          {
-            handlers.add(new YoungGarbageCollectionHandler(garbageCollectors));
-            handlers.add(new ParallelHeapSummaryHandler());
-            break;
-          }
+          handlers.add(new YoungGarbageCollectionHandler(name));
+          handlers.add(new ParallelHeapSummaryHandler());
+          break;
+
+        case "G1 Old Generation":
+          handlers.add(new OldGarbageCollectionHandler(name));
+          break;
+
+        case "PS MarkSweep":
+          handlers.add(new OldGarbageCollectionHandler(name));
+          break;
+
+        case "MarkSweepCompact":
+          handlers.add(new OldGarbageCollectionHandler(name));
+          break;
+
         default:
           // If none of the above GCs are detected, no action.
       }
@@ -86,8 +88,7 @@ public final class HandlerRegistry {
             new ContainerConfigurationHandler(),
             new LongLockHandler(grouper),
             new ThreadCountHandler(),
-            new ClassesLoadedHandler(),
-            new OldGarbageCollectionHandler(garbageCollectors));
+            new ClassesLoadedHandler());
     handlers.addAll(basicHandlers);
 
     var meter =

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/HandlerRegistry.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.contrib.jfr.metrics;
 
 import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.G1GarbageCollectionHandler;
+import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.OldGarbageCollectionHandler;
+import io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection.YoungGarbageCollectionHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import io.opentelemetry.contrib.jfr.metrics.internal.ThreadGrouper;
 import io.opentelemetry.contrib.jfr.metrics.internal.classes.ClassesLoadedHandler;
@@ -28,16 +31,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-final class HandlerRegistry {
+public final class HandlerRegistry {
   private static final String INSTRUMENTATION_NAME = "io.opentelemetry.contrib.jfr";
   private static final String INSTRUMENTATION_VERSION = "1.7.0-SNAPSHOT";
 
   private final List<RecordedEventHandler> mappers;
 
+  public static HashSet<String> garbageCollectors = new HashSet<String>();
+
   private static final Map<String, List<Supplier<RecordedEventHandler>>> HANDLERS_PER_GC =
       Map.of(
           "G1",
-          List.of(G1HeapSummaryHandler::new),
+          List.of(G1HeapSummaryHandler::new, G1GarbageCollectionHandler::new),
           "Parallel",
           List.of(ParallelHeapSummaryHandler::new));
 
@@ -50,6 +55,7 @@ final class HandlerRegistry {
     var seen = new HashSet<String>();
     for (var bean : ManagementFactory.getGarbageCollectorMXBeans()) {
       var name = bean.getName();
+      garbageCollectors.add(name);
       for (var gcType : HANDLERS_PER_GC.keySet()) {
         if (name.contains(gcType)
             && !seen.contains(gcType)
@@ -72,8 +78,13 @@ final class HandlerRegistry {
             new ContainerConfigurationHandler(),
             new LongLockHandler(grouper),
             new ThreadCountHandler(),
-            new ClassesLoadedHandler());
+            new ClassesLoadedHandler(),
+            new OldGarbageCollectionHandler());
     handlers.addAll(basicHandlers);
+
+    if (!garbageCollectors.contains("G1 Young Generation")) {
+      handlers.add(new YoungGarbageCollectionHandler());
+    }
 
     var meter =
         meterProvider

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java
@@ -26,11 +26,19 @@ public final class Constants {
   public static final String REGION_COUNT = "region.count";
   public static final String COMMITTED = "committed";
   public static final String RESERVED = "reserved";
+  public static final String INITIAL_SIZE = "initialSize";
   public static final String USED = "used";
   public static final String COMMITTED_SIZE = "committedSize";
+  public static final String RESERVED_SIZE = "reservedSize";
 
   public static final String DAEMON = "daemon";
   public static final String HEAP = "heap";
+  public static final String NON_HEAP = "nonheap";
+  public static final String NETWORK_MODE_READ = "read";
+  public static final String NETWORK_MODE_WRITE = "write";
+  public static final String DURATION = "duration";
+  public static final String END_OF_MINOR_GC = "end of minor GC";
+  public static final String END_OF_MAJOR_GC = "end of major GC";
 
   public static final String METRIC_NAME_NETWORK_BYTES = "process.runtime.jvm.network.io";
   public static final String METRIC_DESCRIPTION_NETWORK_BYTES = "Network read/write bytes";
@@ -38,25 +46,33 @@ public final class Constants {
   public static final String METRIC_DESCRIPTION_NETWORK_DURATION = "Network read/write duration";
   public static final String METRIC_NAME_COMMITTED = "process.runtime.jvm.memory.committed";
   public static final String METRIC_DESCRIPTION_COMMITTED = "Measure of memory committed";
-  public static final String NETWORK_MODE_READ = "read";
-  public static final String NETWORK_MODE_WRITE = "write";
   public static final String METRIC_NAME_MEMORY = "process.runtime.jvm.memory.usage";
+  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_NAME_MEMORY_AFTER =
       "process.runtime.jvm.memory.usage_after_last_gc";
-  public static final String METRIC_DESCRIPTION_MEMORY = "Measure of memory used";
   public static final String METRIC_DESCRIPTION_MEMORY_AFTER =
       "Measure of memory used, as measured after the most recent garbage collection event on this pool";
   public static final String METRIC_NAME_MEMORY_ALLOCATION =
       "process.runtime.jvm.memory.allocation";
   public static final String METRIC_DESCRIPTION_MEMORY_ALLOCATION = "Allocation";
+  public static final String METRIC_NAME_MEMORY_INIT = "process.runtime.jvm.memory.init";
+  public static final String METRIC_DESCRIPTION_MEMORY_INIT = "Measure of initial memory requested";
+  public static final String METRIC_NAME_MEMORY_LIMIT = "process.runtime.jvm.memory.limit";
+  public static final String METRIC_DESCRIPTION_MEMORY_LIMIT = "Measure of max obtainable memory";
+  public static final String METRIC_NAME_GC_DURATION = "process.runtime.jvm.gc.duration";
+  public static final String METRIC_DESCRIPTION_GC_DURATION =
+      "Duration of JVM garbage collection actions";
 
   public static final AttributeKey<String> ATTR_THREAD_NAME = AttributeKey.stringKey("thread.name");
   public static final AttributeKey<String> ATTR_ARENA_NAME = AttributeKey.stringKey("arena");
   public static final AttributeKey<String> ATTR_NETWORK_MODE = AttributeKey.stringKey("mode");
   public static final AttributeKey<String> ATTR_TYPE = AttributeKey.stringKey("type");
   public static final AttributeKey<String> ATTR_POOL = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_GC = AttributeKey.stringKey("pool");
+  public static final AttributeKey<String> ATTR_ACTION = AttributeKey.stringKey("action");
   public static final AttributeKey<Boolean> ATTR_DAEMON = AttributeKey.booleanKey(DAEMON);
   public static final String UNIT_CLASSES = "{classes}";
   public static final String UNIT_THREADS = "{threads}";
+  public static final String UNIT_BUFFERS = "{buffers}";
   public static final String UNIT_UTILIZATION = "1";
 }

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/G1GarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/G1GarbageCollectionHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ACTION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.END_OF_MINOR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+public final class G1GarbageCollectionHandler implements RecordedEventHandler {
+  private static final String EVENT_NAME = "jdk.G1GarbageCollection";
+  private static final Attributes ATTR =
+      Attributes.of(ATTR_GC, "G1 Young Generation", ATTR_ACTION, END_OF_MINOR_GC);
+  private LongHistogram histogram;
+
+  public G1GarbageCollectionHandler() {
+    initializeMeter(defaultMeter());
+  }
+
+  @Override
+  public void accept(RecordedEvent ev) {
+    histogram.record(ev.getLong(DURATION), ATTR);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void initializeMeter(Meter meter) {
+    histogram =
+        meter
+            .histogramBuilder(METRIC_NAME_GC_DURATION)
+            .setDescription(METRIC_DESCRIPTION_GC_DURATION)
+            .setUnit(MILLISECONDS)
+            .ofLongs()
+            .build();
+  }
+
+  @Override
+  public Optional<Duration> getPollingDuration() {
+    return Optional.of(Duration.ofSeconds(1));
+  }
+}

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
@@ -19,12 +19,10 @@ import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class OldGarbageCollectionHandler implements RecordedEventHandler {
-  private final HashSet<String> garbageCollectors;
   private static final String EVENT_NAME = "jdk.OldGarbageCollection";
   // This could be changed later
   private Attributes attributes =
@@ -32,8 +30,15 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   private LongHistogram histogram;
 
-  public OldGarbageCollectionHandler(HashSet<String> garbageCollectors) {
-    this.garbageCollectors = garbageCollectors;
+  public OldGarbageCollectionHandler(String gc) {
+    // Set the attribute's GC based on which GC is being used.
+    if (gc.equals("PS MarkSweep")) {
+      attributes = Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
+    } else if (gc.equals("G1 Old Generation")) {
+      attributes = Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
+    } else if (gc.equals("MarkSweepCompact")) {
+      attributes = Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
+    }
     initializeMeter(defaultMeter());
   }
 
@@ -49,15 +54,6 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   @Override
   public void initializeMeter(Meter meter) {
-    // Set the attribute's GC based on which GC is being used.
-    if (garbageCollectors.contains("PS MarkSweep")) {
-      attributes = Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (garbageCollectors.contains("G1 Old Generation")) {
-      attributes = Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (garbageCollectors.contains("MarkSweepCompact")) {
-      attributes = Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
-    }
-
     histogram =
         meter
             .histogramBuilder(METRIC_NAME_GC_DURATION)

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
@@ -32,13 +32,7 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   public OldGarbageCollectionHandler(String gc) {
     // Set the attribute's GC based on which GC is being used.
-    if (gc.equals("PS MarkSweep")) {
-      attributes = Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (gc.equals("G1 Old Generation")) {
-      attributes = Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (gc.equals("MarkSweepCompact")) {
-      attributes = Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
-    }
+    attributes = Attributes.of(ATTR_GC, gc, ATTR_ACTION, END_OF_MAJOR_GC);
     initializeMeter(defaultMeter());
   }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ACTION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.END_OF_MAJOR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.contrib.jfr.metrics.HandlerRegistry;
+import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+public final class OldGarbageCollectionHandler implements RecordedEventHandler {
+  private static final String EVENT_NAME = "jdk.OldGarbageCollection";
+  // This could be changed later
+  private Attributes attributes =
+      Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
+
+  private LongHistogram histogram;
+
+  public OldGarbageCollectionHandler() {
+    initializeMeter(defaultMeter());
+  }
+
+  @Override
+  public void accept(RecordedEvent ev) {
+    histogram.record(ev.getLong(DURATION), attributes);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void initializeMeter(Meter meter) {
+    // Set the attribute's GC based on which GC is being used.
+    if (HandlerRegistry.garbageCollectors.contains("PS MarkSweep")) {
+      attributes = Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
+    } else if (HandlerRegistry.garbageCollectors.contains("G1 Old Generation")) {
+      attributes = Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
+    } else if (HandlerRegistry.garbageCollectors.contains("MarkSweepCompact")) {
+      attributes = Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
+    }
+
+    histogram =
+        meter
+            .histogramBuilder(METRIC_NAME_GC_DURATION)
+            .setDescription(METRIC_DESCRIPTION_GC_DURATION)
+            .setUnit(MILLISECONDS)
+            .ofLongs()
+            .build();
+  }
+
+  @Override
+  public Optional<Duration> getPollingDuration() {
+    return Optional.of(Duration.ofSeconds(1));
+  }
+}

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/OldGarbageCollectionHandler.java
@@ -17,13 +17,14 @@ import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.contrib.jfr.metrics.HandlerRegistry;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class OldGarbageCollectionHandler implements RecordedEventHandler {
+  private final HashSet<String> garbageCollectors;
   private static final String EVENT_NAME = "jdk.OldGarbageCollection";
   // This could be changed later
   private Attributes attributes =
@@ -31,7 +32,8 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
 
   private LongHistogram histogram;
 
-  public OldGarbageCollectionHandler() {
+  public OldGarbageCollectionHandler(HashSet<String> garbageCollectors) {
+    this.garbageCollectors = garbageCollectors;
     initializeMeter(defaultMeter());
   }
 
@@ -48,11 +50,11 @@ public final class OldGarbageCollectionHandler implements RecordedEventHandler {
   @Override
   public void initializeMeter(Meter meter) {
     // Set the attribute's GC based on which GC is being used.
-    if (HandlerRegistry.garbageCollectors.contains("PS MarkSweep")) {
+    if (garbageCollectors.contains("PS MarkSweep")) {
       attributes = Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (HandlerRegistry.garbageCollectors.contains("G1 Old Generation")) {
+    } else if (garbageCollectors.contains("G1 Old Generation")) {
       attributes = Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
-    } else if (HandlerRegistry.garbageCollectors.contains("MarkSweepCompact")) {
+    } else if (garbageCollectors.contains("MarkSweepCompact")) {
       attributes = Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
     }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
@@ -17,19 +17,21 @@ import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
-import io.opentelemetry.contrib.jfr.metrics.HandlerRegistry;
 import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Optional;
 import jdk.jfr.consumer.RecordedEvent;
 
 public final class YoungGarbageCollectionHandler implements RecordedEventHandler {
+  private final HashSet<String> garbageCollectors;
   private static final String EVENT_NAME = "jdk.YoungGarbageCollection";
   private Attributes attributes =
       Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
   private LongHistogram histogram;
 
-  public YoungGarbageCollectionHandler() {
+  public YoungGarbageCollectionHandler(HashSet<String> garbageCollectors) {
+    this.garbageCollectors = garbageCollectors;
     initializeMeter(defaultMeter());
   }
 
@@ -47,9 +49,9 @@ public final class YoungGarbageCollectionHandler implements RecordedEventHandler
   public void initializeMeter(Meter meter) {
     // Set the attribute's GC based on which GC is being used.
     // G1 young collection is already handled by G1GarbageCollectionHandler.
-    if (HandlerRegistry.garbageCollectors.contains("PS Scavenge")) {
+    if (garbageCollectors.contains("PS Scavenge")) {
       attributes = Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
-    } else if (HandlerRegistry.garbageCollectors.contains("Copy")) {
+    } else if (garbageCollectors.contains("Copy")) {
       attributes = Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC);
     }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
@@ -31,11 +31,7 @@ public final class YoungGarbageCollectionHandler implements RecordedEventHandler
   public YoungGarbageCollectionHandler(String gc) {
     // Set the attribute's GC based on which GC is being used.
     // G1 young collection is already handled by G1GarbageCollectionHandler.
-    if (gc.equals("PS Scavenge")) {
-      attributes = Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
-    } else if (gc.equals("Copy")) {
-      attributes = Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC);
-    }
+    attributes = Attributes.of(ATTR_GC, gc, ATTR_ACTION, END_OF_MINOR_GC);
     initializeMeter(defaultMeter());
   }
 

--- a/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
+++ b/jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/GarbageCollection/YoungGarbageCollectionHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics.internal.GarbageCollection;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ACTION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.END_OF_MINOR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_NAME_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
+import static io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler.defaultMeter;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.contrib.jfr.metrics.HandlerRegistry;
+import io.opentelemetry.contrib.jfr.metrics.internal.RecordedEventHandler;
+import java.time.Duration;
+import java.util.Optional;
+import jdk.jfr.consumer.RecordedEvent;
+
+public final class YoungGarbageCollectionHandler implements RecordedEventHandler {
+  private static final String EVENT_NAME = "jdk.YoungGarbageCollection";
+  private Attributes attributes =
+      Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
+  private LongHistogram histogram;
+
+  public YoungGarbageCollectionHandler() {
+    initializeMeter(defaultMeter());
+  }
+
+  @Override
+  public void accept(RecordedEvent ev) {
+    histogram.record(ev.getLong(DURATION), attributes);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void initializeMeter(Meter meter) {
+    // Set the attribute's GC based on which GC is being used.
+    // G1 young collection is already handled by G1GarbageCollectionHandler.
+    if (HandlerRegistry.garbageCollectors.contains("PS Scavenge")) {
+      attributes = Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
+    } else if (HandlerRegistry.garbageCollectors.contains("Copy")) {
+      attributes = Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC);
+    }
+
+    histogram =
+        meter
+            .histogramBuilder(METRIC_NAME_GC_DURATION)
+            .setDescription(METRIC_DESCRIPTION_GC_DURATION)
+            .setUnit(MILLISECONDS)
+            .ofLongs()
+            .build();
+  }
+
+  @Override
+  public Optional<Duration> getPollingDuration() {
+    return Optional.of(Duration.ofSeconds(1));
+  }
+}

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/AbstractMetricsTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/AbstractMetricsTest.java
@@ -14,7 +14,9 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.assertj.MetricAssert;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.lang.management.ManagementFactory;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -23,6 +25,7 @@ public class AbstractMetricsTest {
   static SdkMeterProvider meterProvider;
   static InMemoryMetricReader metricReader;
   static boolean isInitialized = false;
+  static HashSet<String> garbageCollectors = new HashSet<String>();
 
   @BeforeAll
   static void initializeOpenTelemetry() {
@@ -34,6 +37,10 @@ public class AbstractMetricsTest {
     meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
     GlobalOpenTelemetry.set(OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build());
     JfrMetrics.enable(meterProvider);
+
+    for (var bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+      garbageCollectors.add(bean.getName());
+    }
   }
 
   @SafeVarargs

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/GCDurationMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/GCDurationMetricTest.java
@@ -25,25 +25,25 @@ class GCDurationMetricTest extends AbstractMetricsTest {
       // Each point must have attributes of one of the following variation:
       // First sort by Major/Minor, then by GC.
       if (pointData.getAttributes().get(ATTR_ACTION).equals(END_OF_MINOR_GC)) {
-        if (HandlerRegistry.garbageCollectors.contains("G1 Young Generation")) {
+        if (garbageCollectors.contains("G1 Young Generation")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(
                   Attributes.of(ATTR_GC, "G1 Young Generation", ATTR_ACTION, END_OF_MINOR_GC));
-        } else if (HandlerRegistry.garbageCollectors.contains("PS Scavenge")) {
+        } else if (garbageCollectors.contains("PS Scavenge")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC));
-        } else if (HandlerRegistry.garbageCollectors.contains("Copy")) {
+        } else if (garbageCollectors.contains("Copy")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC));
         }
       } else {
-        if (HandlerRegistry.garbageCollectors.contains("G1 Old Generation")) {
+        if (garbageCollectors.contains("G1 Old Generation")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC));
-        } else if (HandlerRegistry.garbageCollectors.contains("PS MarkSweep")) {
+        } else if (garbageCollectors.contains("PS MarkSweep")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC));
-        } else if (HandlerRegistry.garbageCollectors.contains("MarkSweepCompact")) {
+        } else if (garbageCollectors.contains("MarkSweepCompact")) {
           assertThat(pointData.getAttributes())
               .isEqualTo(Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC));
         }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/GCDurationMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/metrics/GCDurationMetricTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfr.metrics;
+
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_ACTION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.ATTR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.END_OF_MAJOR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.END_OF_MINOR_GC;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.METRIC_DESCRIPTION_GC_DURATION;
+import static io.opentelemetry.contrib.jfr.metrics.internal.Constants.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+
+class GCDurationMetricTest extends AbstractMetricsTest {
+  static class AttributeCheck implements ThrowingConsumer<PointData> {
+    @Override
+    public void acceptThrows(PointData pointData) throws Throwable {
+      // Each point must have attributes of one of the following variation:
+      // First sort by Major/Minor, then by GC.
+      if (pointData.getAttributes().get(ATTR_ACTION).equals(END_OF_MINOR_GC)) {
+        if (HandlerRegistry.garbageCollectors.contains("G1 Young Generation")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(
+                  Attributes.of(ATTR_GC, "G1 Young Generation", ATTR_ACTION, END_OF_MINOR_GC));
+        } else if (HandlerRegistry.garbageCollectors.contains("PS Scavenge")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC));
+        } else if (HandlerRegistry.garbageCollectors.contains("Copy")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC));
+        }
+      } else {
+        if (HandlerRegistry.garbageCollectors.contains("G1 Old Generation")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC));
+        } else if (HandlerRegistry.garbageCollectors.contains("PS MarkSweep")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC));
+        } else if (HandlerRegistry.garbageCollectors.contains("MarkSweepCompact")) {
+          assertThat(pointData.getAttributes())
+              .isEqualTo(Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC));
+        }
+      }
+    }
+  }
+
+  @Test
+  void shouldHaveGCDurationMetrics() throws Exception {
+    // TODO: Need a reliable way to test old and young gen GC in isolation.
+    System.gc();
+    waitAndAssertMetrics(
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.gc.duration")
+                .hasUnit(MILLISECONDS)
+                .hasDescription(METRIC_DESCRIPTION_GC_DURATION)
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point -> point.hasSumGreaterThan(0).satisfies(new AttributeCheck()))));
+  }
+}


### PR DESCRIPTION
**Description:**

This PR adds changes that implement the metric `process.runtime.jvm.gc.duration`.

This was a part of a larger PR here:  https://github.com/open-telemetry/opentelemetry-java-contrib/pull/644.

`jfr-streaming/src/main/java/io/opentelemetry/contrib/jfr/metrics/internal/Constants.java` has been kept the same as it was in the larger PR because it's used in all of the smaller constituent PRs. This will hopefully also avoid some conflicts as the PRs are sequentially merged. As a result, there are some constants that are defined, but not used in this PR.

**Testing:**

Tests were added but they don't have great coverage. In the future we need to devise a reliable way to test each GC. Currently, I'm not sure of a way to change GCs at runtime in order to test them all. I'm also uncertain of how to reliably force young gen GC and old gen GC. As a result, the test added in this PR basically just invokes "some" GC and ensures that the resulting metric has data that is expected.  