### PR TITLE
Remove mentions of @kubawach

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -47,5 +47,4 @@ components:
     - iNikem
     - jeanbisutti
   static-instrumenter:
-    - kubawach
     - anosek-an

--- a/static-instrumenter/README.md
+++ b/static-instrumenter/README.md
@@ -62,7 +62,6 @@ contains statically instrumented class code.
 
 ## Component owners
 
-- [Jakub Wach](https://github.com/kubawach), Splunk
 - [Anna Nosek](https://github.com/anosek-an), Splunk
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
Kuba left Splunk this month, and it looks like he's removed his GitHub profile too.