### PR TITLE
Make dependabot ignore maven-plugin-api version used by the static in…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
       - dependency-name: "io.micrometer:micrometer-core"
         # compileOnly dependency on old micrometer-core version is intentional
         versions: [ "(1.1.0,)" ]
+      - dependency-name: "org.apache.maven:maven-plugin-api"
+        # static instrumenter maven plugin uses old maven API version for better compatibility
+        versions: [ "(3.5.0,)" ]
+      - dependency-name: "org.apache.maven:maven-core"
+        # compileOnly dependency that matches the maven-plugin-api version in the static instrumenter maven plugin
+        versions: [ "(3.5.0,)" ]
     registries:
       - gradle-plugin-portal
     schedule:


### PR DESCRIPTION
…strumenter

Supersedes #670