### PR TITLE
Allow providing a custom sampler as an option for the RuleBasedRoutingSampler

### DIFF
--- a/samplers/src/main/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerBuilder.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerBuilder.java
@@ -24,27 +24,41 @@ public final class RuleBasedRoutingSamplerBuilder {
     this.defaultDelegate = defaultDelegate;
   }
 
+  /**
+   * Drop all spans when the value of the provided {@link AttributeKey} matches the provided
+   * pattern.
+   */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder drop(AttributeKey<String> attributeKey, String pattern) {
+    return customize(attributeKey, pattern, Sampler.alwaysOff());
+  }
+
+  /**
+   * Use the provided sampler when the value of the provided {@link AttributeKey} matches the
+   * provided pattern.
+   */
+  @CanIgnoreReturnValue
+  public RuleBasedRoutingSamplerBuilder customize(
+      AttributeKey<String> attributeKey, String pattern, Sampler sampler) {
     rules.add(
         new SamplingRule(
             requireNonNull(attributeKey, "attributeKey must not be null"),
             requireNonNull(pattern, "pattern must not be null"),
-            Sampler.alwaysOff()));
+            requireNonNull(sampler, "sampler must not be null")));
     return this;
   }
 
+  /**
+   * Record and sample all spans when the value of the provided {@link AttributeKey} matches the
+   * provided pattern.
+   */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder recordAndSample(
       AttributeKey<String> attributeKey, String pattern) {
-    rules.add(
-        new SamplingRule(
-            requireNonNull(attributeKey, "attributeKey must not be null"),
-            requireNonNull(pattern, "pattern must not be null"),
-            Sampler.alwaysOn()));
-    return this;
+    return customize(attributeKey, pattern, Sampler.alwaysOn());
   }
 
+  /** Build the sampler based on the rules provided. */
   public RuleBasedRoutingSampler build() {
     return new RuleBasedRoutingSampler(rules, kind, defaultDelegate);
   }

--- a/samplers/src/test/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerTest.java
@@ -23,11 +23,13 @@ import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +49,7 @@ class RuleBasedRoutingSamplerTest {
 
   private final List<SamplingRule> patterns = new ArrayList<>();
 
-  @Mock(lenient = true)
+  @Mock(strictness = Mock.Strictness.LENIENT)
   private Sampler delegate;
 
   @BeforeEach
@@ -166,6 +168,25 @@ class RuleBasedRoutingSamplerTest {
         .isEqualTo(SamplingDecision.DROP);
   }
 
+  @Test
+  void customSampler() {
+    Attributes attributes = Attributes.of(HTTP_TARGET, "/test");
+    RuleBasedRoutingSampler testSampler =
+        RuleBasedRoutingSampler.builder(SPAN_KIND, delegate)
+            .customize(HTTP_TARGET, ".*test", new AlternatingSampler())
+            .build();
+    assertThat(
+            testSampler
+                .shouldSample(parentContext, traceId, SPAN_NAME, SPAN_KIND, attributes, emptyList())
+                .getDecision())
+        .isEqualTo(SamplingDecision.DROP);
+    assertThat(
+            testSampler
+                .shouldSample(parentContext, traceId, SPAN_NAME, SPAN_KIND, attributes, emptyList())
+                .getDecision())
+        .isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
+  }
+
   private SamplingResult shouldSample(Sampler sampler, String url) {
     Attributes attributes = Attributes.of(HTTP_URL, url);
     return sampler.shouldSample(
@@ -174,5 +195,31 @@ class RuleBasedRoutingSamplerTest {
 
   private static RuleBasedRoutingSamplerBuilder addRules(RuleBasedRoutingSamplerBuilder builder) {
     return builder.drop(HTTP_URL, ".*/healthcheck").drop(HTTP_TARGET, "/actuator");
+  }
+
+  /** Silly sampler that alternates decisions for testing. */
+  private static class AlternatingSampler implements Sampler {
+    private final AtomicBoolean switcher = new AtomicBoolean();
+
+    @Override
+    public SamplingResult shouldSample(
+        Context parentContext,
+        String traceId,
+        String name,
+        SpanKind spanKind,
+        Attributes attributes,
+        List<LinkData> parentLinks) {
+      if (switcher.get()) {
+        switcher.set(false);
+        return SamplingResult.recordAndSample();
+      }
+      switcher.set(true);
+      return SamplingResult.drop();
+    }
+
+    @Override
+    public String getDescription() {
+      return "weird switching sampler for testing";
+    }
   }
 }

--- a/samplers/src/test/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/samplers/RuleBasedRoutingSamplerTest.java
@@ -209,12 +209,9 @@ class RuleBasedRoutingSamplerTest {
         SpanKind spanKind,
         Attributes attributes,
         List<LinkData> parentLinks) {
-      if (switcher.get()) {
-        switcher.set(false);
-        return SamplingResult.recordAndSample();
-      }
-      switcher.set(true);
-      return SamplingResult.drop();
+      return switcher.getAndSet(!switcher.get())
+          ? SamplingResult.recordAndSample()
+          : SamplingResult.drop();
     }
 
     @Override


### PR DESCRIPTION
**Description:**
Currently, the RuleBasedRoutingSampler only lets you specify `drop` or `recordAndSample`. This PR makes it possible to provide a custom sampler to use when the span has an attribute matching the provided pattern.

**Documentation:**
Added a bunch of javadoc, because there wasn't any in the builder at all.
