### PR TITLE
Fix and enhance resource detection logging.

### DIFF
--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameDetector.java
@@ -49,11 +49,11 @@ final class AppServerServiceNameDetector implements ServiceNameDetector {
     }
 
     if (!dirTool.isDirectory(deploymentDir)) {
-      logger.log(FINE, "Deployment dir '{0}' doesn't exist.", deploymentDir);
+      logger.log(FINE, "Deployment dir {0} doesn't exist.", deploymentDir);
       return null;
     }
 
-    logger.log(FINE, "Looking for deployments in '{0}'.", deploymentDir);
+    logger.log(FINE, "Looking for deployments in {0}.", deploymentDir);
     try (Stream<Path> stream = dirTool.list(deploymentDir)) {
       return stream.map(this::detectName).filter(Objects::nonNull).findFirst().orElse(null);
     }
@@ -62,11 +62,11 @@ final class AppServerServiceNameDetector implements ServiceNameDetector {
   @Nullable
   private String detectName(Path path) {
     if (!appServer.isValidAppName(path)) {
-      logger.log(FINE, "Skipping '{0}'.", path);
+      logger.log(FINE, "Skipping {0}.", path);
       return null;
     }
 
-    logger.log(FINE, "Attempting service name detection in '{0}'.", path);
+    logger.log(FINE, "Attempting service name detection in {0}.", path);
     String name = path.getFileName().toString();
     if (dirTool.isDirectory(path)) {
       return parseBuddy.handleExplodedApp(path);

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.resourceproviders;
 
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
 import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.common.Attributes;
@@ -37,11 +38,14 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
   @Override
   public Resource createResource(ConfigProperties config) {
     String serviceName = detectServiceName();
-    if (serviceName != null) {
-      logger.log(INFO, "Auto-detected service name {0}.", serviceName);
-      return Resource.create(Attributes.of(SERVICE_NAME, serviceName));
+    if (serviceName == null) {
+      logger.log(
+          WARNING,
+          "Service name could not be detected using common application server strategies.");
+      return Resource.empty();
     }
-    return Resource.empty();
+    logger.log(INFO, "Auto-detected service name {0}.", serviceName);
+    return Resource.create(Attributes.of(SERVICE_NAME, serviceName));
   }
 
   @Nullable
@@ -58,10 +62,30 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
   @Override
   public boolean shouldApply(ConfigProperties config, Resource existing) {
     String serviceName = config.getString("otel.service.name");
+    if (serviceName != null) {
+      logger.log(
+          INFO,
+          "Skipping AppServerServiceName detection, service name is already set to {0}",
+          serviceName);
+      return false;
+    }
     Map<String, String> resourceAttributes = config.getMap("otel.resource.attributes");
-    return serviceName == null
-        && !resourceAttributes.containsKey(SERVICE_NAME.getKey())
-        && "unknown_service:java".equals(existing.getAttribute(SERVICE_NAME));
+    if (resourceAttributes.containsKey(SERVICE_NAME.getKey())) {
+      logger.log(
+          INFO,
+          "Skipping AppServerServiceName detection, resourceAttributes already contains {0}",
+          resourceAttributes.get(SERVICE_NAME.getKey()));
+      return false;
+    }
+    String existingName = existing.getAttribute(SERVICE_NAME);
+    if (!"unknown_service:java".equals(existingName)) {
+      logger.log(
+          INFO,
+          "Skipping AppServerServiceName detection, resource already contains {0}",
+          existingName);
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
@@ -65,7 +65,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
     if (serviceName != null) {
       logger.log(
           INFO,
-          "Skipping AppServerServiceName detection, service name is already set to {0}",
+          "Skipping AppServerServiceName detection, otel.service.name is already set to {0}",
           serviceName);
       return false;
     }
@@ -73,7 +73,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
     if (resourceAttributes.containsKey(SERVICE_NAME.getKey())) {
       logger.log(
           INFO,
-          "Skipping AppServerServiceName detection, resourceAttributes already contains {0}",
+          "Skipping AppServerServiceName detection, otel.resource.attributes already contains {0}",
           resourceAttributes.get(SERVICE_NAME.getKey()));
       return false;
     }

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
@@ -38,7 +38,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
   public Resource createResource(ConfigProperties config) {
     String serviceName = detectServiceName();
     if (serviceName != null) {
-      logger.log(INFO, "Auto-detected service name '{0}'.", serviceName);
+      logger.log(INFO, "Auto-detected service name {0}.", serviceName);
       return Resource.create(Attributes.of(SERVICE_NAME, serviceName));
     }
     return Resource.empty();

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/AppServerServiceNameProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.resourceproviders;
 
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
@@ -64,7 +65,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
     String serviceName = config.getString("otel.service.name");
     if (serviceName != null) {
       logger.log(
-          INFO,
+          FINE,
           "Skipping AppServerServiceName detection, otel.service.name is already set to {0}",
           serviceName);
       return false;
@@ -72,7 +73,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
     Map<String, String> resourceAttributes = config.getMap("otel.resource.attributes");
     if (resourceAttributes.containsKey(SERVICE_NAME.getKey())) {
       logger.log(
-          INFO,
+          FINE,
           "Skipping AppServerServiceName detection, otel.resource.attributes already contains {0}",
           resourceAttributes.get(SERVICE_NAME.getKey()));
       return false;
@@ -80,7 +81,7 @@ public final class AppServerServiceNameProvider implements ConditionalResourcePr
     String existingName = existing.getAttribute(SERVICE_NAME);
     if (!"unknown_service:java".equals(existingName)) {
       logger.log(
-          INFO,
+          FINE,
           "Skipping AppServerServiceName detection, resource already contains {0}",
           existingName);
       return false;

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/JettyAppServer.java
@@ -41,11 +41,11 @@ class JettyAppServer implements AppServer {
     // would be located in /dir/webapps.
 
     String programArguments = System.getProperty("sun.java.command");
-    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    logger.log(FINE, "Started with arguments {0}.", programArguments);
     if (programArguments != null) {
       Path jettyBase = parseJettyBase(programArguments);
       if (jettyBase != null) {
-        logger.log(FINE, "Using jetty.base '{0}'.", jettyBase);
+        logger.log(FINE, "Using jetty.base {0}.", jettyBase);
         return jettyBase.resolve("webapps");
       }
     }

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/LibertyAppService.java
@@ -41,7 +41,7 @@ class LibertyAppService implements AppServer {
     if (logger.isLoggable(FINE)) {
       logger.log(
           FINE,
-          "Using WLP_USER_DIR '{0}', WLP_OUTPUT_DIR '{1}'.",
+          "Using WLP_USER_DIR {0}, WLP_OUTPUT_DIR {1}.",
           new Object[] {wlpUserDir, wlpOutputDir});
     }
     if (wlpUserDir != null

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WebSphereServiceNameDetector.java
@@ -39,7 +39,7 @@ class WebSphereServiceNameDetector implements ServiceNameDetector {
     }
 
     String programArguments = System.getProperty("sun.java.command");
-    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    logger.log(FINE, "Started with arguments {0}.", programArguments);
     if (programArguments == null) {
       return null;
     }
@@ -53,7 +53,7 @@ class WebSphereServiceNameDetector implements ServiceNameDetector {
     // in docker image it is /opt/IBM/WebSphere/AppServer/profiles/AppSrv01/config
     Path configDirectory = Paths.get(matcher.group(2));
     if (!Files.isDirectory(configDirectory)) {
-      logger.log(FINE, "Missing configuration directory '{0}'.", configDirectory);
+      logger.log(FINE, "Missing configuration directory {0}.", configDirectory);
       return null;
     }
 
@@ -64,7 +64,7 @@ class WebSphereServiceNameDetector implements ServiceNameDetector {
     if (logger.isLoggable(FINE)) {
       logger.log(
           FINE,
-          "Parsed arguments: cell '{0}', node '{1}', server '{2}', configuration directory '{3}'.",
+          "Parsed arguments: cell {0}, node {1}, server {2}, configuration directory {3}.",
           new Object[] {cell, node, server, configDirectory});
     }
 
@@ -78,17 +78,17 @@ class WebSphereServiceNameDetector implements ServiceNameDetector {
     }
     Path cellApplications = parent.resolve("installedApps").resolve(cell);
     if (Files.isDirectory(cellApplications)) {
-      logger.log(FINE, "Looking for deployments in '{0}'.", cellApplications);
+      logger.log(FINE, "Looking for deployments in {0}.", cellApplications);
 
       try (Stream<Path> stream = Files.list(cellApplications)) {
         for (Path path : stream.collect(Collectors.toList())) {
           String fullName = path.getFileName().toString();
           // websphere deploys all applications as ear
           if (!fullName.endsWith(".ear") || !appServer.isValidAppName(path)) {
-            logger.log(FINE, "Skipping '{0}'.", path);
+            logger.log(FINE, "Skipping {0}.", path);
             continue;
           }
-          logger.log(FINE, "Attempting service name detection in '{0}'.", path);
+          logger.log(FINE, "Attempting service name detection in {0}.", path);
 
           // strip ear suffix
           String name = fullName.substring(0, fullName.length() - 4);

--- a/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
+++ b/resource-providers/src/main/java/io/opentelemetry/resourceproviders/WildflyAppServer.java
@@ -29,7 +29,7 @@ class WildflyAppServer implements AppServer {
   @Override
   public Path getDeploymentDir() throws URISyntaxException {
     String programArguments = System.getProperty("sun.java.command");
-    logger.log(FINE, "Started with arguments '{0}'.", programArguments);
+    logger.log(FINE, "Started with arguments {0}.", programArguments);
     if (programArguments == null) {
       return null;
     }
@@ -42,7 +42,7 @@ class WildflyAppServer implements AppServer {
     // environment variable JBOSS_BASE_DIR to avoid parsing program arguments
     String jbossBaseDir = System.getenv("JBOSS_BASE_DIR");
     if (jbossBaseDir != null) {
-      logger.log(FINE, "Using JBOSS_BASE_DIR '{0}'.", jbossBaseDir);
+      logger.log(FINE, "Using JBOSS_BASE_DIR {0}.", jbossBaseDir);
       return Paths.get(jbossBaseDir, "deployments");
     }
 


### PR DESCRIPTION
I learned (the hard way) today that jul doesn't expand numeric placeholders in string templates if they are surrounded by single quotes. Yup.

* `logger.log(INFO, "{0}", "test")` -> `test`
* `logger.log(INFO, "'{0}'", "test")` -> `{0}`

So this results in pretty useless logs here. I also used this as an opportunity to enhance the details about when/why the resource provider doesn't kick in.