### PR TITLE
Cleanup jfr-streaming tests

### DIFF
--- a/jfr-streaming/src/g1GcTest/java/io/opentelemetry/contrib/jfr/streaming/G1GcMemoryMetricTest.java
+++ b/jfr-streaming/src/g1GcTest/java/io/opentelemetry/contrib/jfr/streaming/G1GcMemoryMetricTest.java
@@ -22,9 +22,7 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.MILLISEC
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.HistogramData;
-import io.opentelemetry.sdk.metrics.data.HistogramPointData;
-import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -40,60 +38,50 @@ class G1GcMemoryMetricTest {
                   .enableFeature(JfrFeature.MEMORY_POOL_METRICS));
 
   @Test
-  void shouldHaveMemoryUsageMetrics() {
+  void shouldHaveMemoryMetrics() {
     System.gc();
     // Test to make sure there's metric data for both eden and survivor spaces.
     // TODO: once G1 old gen usage added to jdk.G1HeapSummary (in JDK 21), test for it here too.
+    // TODO: needs JFR support for process.runtime.jvm.memory.limit.
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
                 .hasName(METRIC_NAME_MEMORY)
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_MEMORY)
-                .satisfies(
-                    data ->
-                        assertThat(data.getLongSumData().getPoints())
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_G1_EDEN_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_G1_SURVIVOR_SPACE))),
-        metric ->
-            metric
-                .hasName(METRIC_NAME_MEMORY_AFTER)
-                .hasUnit(BYTES)
-                .hasDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
-                .satisfies(
-                    data ->
-                        assertThat(data.getLongSumData().getPoints())
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_G1_EDEN_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_G1_SURVIVOR_SPACE))));
-  }
-
-  @Test
-  void shouldHaveMemoryLimitMetrics() {
-    // TODO: needs JFR support. Placeholder.
-  }
-
-  @Test
-  void shouldHaveMemoryCommittedMetrics() {
-    System.gc();
-    // TODO: need JFR support for the other G1 pools
-    jfrExtension.waitAndAssertMetrics(
+                .satisfies(G1GcMemoryMetricTest::hasGcAttributes),
         metric ->
             metric
                 .hasName("process.runtime.jvm.memory.committed")
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_COMMITTED)
+                // TODO: need JFR support for the other G1 pools
                 .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_G1_EDEN_SPACE));
-                    }));
+                    data ->
+                        assertThat(data.getLongSumData().getPoints())
+                            .anyMatch(p -> p.getAttributes().equals(ATTR_G1_EDEN_SPACE))),
+        metric ->
+            metric
+                .hasName(METRIC_NAME_MEMORY_AFTER)
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
+                .satisfies(G1GcMemoryMetricTest::hasGcAttributes));
+  }
+
+  private static void hasGcAttributes(MetricData data) {
+    assertThat(data.getLongSumData().getPoints())
+        .anyMatch(p -> p.getAttributes().equals(ATTR_G1_EDEN_SPACE))
+        .anyMatch(p -> p.getAttributes().equals(ATTR_G1_SURVIVOR_SPACE));
   }
 
   @Test
   void shouldHaveGCDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     System.gc();
+    Attributes minorGcAttributes =
+        Attributes.of(ATTR_GC, "G1 Young Generation", ATTR_ACTION, END_OF_MINOR_GC);
+    Attributes majorGcAttributes =
+        Attributes.of(ATTR_GC, "G1 Old Generation", ATTR_ACTION, END_OF_MAJOR_GC);
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
@@ -101,27 +89,12 @@ class G1GcMemoryMetricTest {
                 .hasUnit(MILLISECONDS)
                 .hasDescription(METRIC_DESCRIPTION_GC_DURATION)
                 .satisfies(
-                    metricData -> {
-                      HistogramData data = metricData.getHistogramData();
-                      assertThat(data.getPoints())
-                          .map(HistogramPointData.class::cast)
-                          .anyMatch(
-                              p ->
-                                  p.getSum() > 0
-                                      && (p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "G1 Young Generation",
-                                                      ATTR_ACTION,
-                                                      END_OF_MINOR_GC))
-                                          || p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "G1 Old Generation",
-                                                      ATTR_ACTION,
-                                                      END_OF_MAJOR_GC))));
-                    }));
+                    data ->
+                        assertThat(data.getHistogramData().getPoints())
+                            .anyMatch(
+                                p ->
+                                    p.getSum() > 0
+                                        && (p.getAttributes().equals(minorGcAttributes)
+                                            || p.getAttributes().equals(majorGcAttributes)))));
   }
 }

--- a/jfr-streaming/src/parallelGcTest/java/io/opentelemetry/contrib/jfr/streaming/PsGcMemoryMetricTest.java
+++ b/jfr-streaming/src/parallelGcTest/java/io/opentelemetry/contrib/jfr/streaming/PsGcMemoryMetricTest.java
@@ -24,9 +24,7 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.MILLISEC
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.HistogramData;
-import io.opentelemetry.sdk.metrics.data.HistogramPointData;
-import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -42,7 +40,7 @@ class PsGcMemoryMetricTest {
                   .enableFeature(JfrFeature.MEMORY_POOL_METRICS));
 
   @Test
-  void shouldHaveMemoryUsageMetrics() {
+  void shouldHaveMemoryMetrics() {
     System.gc();
     jfrExtension.waitAndAssertMetrics(
         metric ->
@@ -50,67 +48,42 @@ class PsGcMemoryMetricTest {
                 .hasName(METRIC_NAME_MEMORY)
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_MEMORY)
-                .satisfies(
-                    data ->
-                        assertThat(data.getLongSumData().getPoints())
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_EDEN_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_SURVIVOR_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN))),
-        metric ->
-            metric
-                .hasName(METRIC_NAME_MEMORY_AFTER)
-                .hasUnit(BYTES)
-                .hasDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
-                .satisfies(
-                    data ->
-                        assertThat(data.getLongSumData().getPoints())
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_EDEN_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_SURVIVOR_SPACE))
-                            .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN))));
-  }
-
-  @Test
-  void shouldHaveMemoryLimitMetrics() {
-    System.gc();
-    jfrExtension.waitAndAssertMetrics(
-        metric ->
-            metric
-                .hasName("process.runtime.jvm.memory.limit")
-                .hasUnit(BYTES)
-                .hasDescription(METRIC_DESCRIPTION_MEMORY_LIMIT)
-                .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_EDEN_SPACE))
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_SURVIVOR_SPACE))
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN));
-                    }));
-  }
-
-  @Test
-  void shouldHaveMemoryCommittedMetrics() {
-    System.gc();
-    jfrExtension.waitAndAssertMetrics(
+                .satisfies(PsGcMemoryMetricTest::hasGcAttributes),
         metric ->
             metric
                 .hasName("process.runtime.jvm.memory.committed")
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_COMMITTED)
-                .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_EDEN_SPACE))
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_SURVIVOR_SPACE))
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN));
-                    }));
+                .satisfies(PsGcMemoryMetricTest::hasGcAttributes),
+        metric ->
+            metric
+                .hasName("process.runtime.jvm.memory.limit")
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_MEMORY_LIMIT)
+                .satisfies(PsGcMemoryMetricTest::hasGcAttributes),
+        metric ->
+            metric
+                .hasName(METRIC_NAME_MEMORY_AFTER)
+                .hasUnit(BYTES)
+                .hasDescription(METRIC_DESCRIPTION_MEMORY_AFTER)
+                .satisfies(PsGcMemoryMetricTest::hasGcAttributes));
+  }
+
+  private static void hasGcAttributes(MetricData data) {
+    assertThat(data.getLongSumData().getPoints())
+        .anyMatch(p -> p.getAttributes().equals(ATTR_PS_EDEN_SPACE))
+        .anyMatch(p -> p.getAttributes().equals(ATTR_PS_SURVIVOR_SPACE))
+        .anyMatch(p -> p.getAttributes().equals(ATTR_PS_OLD_GEN));
   }
 
   @Test
   void shouldHaveGCDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     System.gc();
+    Attributes minorGcAttributes =
+        Attributes.of(ATTR_GC, "PS Scavenge", ATTR_ACTION, END_OF_MINOR_GC);
+    Attributes majorGcAttributes =
+        Attributes.of(ATTR_GC, "PS MarkSweep", ATTR_ACTION, END_OF_MAJOR_GC);
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
@@ -118,27 +91,12 @@ class PsGcMemoryMetricTest {
                 .hasUnit(MILLISECONDS)
                 .hasDescription(METRIC_DESCRIPTION_GC_DURATION)
                 .satisfies(
-                    metricData -> {
-                      HistogramData data = metricData.getHistogramData();
-                      assertThat(data.getPoints())
-                          .map(HistogramPointData.class::cast)
-                          .anyMatch(
-                              p ->
-                                  p.getSum() > 0
-                                      && (p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "PS Scavenge",
-                                                      ATTR_ACTION,
-                                                      END_OF_MINOR_GC))
-                                          || p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "PS MarkSweep",
-                                                      ATTR_ACTION,
-                                                      END_OF_MAJOR_GC))));
-                    }));
+                    data ->
+                        assertThat(data.getHistogramData().getPoints())
+                            .anyMatch(
+                                p ->
+                                    p.getSum() > 0
+                                        && (p.getAttributes().equals(minorGcAttributes)
+                                            || p.getAttributes().equals(majorGcAttributes)))));
   }
 }

--- a/jfr-streaming/src/serialGcTest/java/io/opentelemetry/contrib/jfr/streaming/SerialGcMemoryMetricTest.java
+++ b/jfr-streaming/src/serialGcTest/java/io/opentelemetry/contrib/jfr/streaming/SerialGcMemoryMetricTest.java
@@ -25,20 +25,17 @@ class SerialGcMemoryMetricTest {
           builder -> builder.disableAllFeatures().enableFeature(JfrFeature.GC_DURATION_METRICS));
 
   @Test
-  void shouldHaveMemoryLimitMetrics() {
+  void shouldHaveMemoryMetrics() {
     // TODO: needs JFR support. Placeholder.
   }
 
   @Test
-  void shouldHaveMemoryUsageMetrics() {
-    System.gc();
-    // TODO: needs JFR support. Placeholder.
-  }
-
-  @Test
-  void shouldHaveGCDurationMetrics() throws Exception {
+  void shouldHaveGCDurationMetrics() {
     // TODO: Need a reliable way to test old and young gen GC in isolation.
     System.gc();
+    Attributes minorGcAttributes = Attributes.of(ATTR_GC, "Copy", ATTR_ACTION, END_OF_MINOR_GC);
+    Attributes majorGcAttributes =
+        Attributes.of(ATTR_GC, "MarkSweepCompact", ATTR_ACTION, END_OF_MAJOR_GC);
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
@@ -51,19 +48,7 @@ class SerialGcMemoryMetricTest {
                             .anyMatch(
                                 p ->
                                     p.getSum() > 0
-                                        && (p.getAttributes()
-                                                .equals(
-                                                    Attributes.of(
-                                                        ATTR_GC,
-                                                        "Copy",
-                                                        ATTR_ACTION,
-                                                        END_OF_MINOR_GC))
-                                            || p.getAttributes()
-                                                .equals(
-                                                    Attributes.of(
-                                                        ATTR_GC,
-                                                        "MarkSweepCompact",
-                                                        ATTR_ACTION,
-                                                        END_OF_MAJOR_GC))))));
+                                        && (p.getAttributes().equals(minorGcAttributes)
+                                            || p.getAttributes().equals(majorGcAttributes)))));
   }
 }

--- a/jfr-streaming/src/serialGcTest/java/io/opentelemetry/contrib/jfr/streaming/SerialGcMemoryMetricTest.java
+++ b/jfr-streaming/src/serialGcTest/java/io/opentelemetry/contrib/jfr/streaming/SerialGcMemoryMetricTest.java
@@ -14,8 +14,6 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.MILLISEC
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.sdk.metrics.data.HistogramData;
-import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -48,27 +46,24 @@ class SerialGcMemoryMetricTest {
                 .hasUnit(MILLISECONDS)
                 .hasDescription(METRIC_DESCRIPTION_GC_DURATION)
                 .satisfies(
-                    metricData -> {
-                      HistogramData data = metricData.getHistogramData();
-                      assertThat(data.getPoints())
-                          .map(HistogramPointData.class::cast)
-                          .anyMatch(
-                              p ->
-                                  p.getSum() > 0
-                                      && (p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "Copy",
-                                                      ATTR_ACTION,
-                                                      END_OF_MINOR_GC))
-                                          || p.getAttributes()
-                                              .equals(
-                                                  Attributes.of(
-                                                      ATTR_GC,
-                                                      "MarkSweepCompact",
-                                                      ATTR_ACTION,
-                                                      END_OF_MAJOR_GC))));
-                    }));
+                    data ->
+                        assertThat(data.getHistogramData().getPoints())
+                            .anyMatch(
+                                p ->
+                                    p.getSum() > 0
+                                        && (p.getAttributes()
+                                                .equals(
+                                                    Attributes.of(
+                                                        ATTR_GC,
+                                                        "Copy",
+                                                        ATTR_ACTION,
+                                                        END_OF_MINOR_GC))
+                                            || p.getAttributes()
+                                                .equals(
+                                                    Attributes.of(
+                                                        ATTR_GC,
+                                                        "MarkSweepCompact",
+                                                        ATTR_ACTION,
+                                                        END_OF_MAJOR_GC))))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/BufferMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/BufferMetricTest.java
@@ -39,6 +39,7 @@ class BufferMetricTest {
     ByteBuffer buffer = ByteBuffer.allocateDirect(10000);
     buffer.put("test".getBytes(StandardCharsets.UTF_8));
 
+    Attributes directBuffer = Attributes.of(ATTR_POOL, "direct");
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
@@ -52,8 +53,7 @@ class BufferMetricTest {
                                 point.satisfies(
                                     pointData -> {
                                       assertThat(pointData.getValue()).isGreaterThan(0);
-                                      assertThat(pointData.getAttributes())
-                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
+                                      assertThat(pointData.getAttributes()).isEqualTo(directBuffer);
                                     }))),
         metric ->
             metric
@@ -67,8 +67,7 @@ class BufferMetricTest {
                                 point.satisfies(
                                     pointData -> {
                                       assertThat(pointData.getValue()).isGreaterThan(0);
-                                      assertThat(pointData.getAttributes())
-                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
+                                      assertThat(pointData.getAttributes()).isEqualTo(directBuffer);
                                     }))),
         metric ->
             metric
@@ -82,8 +81,7 @@ class BufferMetricTest {
                                 point.satisfies(
                                     pointData -> {
                                       assertThat(pointData.getValue()).isGreaterThan(0);
-                                      assertThat(pointData.getAttributes())
-                                          .isEqualTo(Attributes.of(ATTR_POOL, "direct"));
+                                      assertThat(pointData.getAttributes()).isEqualTo(directBuffer);
                                     }))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/CodeCacheMemoryInitMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/CodeCacheMemoryInitMetricTest.java
@@ -11,8 +11,6 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.METRIC_D
 import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.METRIC_NAME_MEMORY_INIT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.sdk.metrics.data.LongPointData;
-import io.opentelemetry.sdk.metrics.data.SumData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -32,14 +30,11 @@ class CodeCacheMemoryInitMetricTest {
                 .hasDescription(METRIC_DESCRIPTION_MEMORY_INIT)
                 .hasUnit(BYTES)
                 .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .map(LongPointData.class::cast)
-                          .anyMatch(
-                              pointData ->
-                                  pointData.getValue() > 0
-                                      && pointData.getAttributes().equals(ATTR_CODE_CACHE));
-                    }));
+                    data ->
+                        assertThat(data.getLongSumData().getPoints())
+                            .anyMatch(
+                                pointData ->
+                                    pointData.getValue() > 0
+                                        && pointData.getAttributes().equals(ATTR_CODE_CACHE))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrCPULockTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrCPULockTest.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.MILLISEC
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JfrCPULockTest {
+class JfrCPULockTest {
 
   @RegisterExtension
   JfrExtension jfrExtension =
@@ -18,7 +18,7 @@ public class JfrCPULockTest {
           builder -> builder.disableAllFeatures().enableFeature(JfrFeature.LOCK_METRICS));
 
   @Test
-  public void shouldHaveLockEvents() throws Exception {
+  void shouldHaveLockEvents() throws Exception {
     // This should generate some events
     System.gc();
     synchronized (this) {

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrClassesLoadedCountTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrClassesLoadedCountTest.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.contrib.jfr.streaming;
 
 import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.UNIT_CLASSES;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -33,7 +33,9 @@ class JfrClassesLoadedCountTest {
                         sum.hasPointsSatisfying(
                             point ->
                                 point.satisfies(
-                                    pointData -> Assertions.assertTrue(pointData.getValue() > 0)))),
+                                    pointData ->
+                                        assertThat(pointData.getValue())
+                                            .isGreaterThanOrEqualTo(0)))),
         metric ->
             metric
                 .hasName("process.runtime.jvm.classes.current_loaded")
@@ -45,7 +47,8 @@ class JfrClassesLoadedCountTest {
                             point ->
                                 point.satisfies(
                                     pointData ->
-                                        Assertions.assertTrue(pointData.getValue() >= 0)))),
+                                        assertThat(pointData.getValue())
+                                            .isGreaterThanOrEqualTo(0)))),
         metric ->
             metric
                 .hasName("process.runtime.jvm.classes.unloaded")
@@ -57,6 +60,7 @@ class JfrClassesLoadedCountTest {
                             point ->
                                 point.satisfies(
                                     pointData ->
-                                        Assertions.assertTrue(pointData.getValue() >= 0)))));
+                                        assertThat(pointData.getValue())
+                                            .isGreaterThanOrEqualTo(0)))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrOverallCPULoadHandlerTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrOverallCPULoadHandlerTest.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.UNIT_UTI
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JfrOverallCPULoadHandlerTest {
+class JfrOverallCPULoadHandlerTest {
 
   @RegisterExtension
   JfrExtension jfrExtension =
@@ -19,7 +19,7 @@ public class JfrOverallCPULoadHandlerTest {
               builder.disableAllFeatures().enableFeature(JfrFeature.CPU_UTILIZATION_METRICS));
 
   @Test
-  public void shouldHaveCPULoadEvents() throws Exception {
+  void shouldHaveCPULoadEvents() {
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrThreadCountTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrThreadCountTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
-import io.opentelemetry.sdk.metrics.data.SumData;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -22,26 +22,13 @@ class JfrThreadCountTest {
       new JfrExtension(
           builder -> builder.disableAllFeatures().enableFeature(JfrFeature.THREAD_METRICS));
 
-  private static final int SAMPLING_INTERVAL = 1000;
-
-  private static void doWork() throws InterruptedException {
-    Thread.sleep(2 * SAMPLING_INTERVAL);
-  }
-
-  private static boolean isDaemon(LongPointData p) {
-    Boolean daemon = p.getAttributes().get(AttributeKey.booleanKey(DAEMON));
-    assertThat(daemon).isNotNull();
-    return daemon;
-  }
-
   @Test
   void shouldHaveJfrThreadCountEvents() throws Exception {
     // This should generate some events
     Runnable work =
         () -> {
-          // create contention between threads for one lock
           try {
-            doWork();
+            Thread.sleep(2000);
           } catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
@@ -63,12 +50,13 @@ class JfrThreadCountTest {
                 .hasName("process.runtime.jvm.threads.count")
                 .hasUnit(UNIT_THREADS)
                 .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .map(LongPointData.class::cast)
-                          .anyMatch(p -> p.getValue() > 0 && isDaemon(p))
-                          .anyMatch(p -> p.getValue() > 0 && !isDaemon(p));
-                    }));
+                    data ->
+                        assertThat(data.getLongSumData().getPoints())
+                            .anyMatch(p -> p.getValue() > 0 && !isDaemon(p))
+                            .anyMatch(p -> p.getValue() > 0 && isDaemon(p))));
+  }
+
+  private static boolean isDaemon(LongPointData p) {
+    return Objects.requireNonNull(p.getAttributes().get(AttributeKey.booleanKey(DAEMON)));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrThreadCountTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrThreadCountTest.java
@@ -24,10 +24,10 @@ class JfrThreadCountTest {
 
   @Test
   void shouldHaveJfrThreadCountEvents() throws Exception {
-    // This should generate some events
     Runnable work =
         () -> {
           try {
+            // Sleep enough to produce events, based on ThreadCountHandler#getPollingDuration()
             Thread.sleep(2000);
           } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/MetaspaceMemoryLimitMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/MetaspaceMemoryLimitMetricTest.java
@@ -10,9 +10,6 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.BYTES;
 import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.METRIC_DESCRIPTION_MEMORY_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.metrics.data.SumData;
-import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -26,21 +23,15 @@ class MetaspaceMemoryLimitMetricTest {
   @Test
   void shouldHaveMemoryLimitMetrics() {
     System.gc();
-    check(
-        metricData -> {
-          SumData<?> sumData = metricData.getLongSumData();
-          assertThat(sumData.getPoints())
-              .anyMatch(p -> p.getAttributes().equals(ATTR_COMPRESSED_CLASS_SPACE));
-        });
-  }
-
-  private void check(ThrowingConsumer<MetricData> attributeCheck) {
     jfrExtension.waitAndAssertMetrics(
         metric ->
             metric
                 .hasName("process.runtime.jvm.memory.limit")
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_MEMORY_LIMIT)
-                .satisfies(attributeCheck));
+                .satisfies(
+                    data ->
+                        assertThat(data.getLongSumData().getPoints())
+                            .anyMatch(p -> p.getAttributes().equals(ATTR_COMPRESSED_CLASS_SPACE))));
   }
 }

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/MetaspaceMemoryUsageMetricTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/MetaspaceMemoryUsageMetricTest.java
@@ -12,7 +12,6 @@ import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.METRIC_D
 import static io.opentelemetry.contrib.jfr.streaming.internal.Constants.METRIC_NAME_MEMORY;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.sdk.metrics.data.SumData;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -23,10 +22,7 @@ class MetaspaceMemoryUsageMetricTest {
       new JfrExtension(
           builder -> builder.disableAllFeatures().enableFeature(JfrFeature.MEMORY_POOL_METRICS));
 
-  /**
-   * This is a basic test for process.runtime.jvm.memory.usage and
-   * process.runtime.jvm.memory.usage_after_last_gc metrics.
-   */
+  /** This is a basic test for process.runtime.jvm.memory.usage. */
   @Test
   void shouldHaveMemoryUsageMetrics() {
     System.gc();
@@ -39,21 +35,9 @@ class MetaspaceMemoryUsageMetricTest {
                 .hasUnit(BYTES)
                 .hasDescription(METRIC_DESCRIPTION_MEMORY)
                 .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_METASPACE));
-                    }),
-        metric ->
-            metric
-                .hasName(METRIC_NAME_MEMORY)
-                .hasUnit(BYTES)
-                .hasDescription(METRIC_DESCRIPTION_MEMORY)
-                .satisfies(
-                    metricData -> {
-                      SumData<?> sumData = metricData.getLongSumData();
-                      assertThat(sumData.getPoints())
-                          .anyMatch(p -> p.getAttributes().equals(ATTR_COMPRESSED_CLASS_SPACE));
-                    }));
+                    data ->
+                        assertThat(data.getLongSumData().getPoints())
+                            .anyMatch(p -> p.getAttributes().equals(ATTR_METASPACE))
+                            .anyMatch(p -> p.getAttributes().equals(ATTR_COMPRESSED_CLASS_SPACE))));
   }
 }


### PR DESCRIPTION
Makes the jfr-streaming tests a bit idiomatic:
- Eliminates couple usages of junit assertions
- Package private test classes and methods
- Fluent assertions instead of helper functions