### PR TITLE
Remove publishing of jfr-streaming

### DIFF
--- a/jfr-streaming/build.gradle.kts
+++ b/jfr-streaming/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
   id("otel.java-conventions")
   id("java-test-fixtures")
-
-  id("otel.publish-conventions")
 }
 
 description = "OpenTelemetry JFR Streaming"

--- a/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrTelemetryTest.java
+++ b/jfr-streaming/src/test/java/io/opentelemetry/contrib/jfr/streaming/JfrTelemetryTest.java
@@ -50,8 +50,9 @@ class JfrTelemetryTest {
               metric -> {
                 assertThat(metric.getInstrumentationScopeInfo().getName())
                     .isEqualTo("io.opentelemetry.contrib.jfr.streaming");
-                assertThat(metric.getInstrumentationScopeInfo().getVersion())
-                    .matches("1\\..*-alpha.*");
+                // TODO (trask) uncomment after moving to instrumentation repo
+                //                assertThat(metric.getInstrumentationScopeInfo().getVersion())
+                //                    .matches("1\\..*-alpha.*");
               });
       ;
     }


### PR DESCRIPTION
There hasn't been a release yet since publishing of jfr-streaming was enabled, and we are planning to move it to instrumentation repo, so makes sense to limit maven central clutter.