### PR TITLE
[maven-extension] Emit a warning rather than failing the build with an exception on illegal state

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.maven;
 
 import com.google.auto.value.AutoValue;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,7 +61,7 @@ public final class SpanRegistry {
               + mavenProject.getGroupId()
               + ":"
               + mavenProject.getArtifactId());
-      return getInvalidSpan();
+      return Span.getInvalid();
     }
     return span;
   }
@@ -71,20 +70,16 @@ public final class SpanRegistry {
     Span rootSpan = this.rootSpan;
     if (rootSpan == null) {
       logger.warn("Root span not defined");
-      return getInvalidSpan();
+      return Span.getInvalid();
     }
     return rootSpan;
-  }
-
-  private static Span getInvalidSpan() {
-    return OpenTelemetry.noop().getTracer("invalid").spanBuilder("invalid").startSpan();
   }
 
   public Span removeRootSpan() {
     Span rootSpan = this.rootSpan;
     if (rootSpan == null) {
       logger.warn("Root span not defined");
-      return getInvalidSpan();
+      return Span.getInvalid();
     }
     if (!this.mojoExecutionKeySpanMap.isEmpty()) {
 
@@ -122,7 +117,7 @@ public final class SpanRegistry {
     Span span = mavenProjectKeySpanMap.remove(key);
     if (span == null) {
       logger.warn("No span found for " + mavenProject);
-      return getInvalidSpan();
+      return Span.getInvalid();
     }
     return span;
   }
@@ -134,7 +129,7 @@ public final class SpanRegistry {
     Span span = mojoExecutionKeySpanMap.remove(key);
     if (span == null) {
       logger.warn("No span found for " + mojoExecution + " " + project);
-      return getInvalidSpan();
+      return Span.getInvalid();
     }
     return span;
   }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
@@ -43,12 +43,11 @@ public final class SpanRegistry {
    */
   public void setRootSpan(Span rootSpan) {
     if (this.rootSpan != null) {
-      String message =
+      logger.warn(
           "Root span already defined "
               + this.rootSpan
               + ", can't overwrite root span with "
-              + rootSpan;
-      logger.warn(message);
+              + rootSpan);
     }
     this.rootSpan = rootSpan;
   }
@@ -58,12 +57,11 @@ public final class SpanRegistry {
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span span = this.mavenProjectKeySpanMap.get(key);
     if (span == null) {
-      String message =
+      logger.warn(
           "Span not started for project "
               + mavenProject.getGroupId()
               + ":"
-              + mavenProject.getArtifactId();
-      logger.warn(message);
+              + mavenProject.getArtifactId());
       return getInvalidSpan();
     }
     return span;

--- a/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/SpanRegistry.java
@@ -30,9 +30,6 @@ import org.slf4j.LoggerFactory;
 @Component(role = SpanRegistry.class)
 public final class SpanRegistry {
 
-  static final boolean FAIL_ON_ILLEGAL_STATE =
-      Boolean.parseBoolean(System.getenv("OTEL_SPAN_REGISTRY_FAIL_ON_ILLEGAL_STATE"));
-
   private static final Logger logger = LoggerFactory.getLogger(SpanRegistry.class);
 
   private final Map<MojoExecutionKey, Span> mojoExecutionKeySpanMap = new ConcurrentHashMap<>();
@@ -51,11 +48,7 @@ public final class SpanRegistry {
               + this.rootSpan
               + ", can't overwrite root span with "
               + rootSpan;
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn(message);
     }
     this.rootSpan = rootSpan;
   }
@@ -70,11 +63,7 @@ public final class SpanRegistry {
               + mavenProject.getGroupId()
               + ":"
               + mavenProject.getArtifactId();
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn(message);
       return getInvalidSpan();
     }
     return span;
@@ -83,12 +72,7 @@ public final class SpanRegistry {
   public Span getRootSpanNotNull() {
     Span rootSpan = this.rootSpan;
     if (rootSpan == null) {
-      String message = "Root span not defined";
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("Root span not defined");
       return getInvalidSpan();
     }
     return rootSpan;
@@ -101,25 +85,16 @@ public final class SpanRegistry {
   public Span removeRootSpan() {
     Span rootSpan = this.rootSpan;
     if (rootSpan == null) {
-      String message = "Root span not defined";
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("Root span not defined");
       return getInvalidSpan();
     }
     if (!this.mojoExecutionKeySpanMap.isEmpty()) {
-      String message =
+
+      logger.warn(
           "Remaining children spans: "
               + this.mojoExecutionKeySpanMap.keySet().stream()
                   .map(MojoExecutionKey::toString)
-                  .collect(Collectors.joining(", "));
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+                  .collect(Collectors.joining(", ")));
     }
     this.rootSpan = null;
     return rootSpan;
@@ -130,12 +105,7 @@ public final class SpanRegistry {
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span previousSpanForKey = mavenProjectKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
-      String message = "A span has already been started for " + mavenProject;
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("A span has already been started for " + mavenProject);
     }
   }
 
@@ -144,12 +114,7 @@ public final class SpanRegistry {
     MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span previousSpanForKey = mojoExecutionKeySpanMap.put(key, span);
     if (previousSpanForKey != null) {
-      String message = "A span has already been started for " + mojoExecution + ", " + project;
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("A span has already been started for " + mojoExecution + ", " + project);
     }
   }
 
@@ -158,12 +123,7 @@ public final class SpanRegistry {
     MavenProjectKey key = MavenProjectKey.fromMavenProject(mavenProject);
     Span span = mavenProjectKeySpanMap.remove(key);
     if (span == null) {
-      String message = "No span found for " + mavenProject;
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("No span found for " + mavenProject);
       return getInvalidSpan();
     }
     return span;
@@ -175,12 +135,7 @@ public final class SpanRegistry {
     MojoExecutionKey key = MojoExecutionKey.fromMojoExecution(mojoExecution, project);
     Span span = mojoExecutionKeySpanMap.remove(key);
     if (span == null) {
-      String message = "No span found for " + mojoExecution + " " + project;
-      if (FAIL_ON_ILLEGAL_STATE) {
-        throw new IllegalStateException(message);
-      } else {
-        logger.warn(message);
-      }
+      logger.warn("No span found for " + mojoExecution + " " + project);
       return getInvalidSpan();
     }
     return span;


### PR DESCRIPTION
**Description:**

When an inconsistency is identified on the state of spans (eg caused by the forced interruption of a build or a bug in the extension), emit a warniong message in the logs rather than throwing an exception that breaks the Maven build.

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/731

**Testing:**

No testing of this defensive code was identified nor implemented.

**Documentation:**

None.

**Outstanding items:**

None
