### PR TITLE
[maven-extension] Remove dependency to grpc-netty-shaded as opentelemetry-exporter-otlp…

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -23,8 +23,6 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-semconv")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
-  implementation("io.grpc:grpc-netty-shaded")
-
   annotationProcessor("com.google.auto.value:auto-value")
   compileOnly("com.google.auto.value:auto-value-annotations")
 


### PR DESCRIPTION

**Description:**

Remove dependency to grpc-netty-shaded as opentelemetry-exporter-otlp pulls okhttp3.

**Existing Issue(s):**

None

**Testing:**

No testing in place for GRPC calls

**Documentation:**

No change visible to users

**Outstanding items:**

None
