### PR TITLE
Bump SDK & instrumentation versions to 1.24

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -17,8 +17,8 @@ val DEPENDENCY_BOMS = listOf(
   "com.linecorp.armeria:armeria-bom:1.22.1",
   "org.junit:junit-bom:5.9.2",
   "io.grpc:grpc-bom:1.53.0",
-  "io.opentelemetry:opentelemetry-bom-alpha:1.23.1-alpha",
-  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.23.0-alpha",
+  "io.opentelemetry:opentelemetry-bom-alpha:1.24.0-alpha",
+  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.24.0-alpha",
   "org.testcontainers:testcontainers-bom:1.17.6"
 )
 


### PR DESCRIPTION
Replaces the 2 dependabot PRs