### PR TITLE
[chore] update AWS component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -11,11 +11,14 @@
 # `comp:*` labels
 components:
   aws-resources:
-    - willarmiros
+    - wangzlei
+    - srprash
   aws-xray:
-    - willarmiros
+    - wangzlei
+    - srprash
   aws-xray-propagator:
-    - willarmiros
+    - wangzlei
+    - srprash
   consistent-sampling:
     - oertl
     - PeterF778

--- a/aws-resources/README.md
+++ b/aws-resources/README.md
@@ -4,6 +4,7 @@ This module contains AWS resource detectors including Beanstalk, EC2, ECS, EKS, 
 
 ## Component owners
 
-- [William Armiros](https://github.com/willarmiros), AWS
+- [Lei Wang](https://github.com/wangzlei), AWS
+- [Prashant Srivastava](https://github.com/srprash), AWS
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).

--- a/aws-xray-propagator/README.md
+++ b/aws-xray-propagator/README.md
@@ -5,6 +5,7 @@ the [AWS X-Ray Trace Header propagation protocol](https://docs.aws.amazon.com/xr
 
 ## Component owners
 
-- [William Armiros](https://github.com/willarmiros), AWS
+- [Lei Wang](https://github.com/wangzlei), AWS
+- [Prashant Srivastava](https://github.com/srprash), AWS
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).

--- a/aws-xray/README.md
+++ b/aws-xray/README.md
@@ -4,6 +4,7 @@ This module contains a custom `IdGenerator` and `Sampler` for use with AWS X-Ray
 
 ## Component owners
 
-- [William Armiros](https://github.com/willarmiros), AWS
+- [Lei Wang](https://github.com/wangzlei), AWS
+- [Prashant Srivastava](https://github.com/srprash), AWS
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
I am transferring ownership of the AWS components (X-Ray ID generator + propagator, and AWS resource detectors) to @srprash and @wangzlei, who will be taking care of maintenance going forward.