### PR TITLE
Avoid dependency bom conflict

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -17,7 +17,6 @@ val DEPENDENCY_BOMS = listOf(
   "com.linecorp.armeria:armeria-bom:1.23.1",
   "org.junit:junit-bom:5.9.2",
   "io.grpc:grpc-bom:1.54.1",
-  "io.opentelemetry:opentelemetry-bom-alpha:1.24.0-alpha",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.24.0-alpha",
   "org.testcontainers:testcontainers-bom:1.18.0"
 )


### PR DESCRIPTION
This should avoid the situation we ended up in where the dependabot updates on each one independently failed.