### PR TITLE
Add AwsAttributeKeys to awsxray

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.awsxray;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/** Utility class holding attribute keys with special meaning to AWS components */
+final class AwsAttributeKeys {
+
+  private AwsAttributeKeys() {}
+
+  static final AttributeKey<String> AWS_LOCAL_OPERATION =
+      AttributeKey.stringKey("aws.local.operation");
+
+  static final AttributeKey<String> AWS_REMOTE_APPLICATION =
+      AttributeKey.stringKey("aws.remote.application");
+
+  static final AttributeKey<String> AWS_REMOTE_OPERATION =
+      AttributeKey.stringKey("aws.remote.operation");
+}

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
@@ -15,8 +15,8 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_LOCAL_OPERATION =
       AttributeKey.stringKey("aws.local.operation");
 
-  static final AttributeKey<String> AWS_REMOTE_APPLICATION =
-      AttributeKey.stringKey("aws.remote.application");
+  static final AttributeKey<String> AWS_REMOTE_SERVICE =
+      AttributeKey.stringKey("aws.remote.service");
 
   static final AttributeKey<String> AWS_REMOTE_OPERATION =
       AttributeKey.stringKey("aws.remote.operation");


### PR DESCRIPTION
**Description:**

This PR introduce 3 AWS attributes into awsxray.

* `aws.local.operation` is created when a local root span is found.
* `aws.remote.service` and `aws.remote.operation` will be created by user's manual instrumentation.

This is the prerequisite PR for the SpanMetricsProcessor mentioned in https://github.com/open-telemetry/opentelemetry-java-contrib/issues/789, and the AwsAttributePropagatingSpanProcessor in https://github.com/open-telemetry/opentelemetry-java-contrib/pull/777 to work.

Please note this PR supplants https://github.com/open-telemetry/opentelemetry-java-contrib/pull/800, the author of which is not currently able to close it. Maintainers can feel free to close it on our behalf.

**Testing:**

N/A

**Documentation:**

N/A

**Outstanding items:**

N/A
