### PR TITLE
Fix native mode error cause by static init of random

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -40,7 +40,6 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
 
   static final long DEFAULT_TARGET_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(10);
 
-  private static final Random RANDOM = new Random();
   private static final Logger logger = Logger.getLogger(AwsXrayRemoteSampler.class.getName());
 
   private final Resource resource;
@@ -97,7 +96,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
 
     this.pollingIntervalNanos = pollingIntervalNanos;
     // Add ~1% of jitter
-    jitterNanos = RANDOM.longs(0, pollingIntervalNanos / 100).iterator();
+    jitterNanos = new Random().longs(0, pollingIntervalNanos / 100).iterator();
 
     // Execute first update right away on the executor thread.
     executor.execute(this::getAndUpdateSampler);

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -96,7 +97,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
 
     this.pollingIntervalNanos = pollingIntervalNanos;
     // Add ~1% of jitter
-    jitterNanos = new Random().longs(0, pollingIntervalNanos / 100).iterator();
+    jitterNanos = ThreadLocalRandom.current().longs(0, pollingIntervalNanos / 100).iterator();
 
     // Execute first update right away on the executor thread.
     executor.execute(this::getAndUpdateSampler);


### PR DESCRIPTION
**Description:**

Native build fails because AwsXrayRemoteSampler.java statically inits a Random()
This is not allowed, as explained here:
https://foivos.zakkak.net/tutorials/working-with-randoms-native-images/

See discussion here: https://github.com/quarkusio/quarkus/discussions/33154

