### PR TITLE
Stop publishing static instrumenter maven plugin

### DIFF
--- a/static-instrumenter/maven-plugin/build.gradle.kts
+++ b/static-instrumenter/maven-plugin/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("com.github.johnrengelman.shadow")
 
   id("otel.java-conventions")
-  id("otel.publish-conventions")
 }
 
 description = "Maven3 plugin for static instrumentation of projects code and dependencies"


### PR DESCRIPTION
Since we don't publish any other parts of the static-instrumenter project