### PR TITLE
Add links based sample option to config

### DIFF
--- a/samplers/build.gradle.kts
+++ b/samplers/build.gradle.kts
@@ -9,4 +9,7 @@ otelJava.moduleName.set("io.opentelemetry.contrib.sampler")
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
   api("io.opentelemetry:opentelemetry-semconv")
+  api("io.opentelemetry:opentelemetry-exporter-otlp")
+  api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
 }

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/LinksParentAlwaysOnSamplerProvider.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/LinksParentAlwaysOnSamplerProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public class LinksParentAlwaysOnSamplerProvider implements ConfigurableSamplerProvider {
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    return LinksBasedSampler.create(Sampler.parentBased(Sampler.alwaysOn()));
+  }
+
+  @Override
+  public String getName() {
+    return "linksbased_parentbased_always_on";
+  }
+}

--- a/samplers/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
+++ b/samplers/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.contrib.sampler.LinksParentAlwaysOnSamplerProvider


### PR DESCRIPTION
**Description:**

We do not have the option to use the LinksBasedSampler in the config.
This adds the option "linksbased_parentbased_always_on".

**Existing Issue(s):**

**Testing:**

Unit test

**Documentation:**

**Outstanding items:**
