### PR TITLE
Enhance AWS APM metrics mapping implementation

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
@@ -24,4 +24,12 @@ final class AwsAttributeKeys {
 
   static final AttributeKey<String> AWS_REMOTE_OPERATION =
       AttributeKey.stringKey("aws.remote.operation");
+
+  static final AttributeKey<String> AWS_REMOTE_TARGET = AttributeKey.stringKey("aws.remote.target");
+
+  // use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
+  static final AttributeKey<String> AWS_BUCKET_NAME = AttributeKey.stringKey("aws.bucket.name");
+  static final AttributeKey<String> AWS_QUEUE_NAME = AttributeKey.stringKey("aws.queue.name");
+  static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");
+  static final AttributeKey<String> AWS_TABLE_NAME = AttributeKey.stringKey("aws.table.name");
 }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsAttributeKeys.java
@@ -28,6 +28,10 @@ final class AwsAttributeKeys {
   static final AttributeKey<String> AWS_REMOTE_TARGET = AttributeKey.stringKey("aws.remote.target");
 
   // use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
+  // TODO: all AWS specific attributes should be defined in semconv package and reused cross all
+  // otel packages. Related sim -
+  // https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8710
+
   static final AttributeKey<String> AWS_BUCKET_NAME = AttributeKey.stringKey("aws.bucket.name");
   static final AttributeKey<String> AWS_QUEUE_NAME = AttributeKey.stringKey("aws.queue.name");
   static final AttributeKey<String> AWS_STREAM_NAME = AttributeKey.stringKey("aws.stream.name");


### PR DESCRIPTION
**Description:**
Enhance AWS APM metrics mapping implementation to resolve a few of the following "Unknown" metric attributes use cases.

- if span name used in ingress operation is not valid with values of 'null', 'UnknownOperation' and 'HttpMethod value` for HTTP request use cases. We will try to extract the ingress operation from `http.method` and `http.target` attributes.
- if the remote service attribute can not be directly derived from the attributes such `rpc.name`, `db.system`. We will try to fill it with the `net.peer.name` and `net.sock.peer.addr` attribute values and have Collector to do the further resolution on the populated values. 
- if the remote operation attribute is `Unknown`, We will try to extract the remote operation from  `http.method` and `http.url` attributes.
- Add a new `aws.remote.target` attribute for supporting the following 4 AWS resources when invoking it with Client Spans  
   - AWS S3 Bucket Name
   - AWS Queue Name
   - AWS Stream Name
   - AWS DynamoDB table name

**Testing:**
unit test and adhoc

**Documentation:**
N/A

**Outstanding items:**
N/A
