### PR TITLE
generate error/fault metrics by aws sdk status code

### DIFF
--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
@@ -22,16 +22,21 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.internal.data.ExceptionEventData;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link AwsSpanMetricsProcessor}. */
 class AwsSpanMetricsProcessorTest {
-
   // Test constants
   private static final boolean CONTAINS_ATTRIBUTES = true;
   private static final boolean CONTAINS_NO_ATTRIBUTES = false;
@@ -55,6 +60,32 @@ class AwsSpanMetricsProcessorTest {
   private MetricAttributeGenerator generatorMock;
 
   private AwsSpanMetricsProcessor awsSpanMetricsProcessor;
+
+  static class ThrowableWithMethodGetStatusCode extends Throwable {
+    private final int httpStatusCode;
+
+    ThrowableWithMethodGetStatusCode(int httpStatusCode) {
+      this.httpStatusCode = httpStatusCode;
+    }
+
+    public int getStatusCode() {
+      return this.httpStatusCode;
+    }
+  }
+
+  static class ThrowableWithMethodStatusCode extends Throwable {
+    private final int httpStatusCode;
+
+    ThrowableWithMethodStatusCode(int httpStatusCode) {
+      this.httpStatusCode = httpStatusCode;
+    }
+
+    public int statusCode() {
+      return this.httpStatusCode;
+    }
+  }
+
+  static class ThrowableWithoutStatusCode extends Throwable {}
 
   @BeforeEach
   public void setUpMocks() {
@@ -150,6 +181,16 @@ class AwsSpanMetricsProcessorTest {
   }
 
   @Test
+  public void testOnEndMetricsGenerationWithAwsStatusCodes() {
+    validateMetricsGeneratedForAwsStatusCode(399L, ExpectedStatusMetric.NEITHER);
+    validateMetricsGeneratedForAwsStatusCode(400L, ExpectedStatusMetric.ERROR);
+    validateMetricsGeneratedForAwsStatusCode(499L, ExpectedStatusMetric.ERROR);
+    validateMetricsGeneratedForAwsStatusCode(500L, ExpectedStatusMetric.FAULT);
+    validateMetricsGeneratedForAwsStatusCode(599L, ExpectedStatusMetric.FAULT);
+    validateMetricsGeneratedForAwsStatusCode(600L, ExpectedStatusMetric.NEITHER);
+  }
+
+  @Test
   public void testOnEndMetricsGenerationWithStatusCodes() {
     // Invalid HTTP status codes
     validateMetricsGeneratedForHttpStatusCode(null, ExpectedStatusMetric.NEITHER);
@@ -192,8 +233,39 @@ class AwsSpanMetricsProcessorTest {
 
     // Configure spanData
     SpanData mockSpanData = mock(SpanData.class);
+    InstrumentationScopeInfo awsSdkScopeInfo =
+        InstrumentationScopeInfo.builder("aws-sdk").setVersion("version").build();
+    when(mockSpanData.getInstrumentationScopeInfo()).thenReturn(awsSdkScopeInfo);
     when(mockSpanData.getAttributes()).thenReturn(spanAttributes);
     when(mockSpanData.getTotalAttributeCount()).thenReturn(spanAttributes.size());
+    when(readableSpanMock.toSpanData()).thenReturn(mockSpanData);
+
+    return readableSpanMock;
+  }
+
+  private static ReadableSpan buildReadableSpanWithThrowableMock(Throwable throwable) {
+    // config http status code as null
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, null);
+    ReadableSpan readableSpanMock = mock(ReadableSpan.class);
+    SpanData mockSpanData = mock(SpanData.class);
+    InstrumentationScopeInfo awsSdkScopeInfo =
+        InstrumentationScopeInfo.builder("aws-sdk").setVersion("version").build();
+    ExceptionEventData mockEventData = mock(ExceptionEventData.class);
+    List<EventData> events = new ArrayList<>(Arrays.asList(mockEventData));
+
+    // Configure latency
+    when(readableSpanMock.getLatencyNanos()).thenReturn(TEST_LATENCY_NANOS);
+
+    // Configure attributes
+    when(readableSpanMock.getAttribute(any()))
+        .thenAnswer(invocation -> spanAttributes.get(invocation.getArgument(0)));
+
+    // Configure spanData
+    when(mockSpanData.getInstrumentationScopeInfo()).thenReturn(awsSdkScopeInfo);
+    when(mockSpanData.getAttributes()).thenReturn(spanAttributes);
+    when(mockSpanData.getTotalAttributeCount()).thenReturn(spanAttributes.size());
+    when(mockSpanData.getEvents()).thenReturn(events);
+    when(mockEventData.getException()).thenReturn(throwable);
     when(readableSpanMock.toSpanData()).thenReturn(mockSpanData);
 
     return readableSpanMock;
@@ -214,6 +286,35 @@ class AwsSpanMetricsProcessorTest {
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
 
     awsSpanMetricsProcessor.onEnd(readableSpanMock);
+    validateMetrics(metricAttributes, expectedStatusMetric);
+  }
+
+  private void validateMetricsGeneratedForAwsStatusCode(
+      Long awsStatusCode, ExpectedStatusMetric expectedStatusMetric) {
+    Throwable throwableWithMethodGetStatusCode =
+        new ThrowableWithMethodGetStatusCode(awsStatusCode.intValue());
+    validateMetricsGeneratedByThrowable(throwableWithMethodGetStatusCode, expectedStatusMetric);
+
+    Throwable throwableWithMethodStatusCode =
+        new ThrowableWithMethodGetStatusCode(awsStatusCode.intValue());
+    validateMetricsGeneratedByThrowable(throwableWithMethodStatusCode, expectedStatusMetric);
+
+    Throwable throwableWithoutStatusCode = new ThrowableWithoutStatusCode();
+    validateMetricsGeneratedByThrowable(throwableWithoutStatusCode, ExpectedStatusMetric.NEITHER);
+  }
+
+  private void validateMetricsGeneratedByThrowable(
+      Throwable throwable, ExpectedStatusMetric expectedStatusMetric) {
+    ReadableSpan readableSpanMock = buildReadableSpanWithThrowableMock(throwable);
+    Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
+    configureMocksForOnEnd(readableSpanMock, metricAttributes);
+
+    awsSpanMetricsProcessor.onEnd(readableSpanMock);
+    validateMetrics(metricAttributes, expectedStatusMetric);
+  }
+
+  private void validateMetrics(
+      Attributes metricAttributes, ExpectedStatusMetric expectedStatusMetric) {
     switch (expectedStatusMetric) {
       case ERROR:
         verify(errorCounterMock, times(1)).add(eq(1L), eq(metricAttributes));


### PR DESCRIPTION
**Description:**

A short term solution to generate error/fault metrics by aws sdk status code.

When the AWS SDK calls an API then returns non-200 status code, the AWS SDK simply throws an exception. The exception thrown by the AWS SDK is stored within the produced spans and is accessible in the AwsSpanMetricsProcessor, where we generate Fault/Error metrics. 

We attempt to get the throwable object and call its getStatusCode method to obtain the status code, then generate metrics based on the corresponding status code.


**Existing Issue(s):**

[http.status_code attribute in span was not being populated when AWS APIs were returning non-200 status codes](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8795)

**Testing:**

unit tests

**Documentation:**
N/A

**Outstanding items:**
N/A
