### PR TITLE
Consolidate gradle enterprise version bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,14 @@
   ],
   "packageRules": [
     {
+      "matchPackagePrefixes": ["ch.qos.logback:"],
+      "groupName": "logback packages"
+    },
+    {
+      "matchPackagePrefixes": ["com.gradle.enterprise"],
+      "groupName": "gradle enterprise packages"
+    },
+    {
       // junit-pioneer 2+ requires Java 11+
       "matchPackageNames": ["org.junit-pioneer:junit-pioneer"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Resolves #983

Added the logback consolidation for consistency across repos even though logback isn't used in this repo (yet).