### PR TITLE
add a provider for consistent parent based probability sampler

### DIFF
--- a/consistent-sampling/build.gradle.kts
+++ b/consistent-sampling/build.gradle.kts
@@ -8,6 +8,7 @@ otelJava.moduleName.set("io.opentelemetry.contrib.sampler.consistent")
 
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk-trace")
+  api("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   testImplementation("org.hipparchus:hipparchus-core:2.3")
   testImplementation("org.hipparchus:hipparchus-stat:2.3")
 }

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent/ConsistentParentBasedProbabilitySamplerProvider.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent/ConsistentParentBasedProbabilitySamplerProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler.consistent;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+public final class ConsistentParentBasedProbabilitySamplerProvider
+    implements ConfigurableSamplerProvider {
+
+  @Override
+  public Sampler createSampler(ConfigProperties config) {
+    double samplingProbability = config.getDouble("otel.traces.sampler.arg", 1.0d);
+    return ConsistentSampler.parentBased(ConsistentSampler.probabilityBased(samplingProbability));
+  }
+
+  @Override
+  public String getName() {
+    return "consistent_parent_based_probability";
+  }
+}

--- a/consistent-sampling/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
+++ b/consistent-sampling/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.contrib.sampler.consistent.ConsistentParentBasedProbabilitySamplerProvider


### PR DESCRIPTION
**Description:**

Adding a ConfigurableSamplerProvider for parent based probability sampler to autoconfigure to use in auto instrumentation.

**Existing Issue(s):**

Discussed in here
https://github.com/open-telemetry/opentelemetry-java-contrib/discussions/999

**Testing:**

Tested it by using it in a java application with auto instrumentation on.

**Documentation:**


**Outstanding items:**

It's only adding a provider for one sampler that I need, but I am happy to discuss if we should add them all. 
