### PR TITLE
Disable OTel SDK shutdown hook registration

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -94,6 +94,7 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
         AutoConfiguredOpenTelemetrySdk.builder()
             .setServiceClassLoader(getClass().getClassLoader())
             .addPropertiesSupplier(() -> properties)
+            .disableShutdownHook()
             .build();
 
     if (logger.isDebugEnabled()) {


### PR DESCRIPTION
**Description:**

AutoConfiguredOpenTelemetrySdk by default registers a shutdown hook to close the SDK. Disable this shutdown hook registration as the shutdown of the OTel SDK is managed through Maven lifecycle management.

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/990


**Testing:**

Unfortunately, there is no testing framework provided by the Maven project to test Maven extensions.

**Documentation:**

None, it's a bug fix.

**Outstanding items:**

None