### PR TITLE
Issue-1034 Short XRay Trace

### DIFF
--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
@@ -294,6 +294,7 @@ public final class AwsXrayPropagator implements TextMapPropagator {
       return TraceId.getInvalid();
     }
 
+
     String epochPart = xrayTraceId.substring(firstDelimiter + 1, secondDelimiter);
 
     if (xrayTraceId.length() < secondDelimiter + 25) {

--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
@@ -295,6 +295,11 @@ public final class AwsXrayPropagator implements TextMapPropagator {
     }
 
     String epochPart = xrayTraceId.substring(firstDelimiter + 1, secondDelimiter);
+
+    if (xrayTraceId.length() < secondDelimiter + 25) {
+      return TraceId.getInvalid();
+    }
+
     String uniquePart = xrayTraceId.substring(secondDelimiter + 1, secondDelimiter + 25);
 
     // X-Ray trace id format is 1-{at most 8 digit hex}-{24 digit hex}

--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagator.java
@@ -294,7 +294,6 @@ public final class AwsXrayPropagator implements TextMapPropagator {
       return TraceId.getInvalid();
     }
 
-
     String epochPart = xrayTraceId.substring(firstDelimiter + 1, secondDelimiter);
 
     if (xrayTraceId.length() < secondDelimiter + 25) {

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagatorTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayPropagatorTest.java
@@ -288,11 +288,21 @@ class AwsXrayPropagatorTest {
   }
 
   @Test
-  void extract_InvalidTraceId_Size() {
+  void extract_InvalidTraceId_Size_TooBig() {
     Map<String, String> invalidHeaders = new LinkedHashMap<>();
     invalidHeaders.put(
         TRACE_HEADER_KEY,
         "Root=1-8a3c60f7-d188f8fa79d48a391a778fa600;Parent=53995c3f42cd8ad8;Sampled=0");
+
+    verifyInvalidBehavior(invalidHeaders);
+  }
+
+  @Test
+  void extract_InvalidTraceId_Size_TooShort() {
+    Map<String, String> invalidHeaders = new LinkedHashMap<>();
+    invalidHeaders.put(
+        TRACE_HEADER_KEY,
+        "Root=1-64fbd5a9-2202432c9dfed25ae1e6996;Parent=53995c3f42cd8ad8;Sampled=0");
 
     verifyInvalidBehavior(invalidHeaders);
   }


### PR DESCRIPTION
**Description:**

Bug fix  - Handle too short `X-Amzn-Trace-Id` header

**Existing Issue(s):**

[AWS Propagator throws exception when used with Netty ](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1034)

**Testing:**

Added new test for short trace id

**Documentation:**

No documentation change needed 

**Outstanding items:**

None
