### PR TITLE
Move to io.opentelemetry.semconv:opentelemetry-semconv

### DIFF
--- a/aws-xray/build.gradle.kts
+++ b/aws-xray/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("io.opentelemetry:opentelemetry-semconv")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
 
   annotationProcessor("com.google.auto.service:auto-service")
   testImplementation("com.google.auto.service:auto-service")
@@ -43,12 +43,5 @@ testing {
         runtimeOnly("org.slf4j:slf4j-simple")
       }
     }
-  }
-}
-
-configurations.all {
-  resolutionStrategy {
-    // TODO this module still needs to be updated to the latest semconv
-    force("io.opentelemetry:opentelemetry-semconv:1.28.0-alpha")
   }
 }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGenerator.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGenerator.java
@@ -15,24 +15,24 @@ import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_REMOTE_TARGE
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_SPAN_KIND;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_STREAM_NAME;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_TABLE_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_INVOKED_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_TRIGGER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_ADDR;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_PORT;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.PEER_SERVICE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_METHOD;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.FAAS_INVOKED_NAME;
+import static io.opentelemetry.semconv.SemanticAttributes.FAAS_TRIGGER;
+import static io.opentelemetry.semconv.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.SemanticAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.SemanticAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
+import static io.opentelemetry.semconv.SemanticAttributes.URL_FULL;
+import static io.opentelemetry.semconv.SemanticAttributes.URL_PATH;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -40,8 +40,8 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
@@ -156,8 +156,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     if (operation == null || operation.equals(UNKNOWN_OPERATION)) {
       return false;
     }
-    if (isKeyPresent(span, HTTP_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_METHOD);
+    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
+      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
       return !operation.equals(httpMethod);
     }
     return true;
@@ -260,15 +260,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    */
   private static String generateIngressOperation(SpanData span) {
     String operation = UNKNOWN_OPERATION;
-    if (isKeyPresent(span, HTTP_TARGET)) {
-      String httpTarget = span.getAttributes().get(HTTP_TARGET);
+    if (isKeyPresent(span, URL_PATH)) {
+      String httpTarget = span.getAttributes().get(URL_PATH);
       // get the first part from API path string as operation value
       // the more levels/parts we get from API path the higher chance for getting high cardinality
       // data
       if (httpTarget != null) {
         operation = extractApiPathValue(httpTarget);
-        if (isKeyPresent(span, HTTP_METHOD)) {
-          String httpMethod = span.getAttributes().get(HTTP_METHOD);
+        if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
+          String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
           if (httpMethod != null) {
             operation = httpMethod + " " + operation;
           }
@@ -284,8 +284,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    */
   private static String generateRemoteOperation(SpanData span) {
     String remoteOperation = UNKNOWN_REMOTE_OPERATION;
-    if (isKeyPresent(span, HTTP_URL)) {
-      String httpUrl = span.getAttributes().get(HTTP_URL);
+    if (isKeyPresent(span, URL_FULL)) {
+      String httpUrl = span.getAttributes().get(URL_FULL);
       try {
         URL url;
         if (httpUrl != null) {
@@ -296,8 +296,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         logger.log(Level.FINEST, "invalid http.url attribute: ", httpUrl);
       }
     }
-    if (isKeyPresent(span, HTTP_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_METHOD);
+    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
+      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
       remoteOperation = httpMethod + " " + remoteOperation;
     }
     if (remoteOperation.equals(UNKNOWN_REMOTE_OPERATION)) {
@@ -325,16 +325,16 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
 
   private static String generateRemoteService(SpanData span) {
     String remoteService = UNKNOWN_REMOTE_SERVICE;
-    if (isKeyPresent(span, NET_PEER_NAME)) {
-      remoteService = getRemoteService(span, NET_PEER_NAME);
-      if (isKeyPresent(span, NET_PEER_PORT)) {
-        Long port = span.getAttributes().get(NET_PEER_PORT);
+    if (isKeyPresent(span, SERVER_ADDRESS)) {
+      remoteService = getRemoteService(span, SERVER_ADDRESS);
+      if (isKeyPresent(span, SERVER_PORT)) {
+        Long port = span.getAttributes().get(SERVER_PORT);
         remoteService += ":" + port;
       }
-    } else if (isKeyPresent(span, NET_SOCK_PEER_ADDR)) {
-      remoteService = getRemoteService(span, NET_SOCK_PEER_ADDR);
-      if (isKeyPresent(span, NET_SOCK_PEER_PORT)) {
-        Long port = span.getAttributes().get(NET_SOCK_PEER_PORT);
+    } else if (isKeyPresent(span, SERVER_SOCKET_ADDRESS)) {
+      remoteService = getRemoteService(span, SERVER_SOCKET_ADDRESS);
+      if (isKeyPresent(span, SERVER_SOCKET_PORT)) {
+        Long port = span.getAttributes().get(SERVER_SOCKET_PORT);
         remoteService += ":" + port;
       }
     } else {

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessor.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_STATUS_CODE;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -107,7 +107,7 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   }
 
   private void recordErrorOrFault(SpanData spanData, Attributes attributes) {
-    Long httpStatusCode = spanData.getAttributes().get(HTTP_STATUS_CODE);
+    Long httpStatusCode = spanData.getAttributes().get(HTTP_RESPONSE_STATUS_CODE);
     if (httpStatusCode == null) {
       httpStatusCode = getAwsStatusCode(spanData);
 

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
@@ -17,8 +17,8 @@ import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
@@ -162,13 +162,25 @@ final class SamplingRuleApplier {
     String host = null;
 
     for (Map.Entry<AttributeKey<?>, Object> entry : attributes.asMap().entrySet()) {
-      if (entry.getKey().equals(SemanticAttributes.HTTP_TARGET)) {
+      if (entry.getKey().equals(SemanticAttributes.URL_PATH)) {
         httpTarget = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.HTTP_URL)) {
+      } else if (entry.getKey().equals(SemanticAttributes.HTTP_TARGET)) {
+        // TODO remove support for deprecated http.target attribute
+        httpTarget = (String) entry.getValue();
+      } else if (entry.getKey().equals(SemanticAttributes.URL_FULL)) {
         httpUrl = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.HTTP_METHOD)) {
+      } else if (entry.getKey().equals(SemanticAttributes.HTTP_URL)) {
+        // TODO remove support for deprecated http.url attribute
+        httpUrl = (String) entry.getValue();
+      } else if (entry.getKey().equals(SemanticAttributes.HTTP_REQUEST_METHOD)) {
         httpMethod = (String) entry.getValue();
+      } else if (entry.getKey().equals(SemanticAttributes.HTTP_METHOD)) {
+        // TODO remove support for deprecated http.method attribute
+        httpMethod = (String) entry.getValue();
+      } else if (entry.getKey().equals(SemanticAttributes.SERVER_ADDRESS)) {
+        host = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.NET_HOST_NAME)) {
+        // TODO remove support for deprecated net.host.name attribute
         host = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.HTTP_HOST)) {
         // TODO (trask) remove support for deprecated http.host attribute

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGeneratorTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGeneratorTest.java
@@ -15,25 +15,25 @@ import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_REMOTE_TARGE
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_SPAN_KIND;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_STREAM_NAME;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_TABLE_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_INVOKED_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_INVOKED_PROVIDER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_TRIGGER;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_ADDR;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_PORT;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.PEER_SERVICE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_METHOD;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.FAAS_INVOKED_NAME;
+import static io.opentelemetry.semconv.SemanticAttributes.FAAS_INVOKED_PROVIDER;
+import static io.opentelemetry.semconv.SemanticAttributes.FAAS_TRIGGER;
+import static io.opentelemetry.semconv.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
+import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.SemanticAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.SemanticAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.SemanticAttributes.RPC_SERVICE;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_ADDRESS;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
+import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
+import static io.opentelemetry.semconv.SemanticAttributes.URL_FULL;
+import static io.opentelemetry.semconv.SemanticAttributes.URL_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -170,7 +170,7 @@ class AwsMetricAttributeGeneratorTest {
   public void testServerSpanWithSpanNameAsHttpMethod() {
     updateResourceWithServiceName();
     when(spanDataMock.getName()).thenReturn("GET");
-    mockAttribute(HTTP_METHOD, "GET");
+    mockAttribute(HTTP_REQUEST_METHOD, "GET");
 
     Attributes expectedAttributes =
         Attributes.of(
@@ -178,15 +178,15 @@ class AwsMetricAttributeGeneratorTest {
             AWS_LOCAL_SERVICE, SERVICE_NAME_VALUE,
             AWS_LOCAL_OPERATION, UNKNOWN_OPERATION);
     validateAttributesProducedForSpanOfKind(expectedAttributes, SpanKind.SERVER);
-    mockAttribute(HTTP_METHOD, null);
+    mockAttribute(HTTP_REQUEST_METHOD, null);
   }
 
   @Test
   public void testServerSpanWithSpanNameWithHttpTarget() {
     updateResourceWithServiceName();
     when(spanDataMock.getName()).thenReturn("POST");
-    mockAttribute(HTTP_METHOD, "POST");
-    mockAttribute(HTTP_TARGET, "/payment/123");
+    mockAttribute(HTTP_REQUEST_METHOD, "POST");
+    mockAttribute(URL_PATH, "/payment/123");
 
     Attributes expectedAttributes =
         Attributes.of(
@@ -197,8 +197,8 @@ class AwsMetricAttributeGeneratorTest {
             AWS_LOCAL_OPERATION,
             "POST /payment");
     validateAttributesProducedForSpanOfKind(expectedAttributes, SpanKind.SERVER);
-    mockAttribute(HTTP_METHOD, null);
-    mockAttribute(HTTP_TARGET, null);
+    mockAttribute(HTTP_REQUEST_METHOD, null);
+    mockAttribute(URL_PATH, null);
   }
 
   @Test
@@ -283,44 +283,44 @@ class AwsMetricAttributeGeneratorTest {
     mockAttribute(GRAPHQL_OPERATION_TYPE, null);
 
     // Validate behaviour of extracting Remote Service from net.peer.name
-    mockAttribute(NET_PEER_NAME, "www.example.com");
+    mockAttribute(SERVER_ADDRESS, "www.example.com");
     validateExpectedRemoteAttributes("www.example.com", UNKNOWN_REMOTE_OPERATION);
-    mockAttribute(NET_PEER_NAME, null);
+    mockAttribute(SERVER_ADDRESS, null);
 
     // Validate behaviour of extracting Remote Service from net.peer.name and net.peer.port
-    mockAttribute(NET_PEER_NAME, "192.168.0.0");
-    mockAttribute(NET_PEER_PORT, 8081L);
+    mockAttribute(SERVER_ADDRESS, "192.168.0.0");
+    mockAttribute(SERVER_PORT, 8081L);
     validateExpectedRemoteAttributes("192.168.0.0:8081", UNKNOWN_REMOTE_OPERATION);
-    mockAttribute(NET_PEER_NAME, null);
-    mockAttribute(NET_PEER_PORT, null);
+    mockAttribute(SERVER_ADDRESS, null);
+    mockAttribute(SERVER_PORT, null);
 
     // Validate behaviour of extracting Remote Service from net.peer.socket.addr
-    mockAttribute(NET_SOCK_PEER_ADDR, "www.example.com");
+    mockAttribute(SERVER_SOCKET_ADDRESS, "www.example.com");
     validateExpectedRemoteAttributes("www.example.com", UNKNOWN_REMOTE_OPERATION);
-    mockAttribute(NET_SOCK_PEER_ADDR, null);
+    mockAttribute(SERVER_SOCKET_ADDRESS, null);
 
     // Validate behaviour of extracting Remote Service from net.peer.socket.addr and
     // net.sock.peer.port
-    mockAttribute(NET_SOCK_PEER_ADDR, "192.168.0.0");
-    mockAttribute(NET_SOCK_PEER_PORT, 8081L);
+    mockAttribute(SERVER_SOCKET_ADDRESS, "192.168.0.0");
+    mockAttribute(SERVER_SOCKET_PORT, 8081L);
     validateExpectedRemoteAttributes("192.168.0.0:8081", UNKNOWN_REMOTE_OPERATION);
-    mockAttribute(NET_SOCK_PEER_ADDR, null);
-    mockAttribute(NET_SOCK_PEER_PORT, null);
+    mockAttribute(SERVER_SOCKET_ADDRESS, null);
+    mockAttribute(SERVER_SOCKET_PORT, null);
 
     // Validate behavior of Remote Operation from HttpTarget - with 1st api part, then remove it
-    mockAttribute(HTTP_URL, "http://www.example.com/payment/123");
+    mockAttribute(URL_FULL, "http://www.example.com/payment/123");
     validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, "/payment");
-    mockAttribute(HTTP_URL, null);
+    mockAttribute(URL_FULL, null);
 
     // Validate behavior of Remote Operation from HttpTarget - without 1st api part, then remove it
-    mockAttribute(HTTP_URL, "http://www.example.com");
+    mockAttribute(URL_FULL, "http://www.example.com");
     validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, "/");
-    mockAttribute(HTTP_URL, null);
+    mockAttribute(URL_FULL, null);
 
     // Validate behavior of Remote Operation from HttpTarget - invalid url, then remove it
-    mockAttribute(HTTP_URL, "abc");
+    mockAttribute(URL_FULL, "abc");
     validateExpectedRemoteAttributes(UNKNOWN_REMOTE_SERVICE, UNKNOWN_REMOTE_OPERATION);
-    mockAttribute(HTTP_URL, null);
+    mockAttribute(URL_FULL, null);
 
     // Validate behaviour of Peer service attribute, then remove it.
     mockAttribute(PEER_SERVICE, "Peer service");
@@ -338,8 +338,8 @@ class AwsMetricAttributeGeneratorTest {
     validatePeerServiceDoesOverride(FAAS_INVOKED_PROVIDER);
     validatePeerServiceDoesOverride(MESSAGING_SYSTEM);
     validatePeerServiceDoesOverride(GRAPHQL_OPERATION_TYPE);
-    validatePeerServiceDoesOverride(NET_PEER_NAME);
-    validatePeerServiceDoesOverride(NET_SOCK_PEER_ADDR);
+    validatePeerServiceDoesOverride(SERVER_ADDRESS);
+    validatePeerServiceDoesOverride(SERVER_SOCKET_ADDRESS);
     // Actually testing that peer service overrides "UnknownRemoteService".
     validatePeerServiceDoesOverride(AttributeKey.stringKey("unknown.service.key"));
   }

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_STATUS_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -141,7 +141,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithoutMetricAttributes() {
-    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 500L);
+    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 500L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_NO_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -154,7 +154,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithoutEndRequired() {
-    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 500L);
+    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 500L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -167,7 +167,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithLatency() {
-    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 200L);
+    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 200L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -245,7 +245,7 @@ class AwsSpanMetricsProcessorTest {
 
   private static ReadableSpan buildReadableSpanWithThrowableMock(Throwable throwable) {
     // config http status code as null
-    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, null);
+    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, null);
     ReadableSpan readableSpanMock = mock(ReadableSpan.class);
     SpanData mockSpanData = mock(SpanData.class);
     InstrumentationScopeInfo awsSdkScopeInfo =
@@ -280,7 +280,7 @@ class AwsSpanMetricsProcessorTest {
 
   private void validateMetricsGeneratedForHttpStatusCode(
       Long httpStatusCode, ExpectedStatusMetric expectedStatusMetric) {
-    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, httpStatusCode);
+    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplierTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplierTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -22,8 +22,8 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.time.TestClock;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
@@ -61,9 +61,9 @@ class SamplingRuleApplierTest {
 
     private final Attributes attributes =
         Attributes.builder()
-            .put(SemanticAttributes.HTTP_METHOD, "GET")
-            .put(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io")
-            .put(SemanticAttributes.HTTP_TARGET, "/instrument-me")
+            .put(SemanticAttributes.HTTP_REQUEST_METHOD, "GET")
+            .put(SemanticAttributes.SERVER_ADDRESS, "opentelemetry.io")
+            .put(SemanticAttributes.URL_PATH, "/instrument-me")
             .put(AttributeKey.stringKey("animal"), "cat")
             .put(AttributeKey.longKey("speed"), 10)
             .build();
@@ -109,8 +109,8 @@ class SamplingRuleApplierTest {
       assertThat(
               applier.matches(
                   attributes.toBuilder()
-                      .remove(SemanticAttributes.HTTP_TARGET)
-                      .put(SemanticAttributes.HTTP_URL, "scheme://host:port/instrument-me")
+                      .remove(SemanticAttributes.URL_PATH)
+                      .put(SemanticAttributes.URL_FULL, "scheme://host:port/instrument-me")
                       .build(),
                   resource))
           .isTrue();
@@ -133,7 +133,7 @@ class SamplingRuleApplierTest {
     @Test
     void methodNotMatch() {
       Attributes attributes =
-          this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "POST").build();
+          this.attributes.toBuilder().put(SemanticAttributes.HTTP_REQUEST_METHOD, "POST").build();
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
@@ -143,7 +143,7 @@ class SamplingRuleApplierTest {
       // wildcard.
       Attributes attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentelemetryfio")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentelemetryfio")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
@@ -151,20 +151,18 @@ class SamplingRuleApplierTest {
     @Test
     void pathNotMatch() {
       Attributes attributes =
+          this.attributes.toBuilder().put(SemanticAttributes.URL_PATH, "/instrument-you").build();
+      assertThat(applier.matches(attributes, resource)).isFalse();
+      attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.HTTP_TARGET, "/instrument-you")
+              .remove(SemanticAttributes.URL_PATH)
+              .put(SemanticAttributes.URL_FULL, "scheme://host:port/instrument-you")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
-              .remove(SemanticAttributes.HTTP_TARGET)
-              .put(SemanticAttributes.HTTP_URL, "scheme://host:port/instrument-you")
-              .build();
-      assertThat(applier.matches(attributes, resource)).isFalse();
-      attributes =
-          this.attributes.toBuilder()
-              .remove(SemanticAttributes.HTTP_TARGET)
-              .put(SemanticAttributes.HTTP_URL, "scheme://host:port")
+              .remove(SemanticAttributes.URL_PATH)
+              .put(SemanticAttributes.URL_FULL, "scheme://host:port")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
 
@@ -172,8 +170,8 @@ class SamplingRuleApplierTest {
       // present.
       attributes =
           this.attributes.toBuilder()
-              .remove(SemanticAttributes.HTTP_TARGET)
-              .put(SemanticAttributes.HTTP_URL, "host:port/instrument-me")
+              .remove(SemanticAttributes.URL_PATH)
+              .put(SemanticAttributes.URL_FULL, "host:port/instrument-me")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
@@ -236,9 +234,9 @@ class SamplingRuleApplierTest {
 
     private final Attributes attributes =
         Attributes.builder()
-            .put(SemanticAttributes.HTTP_METHOD, "GET")
-            .put(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io")
-            .put(SemanticAttributes.HTTP_TARGET, "/instrument-me?foo=bar&cat=meow")
+            .put(SemanticAttributes.HTTP_REQUEST_METHOD, "GET")
+            .put(SemanticAttributes.SERVER_ADDRESS, "opentelemetry.io")
+            .put(SemanticAttributes.URL_PATH, "/instrument-me?foo=bar&cat=meow")
             .put(AttributeKey.stringKey("animal"), "cat")
             .put(AttributeKey.longKey("speed"), 10)
             .build();
@@ -310,22 +308,24 @@ class SamplingRuleApplierTest {
     @Test
     void methodMatches() {
       Attributes attributes =
-          this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "BADGETGOOD").build();
+          this.attributes.toBuilder()
+              .put(SemanticAttributes.HTTP_REQUEST_METHOD, "BADGETGOOD")
+              .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
-          this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "BADGET").build();
+          this.attributes.toBuilder().put(SemanticAttributes.HTTP_REQUEST_METHOD, "BADGET").build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
-          this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "GETGET").build();
+          this.attributes.toBuilder().put(SemanticAttributes.HTTP_REQUEST_METHOD, "GETGET").build();
       assertThat(applier.matches(attributes, resource)).isTrue();
     }
 
     @Test
     void methodNotMatch() {
       Attributes attributes =
-          this.attributes.toBuilder().put(SemanticAttributes.HTTP_METHOD, "POST").build();
+          this.attributes.toBuilder().put(SemanticAttributes.HTTP_REQUEST_METHOD, "POST").build();
       assertThat(applier.matches(attributes, resource)).isFalse();
-      attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_METHOD);
+      attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_REQUEST_METHOD);
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
@@ -333,27 +333,27 @@ class SamplingRuleApplierTest {
     void hostMatches() {
       Attributes attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "alpha.opentelemetry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "alpha.opentelemetry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opfdnqtelemetry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opfdnqtelemetry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentglemetry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentglemetry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentglemry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentglemry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentglemrz.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentglemrz.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
     }
@@ -362,20 +362,20 @@ class SamplingRuleApplierTest {
     void hostNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentelemetryfio")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentelemetryfio")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "opentgalemetry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "opentgalemetry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.NET_HOST_NAME, "alpha.oentelemetry.io")
+              .put(SemanticAttributes.SERVER_ADDRESS, "alpha.oentelemetry.io")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
-      attributes = removeAttribute(this.attributes, SemanticAttributes.NET_HOST_NAME);
+      attributes = removeAttribute(this.attributes, SemanticAttributes.SERVER_ADDRESS);
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
@@ -383,13 +383,13 @@ class SamplingRuleApplierTest {
     void pathMatches() {
       Attributes attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.HTTP_TARGET, "/instrument-me?foo=bar&cat=")
+              .put(SemanticAttributes.URL_PATH, "/instrument-me?foo=bar&cat=")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
       // Deceptive question mark, it's actually a wildcard :-)
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.HTTP_TARGET, "/instrument-meafoo=bar&cat=")
+              .put(SemanticAttributes.URL_PATH, "/instrument-meafoo=bar&cat=")
               .build();
       assertThat(applier.matches(attributes, resource)).isTrue();
     }
@@ -398,15 +398,15 @@ class SamplingRuleApplierTest {
     void pathNotMatch() {
       Attributes attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.HTTP_TARGET, "/instrument-mea?foo=bar&cat=")
+              .put(SemanticAttributes.URL_PATH, "/instrument-mea?foo=bar&cat=")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
       attributes =
           this.attributes.toBuilder()
-              .put(SemanticAttributes.HTTP_TARGET, "foo/instrument-meafoo=bar&cat=")
+              .put(SemanticAttributes.URL_PATH, "foo/instrument-meafoo=bar&cat=")
               .build();
       assertThat(applier.matches(attributes, resource)).isFalse();
-      attributes = removeAttribute(this.attributes, SemanticAttributes.HTTP_TARGET);
+      attributes = removeAttribute(this.attributes, SemanticAttributes.URL_PATH);
       assertThat(applier.matches(attributes, resource)).isFalse();
     }
 
@@ -507,9 +507,9 @@ class SamplingRuleApplierTest {
 
     private final Attributes attributes =
         Attributes.builder()
-            .put(SemanticAttributes.HTTP_METHOD, "GET")
-            .put(SemanticAttributes.NET_HOST_NAME, "opentelemetry.io")
-            .put(SemanticAttributes.HTTP_TARGET, "/instrument-me")
+            .put(SemanticAttributes.HTTP_REQUEST_METHOD, "GET")
+            .put(SemanticAttributes.SERVER_ADDRESS, "opentelemetry.io")
+            .put(SemanticAttributes.URL_PATH, "/instrument-me")
             .put(AttributeKey.stringKey("animal"), "cat")
             .put(AttributeKey.longKey("speed"), 10)
             .build();


### PR DESCRIPTION
**Description:**

[io.opentelemetry:opentelemetry-semconv](https://search.maven.org/artifact/io.opentelemetry/opentelemetry-semconv) was moved to [io.opentelemetry.semconv:opentelemetry-semconv](https://search.maven.org/artifact/io.opentelemetry.semconv/opentelemetry-semconv) and the former is now deprecated as per https://github.com/open-telemetry/opentelemetry-java/pull/5786.

After updating to 1.30.0 I have now both variants in my dependency tree and therefore raising this PR to clean it up.

**Existing Issue(s):**

 #1043

**Testing:**

Unittest execution

**Documentation:**

-

**Outstanding items:**

-