### PR TITLE
Move to io.opentelemetry.semconv:opentelemetry-semconv

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-trace")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  implementation("io.opentelemetry:opentelemetry-semconv")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
   annotationProcessor("com.google.auto.value:auto-value")
@@ -60,10 +60,3 @@ tasks {
 }
 
 tasks.getByName("test").dependsOn("shadowJar")
-
-configurations.all {
-  resolutionStrategy {
-    // TODO this module still needs to be updated to the latest semconv
-    force("io.opentelemetry:opentelemetry-semconv:1.28.0-alpha")
-  }
-}

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,8 +86,8 @@ final class GoogleJibBuildHandler implements MojoGoalExecutionHandler {
     spanBuilder.setAttribute(
         MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL,
         "https://" + registryHostname);
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://" + registryHostname);
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(SemanticAttributes.URL_FULL, "https://" + registryHostname);
+    spanBuilder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "POST");
     // Note: setting the "peer.service" helps visualization on Jaeger but
     // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
     // service will be instrumented and what it "service.name" would be

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -68,8 +68,8 @@ final class MavenDeployHandler implements MojoGoalExecutionHandler {
               + artifact.getArtifactId()
               + '/'
               + artifact.getVersion();
-      spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, artifactRootUrl);
-      spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+      spanBuilder.setAttribute(SemanticAttributes.URL_FULL, artifactRootUrl);
+      spanBuilder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "POST");
     }
   }
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
@@ -8,7 +8,7 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
@@ -25,9 +25,9 @@ final class SnykMonitorHandler implements MojoGoalExecutionHandler {
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);
     spanBuilder.setAttribute(SemanticAttributes.PEER_SERVICE, "snyk.io");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://snyk.io/api/v1/monitor/maven");
+    spanBuilder.setAttribute(SemanticAttributes.URL_FULL, "https://snyk.io/api/v1/monitor/maven");
     spanBuilder.setAttribute(SemanticAttributes.RPC_METHOD, "monitor");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "POST");
   }
 
   @Override

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
@@ -8,7 +8,7 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
@@ -25,9 +25,9 @@ final class SnykTestHandler implements MojoGoalExecutionHandler {
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);
     spanBuilder.setAttribute(SemanticAttributes.PEER_SERVICE, "snyk.io");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://snyk.io/api/v1/test-dep-graph");
+    spanBuilder.setAttribute(SemanticAttributes.URL_FULL, "https://snyk.io/api/v1/test-dep-graph");
     spanBuilder.setAttribute(SemanticAttributes.RPC_METHOD, "test");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "POST");
   }
 
   @Override

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -99,8 +99,8 @@ final class SpringBootBuildImageHandler implements MojoGoalExecutionHandler {
             && (registryUrl.startsWith("http://") || registryUrl.startsWith("https://"))) {
           spanBuilder.setAttribute(
               MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL, registryUrl);
-          spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, registryUrl);
-          spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+          spanBuilder.setAttribute(SemanticAttributes.URL_FULL, registryUrl);
+          spanBuilder.setAttribute(SemanticAttributes.HTTP_REQUEST_METHOD, "POST");
           try {
             // Note: setting the "peer.service" helps visualization on Jaeger but
             // may not fully comply with the OTel "peer.service" spec as we don't know if the remote

--- a/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
@@ -9,7 +9,7 @@ import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
@@ -9,14 +9,14 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.List;
 
 /**
  * Semantic attributes for Maven executions.
  *
  * @see io.opentelemetry.api.common.Attributes
- * @see io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+ * @see io.opentelemetry.semconv.SemanticAttributes
  */
 public class MavenOtelSemanticAttributes {
 

--- a/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
@@ -13,7 +13,7 @@ import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -75,8 +75,8 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_REPOSITORY_ID))
           .isEqualTo("snapshots");
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_METHOD)).isEqualTo("POST");
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(SemanticAttributes.HTTP_REQUEST_METHOD)).isEqualTo("POST");
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL))
           .isEqualTo(
               "https://maven.example.com/repository/maven-snapshots/io/opentelemetry/contrib/maven/test-jar/1.0-SNAPSHOT");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_REPOSITORY_URL))
@@ -124,7 +124,7 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("latest"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL)).isEqualTo("https://docker.io");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
@@ -168,7 +168,7 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("${project.version}"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL)).isEqualTo("https://docker.io");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
@@ -209,7 +209,7 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Arrays.asList("latest", "${project.version}"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL)).isEqualTo("https://docker.io");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
@@ -250,7 +250,7 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("1.0-SNAPSHOT"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://gcr.io");
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL)).isEqualTo("https://gcr.io");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("gcr.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://gcr.io");
@@ -286,7 +286,7 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL))
           .isEqualTo("https://snyk.io/api/v1/test-dep-graph");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
       assertThat(span.getAttribute(SemanticAttributes.RPC_METHOD)).isEqualTo("test");
@@ -322,7 +322,7 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(SemanticAttributes.URL_FULL))
           .isEqualTo("https://snyk.io/api/v1/monitor/maven");
       assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
       assertThat(span.getAttribute(SemanticAttributes.RPC_METHOD)).isEqualTo("monitor");


### PR DESCRIPTION
**Description:**

[io.opentelemetry:opentelemetry-semconv](https://search.maven.org/artifact/io.opentelemetry/opentelemetry-semconv) was moved to [io.opentelemetry.semconv:opentelemetry-semconv](https://search.maven.org/artifact/io.opentelemetry.semconv/opentelemetry-semconv) and the former is now deprecated as per https://github.com/open-telemetry/opentelemetry-java/pull/5786.

**Existing Issue(s):**

#1044 

**Testing:**

Unittest execution

**Documentation:**


**Outstanding items:**

