### PR TITLE
Adopt new `io.opentelemetry.semconv:opentelemetry-semconv` lib

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-trace")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  implementation("io.opentelemetry:opentelemetry-semconv")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
   annotationProcessor("com.google.auto.value:auto-value")
@@ -60,10 +60,3 @@ tasks {
 }
 
 tasks.getByName("test").dependsOn("shadowJar")
-
-configurations.all {
-  resolutionStrategy {
-    // TODO this module still needs to be updated to the latest semconv
-    force("io.opentelemetry:opentelemetry-semconv:1.28.0-alpha")
-  }
-}

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
@@ -19,7 +19,10 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** See <a href="https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin">Jit Maven Plugin</a> */
+/**
+ * See <a href="https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin">Jit Maven
+ * Plugin</a>
+ */
 final class GoogleJibBuildHandler implements MojoGoalExecutionHandler {
   private static final Logger logger = LoggerFactory.getLogger(GoogleJibBuildHandler.class);
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
@@ -19,7 +19,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** See https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin */
+/** See <a href="https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin">Jit Maven Plugin</a> */
 final class GoogleJibBuildHandler implements MojoGoalExecutionHandler {
   private static final Logger logger = LoggerFactory.getLogger(GoogleJibBuildHandler.class);
 
@@ -29,6 +29,7 @@ final class GoogleJibBuildHandler implements MojoGoalExecutionHandler {
         MavenGoal.create("com.google.cloud.tools", "jib-maven-plugin", "build"));
   }
 
+  @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 final class MavenDeployHandler implements MojoGoalExecutionHandler {
   private static final Logger logger = LoggerFactory.getLogger(MavenDeployHandler.class);
 
+  @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent execution) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
@@ -9,9 +9,9 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.net.MalformedURLException;
-import java.net.URL;
+import io.opentelemetry.semconv.SemanticAttributes;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.artifact.Artifact;
@@ -53,8 +53,8 @@ final class MavenDeployHandler implements MojoGoalExecutionHandler {
         // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
         // service will be instrumented and what it "service.name" would be
         spanBuilder.setAttribute(
-            SemanticAttributes.PEER_SERVICE, new URL(artifactRepositoryUrl).getHost());
-      } catch (MalformedURLException e) {
+            SemanticAttributes.PEER_SERVICE, new URI(artifactRepositoryUrl).getHost());
+      } catch (URISyntaxException e) {
         logger.debug("Ignore exception parsing artifact repository URL", e);
       }
       Artifact artifact = project.getArtifact();

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
@@ -8,12 +8,12 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
 
-/** See https://github.com/snyk/snyk-maven-plugin */
+/** See <a href="https://github.com/snyk/snyk-maven-plugin">Snyk Maven Plugin</a> */
 final class SnykMonitorHandler implements MojoGoalExecutionHandler {
 
   /**

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
@@ -21,6 +21,7 @@ final class SnykMonitorHandler implements MojoGoalExecutionHandler {
    * flag `snyk -d monitor`. See <a href="https://snyk.io/blog/snyk-cli-cheat-sheet/">Snyk CLI Cheat
    * Sheet</a>
    */
+  @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
@@ -21,6 +21,7 @@ final class SnykTestHandler implements MojoGoalExecutionHandler {
    * flag `snyk -d test`. See <a href="https://snyk.io/blog/snyk-cli-cheat-sheet/">Snyk CLI Cheat
    * Sheet</a>
    */
+  @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
@@ -8,12 +8,12 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
 
-/** See https://github.com/snyk/snyk-maven-plugin */
+/** See <a href="https://github.com/snyk/snyk-maven-plugin">Snyk Maven Plugin</a> */
 final class SnykTestHandler implements MojoGoalExecutionHandler {
 
   /**

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
@@ -40,6 +40,7 @@ final class SpringBootBuildImageHandler implements MojoGoalExecutionHandler {
         MavenGoal.create("org.springframework.boot", "spring-boot-maven-plugin", "build-image"));
   }
 
+  @SuppressWarnings("deprecation") // until old http semconv are dropped in 2.0
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
@@ -9,9 +9,9 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import java.net.MalformedURLException;
-import java.net.URL;
+import io.opentelemetry.semconv.SemanticAttributes;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
@@ -106,8 +106,8 @@ final class SpringBootBuildImageHandler implements MojoGoalExecutionHandler {
             // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
             // service will be instrumented and what it "service.name" would be
             spanBuilder.setAttribute(
-                SemanticAttributes.PEER_SERVICE, new URL(registryUrl).getHost());
-          } catch (MalformedURLException e) {
+                SemanticAttributes.PEER_SERVICE, new URI(registryUrl).getHost());
+          } catch (URISyntaxException e) {
             logger.debug("Ignore exception parsing container registry URL", e);
           }
         }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
@@ -9,7 +9,7 @@ import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
@@ -9,14 +9,14 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import java.util.List;
 
 /**
  * Semantic attributes for Maven executions.
  *
  * @see io.opentelemetry.api.common.Attributes
- * @see io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+ * @see io.opentelemetry.semconv.SemanticAttributes
  */
 public class MavenOtelSemanticAttributes {
 

--- a/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
@@ -13,7 +13,7 @@ import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -40,8 +40,10 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Test;
 
 /**
- * TODO Find a better solution to instantiate a MavenProject and a MojoExecutionEvent. See
- * https://github.com/takari/takari-lifecycle/blob/master/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/plugin/PluginDescriptorMojoTest.java
+ * TODO Find a better solution to instantiate a MavenProject and a MojoExecutionEvent. Unfortunately
+ * the <a
+ * href="https://github.com/takari/takari-lifecycle/blob/master/takari-lifecycle-plugin/src/test/java/io/takari/maven/plugins/plugin/PluginDescriptorMojoTest.java">Takari
+ * testing framework</a> can't test Maven extensions.
  */
 @SuppressWarnings({"DeduplicateConstants", "deprecation"})
 public class MojoGoalExecutionHandlerTest {


### PR DESCRIPTION
**Description:**

Adopt new `io.opentelemetry.semconv:opentelemetry-semconv` lib without yet replacing `http.url` and `http.method` by `url.full` and `http.request.method` as we will want to align with the OTel Java Auto Instrumentation and support `-Dotel.semconv-stability.opt-in=http...` to embrace the new semantic conventions

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1044

**Testing:**

None as there are no change in the behavior of the instrumentation

**Documentation:**

None as there are no change in the behavior of the instrumentation

**Outstanding items:**

Not really outstanding but we will have to add support for the new HTTP Semantic Conventions, `url.full` and `http.request.method` and we want to do it the same way the Otel Java Auto Instr implementing `-Dotel.semconv-stability.opt-in=http...` as described in https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.27.0
