### PR TITLE
Replace SimpleHttpClient (okhttp based) by JdkHttpClient (HttpURLConnection based)

### DIFF
--- a/aws-resources/build.gradle.kts
+++ b/aws-resources/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
   implementation("com.fasterxml.jackson.core:jackson-core")
-  implementation("com.squareup.okhttp3:okhttp")
+  compileOnly("com.squareup.okhttp3:okhttp")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/Ec2Resource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/Ec2Resource.java
@@ -138,7 +138,7 @@ public final class Ec2Resource {
 
   // Generic HTTP fetch function for IMDS.
   private static String fetchString(String httpMethod, URL url, String token, boolean includeTtl) {
-    SimpleHttpClient client = new SimpleHttpClient();
+    JdkHttpClient client = new JdkHttpClient();
     Map<String, String> headers = new HashMap<>();
 
     if (includeTtl) {

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
@@ -44,11 +44,11 @@ public final class EcsResource {
   }
 
   private static Resource buildResource() {
-    return buildResource(System.getenv(), new SimpleHttpClient());
+    return buildResource(System.getenv(), new JdkHttpClient());
   }
 
   // Visible for testing
-  static Resource buildResource(Map<String, String> sysEnv, SimpleHttpClient httpClient) {
+  static Resource buildResource(Map<String, String> sysEnv, JdkHttpClient httpClient) {
     // Note: If V4 is set V3 is set as well, so check V4 first.
     String ecsMetadataUrl =
         sysEnv.getOrDefault(ECS_METADATA_KEY_V4, sysEnv.getOrDefault(ECS_METADATA_KEY_V3, ""));
@@ -65,7 +65,7 @@ public final class EcsResource {
   }
 
   static void fetchMetadata(
-      SimpleHttpClient httpClient, String url, AttributesBuilder attrBuilders) {
+      JdkHttpClient httpClient, String url, AttributesBuilder attrBuilders) {
     String json = httpClient.fetchString("GET", url, Collections.emptyMap(), null);
     if (json.isEmpty()) {
       return;

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EksResource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EksResource.java
@@ -51,12 +51,12 @@ public final class EksResource {
   }
 
   private static Resource buildResource() {
-    return buildResource(new SimpleHttpClient(), new DockerHelper(), K8S_TOKEN_PATH, K8S_CERT_PATH);
+    return buildResource(new JdkHttpClient(), new DockerHelper(), K8S_TOKEN_PATH, K8S_CERT_PATH);
   }
 
   // Visible for testing
   static Resource buildResource(
-      SimpleHttpClient httpClient,
+      JdkHttpClient httpClient,
       DockerHelper dockerHelper,
       String k8sTokenPath,
       String k8sKeystorePath) {
@@ -83,7 +83,7 @@ public final class EksResource {
   }
 
   private static boolean isEks(
-      String k8sTokenPath, String k8sKeystorePath, SimpleHttpClient httpClient) {
+      String k8sTokenPath, String k8sKeystorePath, JdkHttpClient httpClient) {
     if (!isK8s(k8sTokenPath, k8sKeystorePath)) {
       logger.log(Level.FINE, "Not running on k8s.");
       return false;
@@ -104,7 +104,7 @@ public final class EksResource {
     return k8sTokeyFile.exists() && k8sKeystoreFile.exists();
   }
 
-  private static String getClusterName(SimpleHttpClient httpClient) {
+  private static String getClusterName(JdkHttpClient httpClient) {
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put("Authorization", getK8sCredHeader());
     String json =

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/JdkHttpClient.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/JdkHttpClient.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.aws.resource;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A simple HTTP client based on JDK HttpURLConnection. Not meant for high throughput.
+ */
+final class JdkHttpClient {
+
+  private static final Logger logger = Logger.getLogger(JdkHttpClient.class.getName());
+
+  private static final int TIMEOUT = 2000;
+
+  /** Fetch a string from a remote server. */
+  public String fetchString(
+      String httpMethod, String urlStr, Map<String, String> headers, @Nullable String certPath) {
+
+    try {
+      // create URL from string
+      URL url = new URL(urlStr);
+      // create connection
+      URLConnection connection = url.openConnection();
+      // https
+      if (connection instanceof HttpsURLConnection) {
+        // cast
+        HttpsURLConnection httpsConnection = (HttpsURLConnection)connection;
+        // check CA cert path is available
+        if (certPath != null) {
+          // create trust manager
+          X509TrustManager trustManager = SslSocketFactoryBuilder.createTrustManager(certPath);
+          // socket factory
+          SSLSocketFactory socketFactory = SslSocketFactoryBuilder.createSocketFactory(trustManager);
+          if (socketFactory != null) {
+            // update connection
+            httpsConnection.setSSLSocketFactory(socketFactory);
+          }
+        }
+        // process request
+        return processRequest(httpsConnection, httpMethod, urlStr, headers);
+      }
+      // http
+      if (connection instanceof HttpURLConnection) {
+        // cast
+        HttpURLConnection httpConnection = (HttpURLConnection)connection;
+        // process request
+        return processRequest(httpConnection, httpMethod, urlStr, headers);
+      }
+      // not http
+      logger.log(Level.FINE, "JdkHttpClient only HTTP/HTTPS connections are supported.");
+    } catch (MalformedURLException e) {
+      logger.log(Level.FINE, "JdkHttpClient invalid URL.", e);
+    } catch (IOException e) {
+      logger.log(Level.FINE, "JdkHttpClient fetch string failed.", e);
+    }
+    return "";
+  }
+
+  private static String processRequest(HttpURLConnection httpConnection, String httpMethod, String urlStr, Map<String, String> headers) throws IOException {
+    // set method
+    httpConnection.setRequestMethod(httpMethod);
+    // set headers
+    headers.forEach(httpConnection::setRequestProperty);
+    // timeouts
+    httpConnection.setConnectTimeout(TIMEOUT);
+    httpConnection.setReadTimeout(TIMEOUT);
+    // connect
+    httpConnection.connect();
+    try {
+      // status code
+      int responseCode = httpConnection.getResponseCode();
+      if (responseCode != 200) {
+        logger.log(
+          Level.FINE,
+          "Error response from "
+            + urlStr
+            + " code ("
+            + responseCode
+            + ") text "
+            + httpConnection.getResponseMessage());
+        return "";
+      }
+      // read response
+      try (InputStream inputStream = httpConnection.getInputStream()) {
+        // store read data in byte array
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+          // read all bytes
+          int b;
+          while ((b = inputStream.read()) != -1) {
+            outputStream.write(b);
+          }
+          // result
+          return outputStream.toString("UTF-8");
+        }
+      }
+    } finally {
+      // disconnect, no need for persistent connections
+      httpConnection.disconnect();
+    }
+  }
+}

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/SslSocketFactoryBuilder.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/SslSocketFactoryBuilder.java
@@ -1,0 +1,78 @@
+package io.opentelemetry.contrib.aws.resource;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class SslSocketFactoryBuilder {
+
+  private static final Logger logger = Logger.getLogger(SslSocketFactoryBuilder.class.getName());
+
+  private SslSocketFactoryBuilder() {}
+
+  @Nullable
+  private static KeyStore getKeystoreForTrustedCert(String certPath) {
+    try (FileInputStream fis = new FileInputStream(certPath)) {
+      KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      trustStore.load(null, null);
+      CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+
+      Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(fis);
+
+      int i = 0;
+      for (Certificate certificate : certificates) {
+        trustStore.setCertificateEntry("cert_" + i, certificate);
+        i++;
+      }
+      return trustStore;
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "Cannot load KeyStore from " + certPath);
+      return null;
+    }
+  }
+
+  @Nullable
+  static X509TrustManager createTrustManager(@Nullable String certPath) {
+    if (certPath == null) {
+      return null;
+    }
+    try {
+      // create keystore
+      KeyStore keyStore = getKeystoreForTrustedCert(certPath);
+      String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+      TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+      tmf.init(keyStore);
+      return (X509TrustManager) tmf.getTrustManagers()[0];
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "Build SslSocketFactory for K8s restful client exception.", e);
+      return null;
+    }
+  }
+
+  @Nullable
+  static SSLSocketFactory createSocketFactory(@Nullable TrustManager trustManager) {
+    if (trustManager == null) {
+      return null;
+    }
+    try {
+      SSLContext context = SSLContext.getInstance("TLS");
+      context.init(null, new TrustManager[] {trustManager}, null);
+      return context.getSocketFactory();
+
+    } catch (Exception e) {
+      logger.log(Level.WARNING, "Build SslSocketFactory for K8s restful client exception.", e);
+    }
+    return null;
+  }
+}

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
@@ -31,7 +31,7 @@ class EcsResourceTest {
   private static final String ECS_METADATA_KEY_V4 = "ECS_CONTAINER_METADATA_URI_V4";
   private static final String ECS_METADATA_KEY_V3 = "ECS_CONTAINER_METADATA_URI";
 
-  @Mock private SimpleHttpClient mockHttpClient;
+  @Mock private JdkHttpClient mockHttpClient;
 
   @Test
   void testCreateAttributesV3() throws IOException {

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EksResourceTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EksResourceTest.java
@@ -34,7 +34,7 @@ public class EksResourceTest {
 
   @Mock private DockerHelper mockDockerHelper;
 
-  @Mock private SimpleHttpClient httpClient;
+  @Mock private JdkHttpClient httpClient;
 
   @Test
   void testEks(@TempDir File tempFolder) throws IOException {

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/JdkHttpClientTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/JdkHttpClientTest.java
@@ -1,0 +1,110 @@
+package io.opentelemetry.contrib.aws.resource;
+
+import com.google.common.collect.ImmutableMap;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.testing.junit5.server.mock.MockWebServerExtension;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JdkHttpClientTest {
+
+  @RegisterExtension
+  public static final MockWebServerExtension server = new MockWebServerExtension();
+
+  @Test
+  void testFetchString() {
+    server.enqueue(HttpResponse.of("expected result"));
+
+    ImmutableMap<String, String> requestPropertyMap =
+      ImmutableMap.of("key1", "value1", "key2", "value2");
+    String urlStr = String.format("http://localhost:%s%s", server.httpPort(), "/path");
+    JdkHttpClient httpClient = new JdkHttpClient();
+    String result = httpClient.fetchString("GET", urlStr, requestPropertyMap, null);
+
+    assertThat(result).isEqualTo("expected result");
+
+    AggregatedHttpRequest request1 = server.takeRequest().request();
+    assertThat(request1.path()).isEqualTo("/path");
+    assertThat(request1.headers().get("key1")).isEqualTo("value1");
+    assertThat(request1.headers().get("key2")).isEqualTo("value2");
+  }
+
+  @Test
+  void testFailedFetchString() {
+    ImmutableMap<String, String> requestPropertyMap =
+      ImmutableMap.of("key1", "value1", "key2", "value2");
+    String urlStr = String.format("http://localhost:%s%s", server.httpPort(), "/path");
+    JdkHttpClient httpClient = new JdkHttpClient();
+    String result = httpClient.fetchString("GET", urlStr, requestPropertyMap, null);
+    assertThat(result).isEmpty();
+  }
+
+  static class HttpsServerTest {
+    @RegisterExtension
+    @Order(1)
+    public static final SelfSignedCertificateExtension certificate = new SelfSignedCertificateExtension();
+
+    @RegisterExtension
+    @Order(2)
+    public static ServerExtension server =
+      new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+          sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
+
+          sb.service("/", (ctx, req) -> HttpResponse.of("Thanks for trusting me"));
+        }
+      };
+
+    @Test
+    void goodCert() {
+      JdkHttpClient httpClient = new JdkHttpClient();
+      String result =
+        httpClient.fetchString(
+          "GET",
+          "https://localhost:" + server.httpsPort() + "/",
+          Collections.emptyMap(),
+          certificate.certificateFile().getAbsolutePath());
+      assertThat(result).isEqualTo("Thanks for trusting me");
+    }
+
+    @Test
+    void missingCert() {
+      JdkHttpClient httpClient = new JdkHttpClient();
+      String result =
+        httpClient.fetchString(
+          "GET",
+          "https://localhost:" + server.httpsPort() + "/",
+          Collections.emptyMap(),
+          "/foo/bar/bad");
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void badCert(@TempDir Path tempDir) throws Exception {
+      Path certFile = tempDir.resolve("test.crt");
+      Files.write(certFile, "bad cert".getBytes(StandardCharsets.UTF_8));
+      JdkHttpClient httpClient = new JdkHttpClient();
+      String result =
+        httpClient.fetchString(
+          "GET",
+          "https://localhost:" + server.httpsPort() + "/",
+          Collections.emptyMap(),
+          certFile.toString());
+      assertThat(result).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
**Description:**

Replaced existing `okhttp` based HttpClient (`SimpleHttpClient`) by a JDK 1.8 implementation using `HttpURLConnection`. `okhttp` adds too many dependencies to a project that performs simple HTTP calls to discover resource metadata in AWS ECS and EKS. The AWS endpoints supports HTTP/1.1 and there is no need to higher protocol version (HTTP/2).

See the `okhttp` dependency tree in a Java project:

<img width="657" alt="image" src="https://github.com/open-telemetry/opentelemetry-java-contrib/assets/1074987/a7a3b873-9e21-47d9-9543-ba9f91223a0e">

Is is well known that having `okhttp` as a dependency makes very difficult (or impossible) to create a Graal native image of a consuming application.

Also, `okio` has known [vulnerabilities](https://nvd.nist.gov/vuln/detail/CVE-2023-3635)

OpenTelemetry OTLP exporter supports excluding `okhttp` based implementation in favor of a JDK-11 implementation via ServiceManager. I do not think the same solution is needed here since the HTTP client requirements for this project are very simple and not a high throughput implementation is required for a single HTTP request in the application lifespan.

Initial PR does not remove the `okhttp` implementation nor the dependency (made optional). An update is required before merging it to completely remove `okhttp`.

