### PR TITLE
Revert "Move to io.opentelemetry.semconv:opentelemetry-semconv (#1050)"

### DIFF
--- a/aws-xray/build.gradle.kts
+++ b/aws-xray/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
   implementation("com.squareup.okhttp3:okhttp")
-  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
+  implementation("io.opentelemetry:opentelemetry-semconv")
 
   annotationProcessor("com.google.auto.service:auto-service")
   testImplementation("com.google.auto.service:auto-service")
@@ -43,5 +43,12 @@ testing {
         runtimeOnly("org.slf4j:slf4j-simple")
       }
     }
+  }
+}
+
+configurations.all {
+  resolutionStrategy {
+    // TODO this module still needs to be updated to the latest semconv
+    force("io.opentelemetry:opentelemetry-semconv:1.28.0-alpha")
   }
 }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGenerator.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsMetricAttributeGenerator.java
@@ -15,24 +15,24 @@ import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_REMOTE_TARGE
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_SPAN_KIND;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_STREAM_NAME;
 import static io.opentelemetry.contrib.awsxray.AwsAttributeKeys.AWS_TABLE_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
-import static io.opentelemetry.semconv.SemanticAttributes.DB_OPERATION;
-import static io.opentelemetry.semconv.SemanticAttributes.DB_SYSTEM;
-import static io.opentelemetry.semconv.SemanticAttributes.FAAS_INVOKED_NAME;
-import static io.opentelemetry.semconv.SemanticAttributes.FAAS_TRIGGER;
-import static io.opentelemetry.semconv.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_REQUEST_METHOD;
-import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_OPERATION;
-import static io.opentelemetry.semconv.SemanticAttributes.MESSAGING_SYSTEM;
-import static io.opentelemetry.semconv.SemanticAttributes.PEER_SERVICE;
-import static io.opentelemetry.semconv.SemanticAttributes.RPC_METHOD;
-import static io.opentelemetry.semconv.SemanticAttributes.RPC_SERVICE;
-import static io.opentelemetry.semconv.SemanticAttributes.SERVER_ADDRESS;
-import static io.opentelemetry.semconv.SemanticAttributes.SERVER_PORT;
-import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_ADDRESS;
-import static io.opentelemetry.semconv.SemanticAttributes.SERVER_SOCKET_PORT;
-import static io.opentelemetry.semconv.SemanticAttributes.URL_FULL;
-import static io.opentelemetry.semconv.SemanticAttributes.URL_PATH;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_OPERATION;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.DB_SYSTEM;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_INVOKED_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.FAAS_TRIGGER;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.GRAPHQL_OPERATION_TYPE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_URL;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_OPERATION;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.MESSAGING_SYSTEM;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_NAME;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_PEER_PORT;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_ADDR;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_SOCK_PEER_PORT;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.PEER_SERVICE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_METHOD;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.RPC_SERVICE;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -40,8 +40,8 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.ResourceAttributes;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
@@ -156,8 +156,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
     if (operation == null || operation.equals(UNKNOWN_OPERATION)) {
       return false;
     }
-    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
+    if (isKeyPresent(span, HTTP_METHOD)) {
+      String httpMethod = span.getAttributes().get(HTTP_METHOD);
       return !operation.equals(httpMethod);
     }
     return true;
@@ -260,15 +260,15 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    */
   private static String generateIngressOperation(SpanData span) {
     String operation = UNKNOWN_OPERATION;
-    if (isKeyPresent(span, URL_PATH)) {
-      String httpTarget = span.getAttributes().get(URL_PATH);
+    if (isKeyPresent(span, HTTP_TARGET)) {
+      String httpTarget = span.getAttributes().get(HTTP_TARGET);
       // get the first part from API path string as operation value
       // the more levels/parts we get from API path the higher chance for getting high cardinality
       // data
       if (httpTarget != null) {
         operation = extractApiPathValue(httpTarget);
-        if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
-          String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
+        if (isKeyPresent(span, HTTP_METHOD)) {
+          String httpMethod = span.getAttributes().get(HTTP_METHOD);
           if (httpMethod != null) {
             operation = httpMethod + " " + operation;
           }
@@ -284,8 +284,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
    */
   private static String generateRemoteOperation(SpanData span) {
     String remoteOperation = UNKNOWN_REMOTE_OPERATION;
-    if (isKeyPresent(span, URL_FULL)) {
-      String httpUrl = span.getAttributes().get(URL_FULL);
+    if (isKeyPresent(span, HTTP_URL)) {
+      String httpUrl = span.getAttributes().get(HTTP_URL);
       try {
         URL url;
         if (httpUrl != null) {
@@ -296,8 +296,8 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         logger.log(Level.FINEST, "invalid http.url attribute: ", httpUrl);
       }
     }
-    if (isKeyPresent(span, HTTP_REQUEST_METHOD)) {
-      String httpMethod = span.getAttributes().get(HTTP_REQUEST_METHOD);
+    if (isKeyPresent(span, HTTP_METHOD)) {
+      String httpMethod = span.getAttributes().get(HTTP_METHOD);
       remoteOperation = httpMethod + " " + remoteOperation;
     }
     if (remoteOperation.equals(UNKNOWN_REMOTE_OPERATION)) {
@@ -325,16 +325,16 @@ final class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
 
   private static String generateRemoteService(SpanData span) {
     String remoteService = UNKNOWN_REMOTE_SERVICE;
-    if (isKeyPresent(span, SERVER_ADDRESS)) {
-      remoteService = getRemoteService(span, SERVER_ADDRESS);
-      if (isKeyPresent(span, SERVER_PORT)) {
-        Long port = span.getAttributes().get(SERVER_PORT);
+    if (isKeyPresent(span, NET_PEER_NAME)) {
+      remoteService = getRemoteService(span, NET_PEER_NAME);
+      if (isKeyPresent(span, NET_PEER_PORT)) {
+        Long port = span.getAttributes().get(NET_PEER_PORT);
         remoteService += ":" + port;
       }
-    } else if (isKeyPresent(span, SERVER_SOCKET_ADDRESS)) {
-      remoteService = getRemoteService(span, SERVER_SOCKET_ADDRESS);
-      if (isKeyPresent(span, SERVER_SOCKET_PORT)) {
-        Long port = span.getAttributes().get(SERVER_SOCKET_PORT);
+    } else if (isKeyPresent(span, NET_SOCK_PEER_ADDR)) {
+      remoteService = getRemoteService(span, NET_SOCK_PEER_ADDR);
+      if (isKeyPresent(span, NET_SOCK_PEER_PORT)) {
+        Long port = span.getAttributes().get(NET_SOCK_PEER_PORT);
         remoteService += ":" + port;
       }
     } else {

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessor.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessor.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
@@ -107,7 +107,7 @@ public final class AwsSpanMetricsProcessor implements SpanProcessor {
   }
 
   private void recordErrorOrFault(SpanData spanData, Attributes attributes) {
-    Long httpStatusCode = spanData.getAttributes().get(HTTP_RESPONSE_STATUS_CODE);
+    Long httpStatusCode = spanData.getAttributes().get(HTTP_STATUS_CODE);
     if (httpStatusCode == null) {
       httpStatusCode = getAwsStatusCode(spanData);
 

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
@@ -17,8 +17,8 @@ import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
-import io.opentelemetry.semconv.ResourceAttributes;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
@@ -162,25 +162,13 @@ final class SamplingRuleApplier {
     String host = null;
 
     for (Map.Entry<AttributeKey<?>, Object> entry : attributes.asMap().entrySet()) {
-      if (entry.getKey().equals(SemanticAttributes.URL_PATH)) {
+      if (entry.getKey().equals(SemanticAttributes.HTTP_TARGET)) {
         httpTarget = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.HTTP_TARGET)) {
-        // TODO remove support for deprecated http.target attribute
-        httpTarget = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.URL_FULL)) {
-        httpUrl = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.HTTP_URL)) {
-        // TODO remove support for deprecated http.url attribute
         httpUrl = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.HTTP_REQUEST_METHOD)) {
-        httpMethod = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.HTTP_METHOD)) {
-        // TODO remove support for deprecated http.method attribute
         httpMethod = (String) entry.getValue();
-      } else if (entry.getKey().equals(SemanticAttributes.SERVER_ADDRESS)) {
-        host = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.NET_HOST_NAME)) {
-        // TODO remove support for deprecated net.host.name attribute
         host = (String) entry.getValue();
       } else if (entry.getKey().equals(SemanticAttributes.HTTP_HOST)) {
         // TODO (trask) remove support for deprecated http.host attribute

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsSpanMetricsProcessorTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.awsxray;
 
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_STATUS_CODE;
+import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -141,7 +141,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithoutMetricAttributes() {
-    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 500L);
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 500L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_NO_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -154,7 +154,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithoutEndRequired() {
-    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 500L);
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 500L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -167,7 +167,7 @@ class AwsSpanMetricsProcessorTest {
 
   @Test
   public void testOnEndMetricsGenerationWithLatency() {
-    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, 200L);
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, 200L);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);
@@ -245,7 +245,7 @@ class AwsSpanMetricsProcessorTest {
 
   private static ReadableSpan buildReadableSpanWithThrowableMock(Throwable throwable) {
     // config http status code as null
-    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, null);
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, null);
     ReadableSpan readableSpanMock = mock(ReadableSpan.class);
     SpanData mockSpanData = mock(SpanData.class);
     InstrumentationScopeInfo awsSdkScopeInfo =
@@ -280,7 +280,7 @@ class AwsSpanMetricsProcessorTest {
 
   private void validateMetricsGeneratedForHttpStatusCode(
       Long httpStatusCode, ExpectedStatusMetric expectedStatusMetric) {
-    Attributes spanAttributes = Attributes.of(HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
+    Attributes spanAttributes = Attributes.of(HTTP_STATUS_CODE, httpStatusCode);
     ReadableSpan readableSpanMock = buildReadableSpanMock(spanAttributes);
     Attributes metricAttributes = buildMetricAttributes(CONTAINS_ATTRIBUTES);
     configureMocksForOnEnd(readableSpanMock, metricAttributes);

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerProviderTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.semconv.ResourceAttributes;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This reverts commit 1d14305fb02492b185cc813d802b29df0e957a92.

hi @deki @wangzlei @srprash, my apologies, I think I shouldn't have merged this change until after OpenTelemetry Java Instrumentation 2.0 is released (in ~2 months), where we will switch to the new HTTP semconv.

If you'd like to submit a PR to move to `io.opentelemetry.semconv:opentelemetry-semconv`, but continue using the deprecated constants, we could merge that sooner.