### PR TITLE
Fix the build

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JettyIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JettyIntegrationTest.java
@@ -29,7 +29,7 @@ class JettyIntegrationTest extends AbstractIntegrationTest {
                   .withDockerfileFromBuilder(
                       builder ->
                           builder
-                              .from("jetty")
+                              .from("jetty:11")
                               .run(
                                   "java",
                                   "-jar",


### PR DESCRIPTION
Tests is failing with newly released Jetty 12