### PR TITLE
Using android 21 as minimum supported for disk-buffering

### DIFF
--- a/disk-buffering/build.gradle.kts
+++ b/disk-buffering/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
-  signature("com.toasttab.android:gummy-bears-api-24:0.6.1@signature")
+  signature("com.toasttab.android:gummy-bears-api-21:0.6.1:coreLib@signature")
   testImplementation("org.mockito:mockito-inline")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }


### PR DESCRIPTION
Following up from https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1092#discussion_r1386949415 - Setting 21 as the minimum android api supported by `disk-buffering` in order to keep consistency with the core lib. 
