### PR TITLE
Add Error handling for closure parameters

### DIFF
--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -165,10 +165,18 @@ class InstrumentHelper {
     private static Map<String, String> getLabels(GroovyMBean mbean, Map<String, Closure> labelFuncs, Map<String, Closure> additionalLabels) {
         def labels = [:]
         labelFuncs.each { label, labelFunc ->
-            labels[label] = labelFunc(mbean) as String
+            try {
+                labels[label] = labelFunc(mbean) as String
+            } catch(AttributeNotFoundException e) {
+                logger.warning("Attribute missing for label:${label}, label was not applied")
+            }
         }
         additionalLabels.each { label, labelFunc ->
-            labels[label] = labelFunc(mbean) as String
+            try {
+                labels[label] = labelFunc(mbean) as String
+            } catch(AttributeNotFoundException e) {
+                logger.warning("Attribute missing for label:${label}, label was not applied")
+            }
         }
         return labels
     }

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/MBeanHelper.groovy
@@ -122,8 +122,16 @@ class MBeanHelper {
     }
 
     Object getBeanAttributeWithTransform(GroovyMBean bean, String attribute){
-      def transformationClosure = attributeTransformation.get(attribute);
-      return transformationClosure != null ? transformationClosure(bean) : getBeanAttribute(bean, attribute)
+        def transformationClosure = attributeTransformation.get(attribute);
+        if (transformationClosure == null) {
+            return getBeanAttribute(bean, attribute)
+        }
+        try {
+            return transformationClosure(bean)
+        } catch(AttributeNotFoundException e) {
+            logger.warning("Transformed attribute not found in ${bean.name()}")
+            return null
+        }
     }
 
     static Object getBeanAttribute(GroovyMBean bean, String attribute) {


### PR DESCRIPTION
In #960 we discussed the way we handle attributes that do not exist when extracted from user defined closures, currently this will throw an AttributeNotFoundException, which does not seem like the correct pattern. This should should just be handled gracefully and in the case if the transformation just avoid creating the metric and in the case of the labels, omit that label.

**Existing Issue(s):**

N/A

**Testing:**

