### PR TITLE
switch from acceptance to rejection threshold

### DIFF
--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
@@ -16,7 +16,7 @@ final class ConsistentAlwaysOffSampler extends ConsistentSampler {
 
   @Override
   protected long getThreshold(long parentThreshold, boolean isRoot) {
-    return 0;
+    return ConsistentSamplingUtil.getMaxThreshold();
   }
 
   @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSampler.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.sampler.consistent56;
 
-import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMaxThreshold;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMinThreshold;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -18,7 +18,7 @@ final class ConsistentAlwaysOnSampler extends ConsistentSampler {
 
   @Override
   protected long getThreshold(long parentThreshold, boolean isRoot) {
-    return getMaxThreshold();
+    return getMinThreshold();
   }
 
   @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedAndSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedAndSampler.java
@@ -43,7 +43,7 @@ final class ConsistentComposedAndSampler extends ConsistentSampler {
     long threshold2 = sampler2.getThreshold(parentThreshold, isRoot);
     if (ConsistentSamplingUtil.isValidThreshold(threshold1)
         && ConsistentSamplingUtil.isValidThreshold(threshold2)) {
-      return Math.min(threshold1, threshold2);
+      return Math.max(threshold1, threshold2);
     } else {
       return ConsistentSamplingUtil.getInvalidThreshold();
     }

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedOrSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedOrSampler.java
@@ -43,7 +43,7 @@ final class ConsistentComposedOrSampler extends ConsistentSampler {
     long threshold2 = sampler2.getThreshold(parentThreshold, isRoot);
     if (ConsistentSamplingUtil.isValidThreshold(threshold1)) {
       if (ConsistentSamplingUtil.isValidThreshold(threshold2)) {
-        return Math.max(threshold1, threshold2);
+        return Math.min(threshold1, threshold2);
       }
       return threshold1;
     } else {

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentParentBasedSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentParentBasedSampler.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.sampler.consistent56;
 
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getInvalidThreshold;
 import static java.util.Objects.requireNonNull;
 
 import javax.annotation.concurrent.Immutable;
@@ -38,7 +39,7 @@ final class ConsistentParentBasedSampler extends ConsistentSampler {
   @Override
   protected long getThreshold(long parentThreshold, boolean isRoot) {
     if (isRoot) {
-      return rootSampler.getThreshold(ConsistentSamplingUtil.getInvalidThreshold(), isRoot);
+      return rootSampler.getThreshold(getInvalidThreshold(), isRoot);
     } else {
       return parentThreshold;
     }

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.sampler.consistent56;
 
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.calculateThreshold;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMinThreshold;
 import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.sdk.trace.samplers.Sampler;
@@ -147,9 +149,9 @@ final class ConsistentRateLimitingSampler extends ConsistentSampler {
             / currentState.effectiveWindowCount;
 
     if (samplingProbability >= 1.) {
-      return ConsistentSamplingUtil.getMaxThreshold();
+      return getMinThreshold();
     } else {
-      return ConsistentSamplingUtil.calculateThreshold(samplingProbability);
+      return calculateThreshold(samplingProbability);
     }
   }
 

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
@@ -10,7 +10,9 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 public final class ConsistentSamplingUtil {
 
   private static final int RANDOM_VALUE_BITS = 56;
-  private static final long MAX_THRESHOLD = 1L << RANDOM_VALUE_BITS;
+  private static final long MAX_THRESHOLD =
+      1L << RANDOM_VALUE_BITS; // corresponds to 0% sampling probability
+  private static final long MIN_THRESHOLD = 0; // corresponds to 100% sampling probability
   private static final long MAX_RANDOM_VALUE = MAX_THRESHOLD - 1;
   private static final long INVALID_THRESHOLD = -1;
   private static final long INVALID_RANDOM_VALUE = -1;
@@ -29,7 +31,7 @@ public final class ConsistentSamplingUtil {
    */
   public static double calculateSamplingProbability(long threshold) {
     checkThreshold(threshold);
-    return threshold * 0x1p-56;
+    return (MAX_THRESHOLD - threshold) * 0x1p-56;
   }
 
   /**
@@ -41,7 +43,7 @@ public final class ConsistentSamplingUtil {
    */
   public static long calculateThreshold(double samplingProbability) {
     checkProbability(samplingProbability);
-    return Math.round(samplingProbability * 0x1p56);
+    return MAX_THRESHOLD - Math.round(samplingProbability * 0x1p56);
   }
 
   /**
@@ -49,21 +51,16 @@ public final class ConsistentSamplingUtil {
    *
    * <p>Returns 1, if the threshold is invalid.
    *
-   * <p>Returns 0, if the threshold is 0. A span with zero threshold is only sampled due to a
-   * non-probabilistic sampling decision and therefore does not contribute to the adjusted count.
+   * <p>Returns 0, if there is no valid threshold.
    *
    * @param threshold the threshold
    * @return the adjusted count
    */
   public static double calculateAdjustedCount(long threshold) {
     if (isValidThreshold(threshold)) {
-      if (threshold > 0) {
-        return 0x1p56 / threshold;
-      } else {
-        return 0;
-      }
+      return 0x1p56 / (MAX_THRESHOLD - threshold);
     } else {
-      return 1.;
+      return 0;
     }
   }
 
@@ -93,6 +90,10 @@ public final class ConsistentSamplingUtil {
     return MAX_RANDOM_VALUE;
   }
 
+  public static long getMinThreshold() {
+    return MIN_THRESHOLD;
+  }
+
   public static long getMaxThreshold() {
     return MAX_THRESHOLD;
   }
@@ -102,7 +103,7 @@ public final class ConsistentSamplingUtil {
   }
 
   public static boolean isValidThreshold(long threshold) {
-    return 0 <= threshold && threshold <= getMaxThreshold();
+    return getMinThreshold() <= threshold && threshold <= getMaxThreshold();
   }
 
   public static boolean isValidProbability(double probability) {

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
@@ -49,19 +49,12 @@ public final class ConsistentSamplingUtil {
   /**
    * Calculates the adjusted count from a given threshold.
    *
-   * <p>Returns 1, if the threshold is invalid.
-   *
-   * <p>Returns 0, if there is no valid threshold.
-   *
    * @param threshold the threshold
    * @return the adjusted count
    */
   public static double calculateAdjustedCount(long threshold) {
-    if (isValidThreshold(threshold)) {
-      return 0x1p56 / (MAX_THRESHOLD - threshold);
-    } else {
-      return 0;
-    }
+    checkThreshold(threshold);
+    return 0x1p56 / (MAX_THRESHOLD - threshold);
   }
 
   /**

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSamplerTest.java
@@ -21,11 +21,15 @@ public class ConsistentAlwaysOffSamplerTest {
 
   @Test
   void testThreshold() {
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(getInvalidThreshold(), false)).isZero();
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(getInvalidThreshold(), true)).isZero();
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(getMaxThreshold(), false)).isZero();
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(getMaxThreshold(), true)).isZero();
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(0, false)).isZero();
-    assertThat(ConsistentSampler.alwaysOff().getThreshold(0, true)).isZero();
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(getInvalidThreshold(), false))
+        .isEqualTo(getMaxThreshold());
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(getInvalidThreshold(), true))
+        .isEqualTo(getMaxThreshold());
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(getMaxThreshold(), false))
+        .isEqualTo(getMaxThreshold());
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(getMaxThreshold(), true))
+        .isEqualTo(getMaxThreshold());
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(0, false)).isEqualTo(getMaxThreshold());
+    assertThat(ConsistentSampler.alwaysOff().getThreshold(0, true)).isEqualTo(getMaxThreshold());
   }
 }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSamplerTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.contrib.sampler.consistent56;
 
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getInvalidThreshold;
-import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMaxThreshold;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMinThreshold;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -22,14 +22,14 @@ public class ConsistentAlwaysOnSamplerTest {
   @Test
   void testThreshold() {
     assertThat(ConsistentSampler.alwaysOn().getThreshold(getInvalidThreshold(), false))
-        .isEqualTo(getMaxThreshold());
+        .isEqualTo(getMinThreshold());
     assertThat(ConsistentSampler.alwaysOn().getThreshold(getInvalidThreshold(), true))
-        .isEqualTo(getMaxThreshold());
-    assertThat(ConsistentSampler.alwaysOn().getThreshold(getMaxThreshold(), false))
-        .isEqualTo(getMaxThreshold());
-    assertThat(ConsistentSampler.alwaysOn().getThreshold(getMaxThreshold(), true))
-        .isEqualTo(getMaxThreshold());
-    assertThat(ConsistentSampler.alwaysOn().getThreshold(0, false)).isEqualTo(getMaxThreshold());
-    assertThat(ConsistentSampler.alwaysOn().getThreshold(0, true)).isEqualTo(getMaxThreshold());
+        .isEqualTo(getMinThreshold());
+    assertThat(ConsistentSampler.alwaysOn().getThreshold(getMinThreshold(), false))
+        .isEqualTo(getMinThreshold());
+    assertThat(ConsistentSampler.alwaysOn().getThreshold(getMinThreshold(), true))
+        .isEqualTo(getMinThreshold());
+    assertThat(ConsistentSampler.alwaysOn().getThreshold(0, false)).isEqualTo(getMinThreshold());
+    assertThat(ConsistentSampler.alwaysOn().getThreshold(0, true)).isEqualTo(getMinThreshold());
   }
 }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSamplerTest.java
@@ -63,12 +63,8 @@ public class ConsistentFixedThresholdSamplerTest {
                 .get(OtelTraceState.TRACE_STATE_KEY);
         OtelTraceState traceState = OtelTraceState.parse(traceStateString);
         assertThat(traceState.hasValidRandomValue()).isTrue();
-        if (samplingProbability == 1.) {
-          assertThat(traceState.hasValidThreshold()).isFalse();
-        } else {
-          assertThat(traceState.hasValidThreshold()).isTrue();
-          assertThat(traceState.getThreshold()).isEqualTo(calculateThreshold(samplingProbability));
-        }
+        assertThat(traceState.hasValidThreshold()).isTrue();
+        assertThat(traceState.getThreshold()).isEqualTo(calculateThreshold(samplingProbability));
 
         numSampled += 1;
       }
@@ -101,14 +97,14 @@ public class ConsistentFixedThresholdSamplerTest {
   @Test
   public void testDescription() {
     assertThat(ConsistentSampler.probabilityBased(1.0).getDescription())
-        .isEqualTo("ConsistentFixedThresholdSampler{threshold=max, sampling probability=1.0}");
+        .isEqualTo("ConsistentFixedThresholdSampler{threshold=0, sampling probability=1.0}");
     assertThat(ConsistentSampler.probabilityBased(0.5).getDescription())
         .isEqualTo("ConsistentFixedThresholdSampler{threshold=8, sampling probability=0.5}");
     assertThat(ConsistentSampler.probabilityBased(0.25).getDescription())
-        .isEqualTo("ConsistentFixedThresholdSampler{threshold=4, sampling probability=0.25}");
+        .isEqualTo("ConsistentFixedThresholdSampler{threshold=c, sampling probability=0.25}");
     assertThat(ConsistentSampler.probabilityBased(1e-300).getDescription())
-        .isEqualTo("ConsistentFixedThresholdSampler{threshold=0, sampling probability=0.0}");
+        .isEqualTo("ConsistentFixedThresholdSampler{threshold=max, sampling probability=0.0}");
     assertThat(ConsistentSampler.probabilityBased(0).getDescription())
-        .isEqualTo("ConsistentFixedThresholdSampler{threshold=0, sampling probability=0.0}");
+        .isEqualTo("ConsistentFixedThresholdSampler{threshold=max, sampling probability=0.0}");
   }
 }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtilTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtilTest.java
@@ -10,6 +10,8 @@ import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUt
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.calculateThreshold;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getInvalidRandomValue;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getInvalidThreshold;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMaxThreshold;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMinThreshold;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.isValidRandomValue;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.isValidThreshold;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,21 +23,23 @@ public class ConsistentSamplingUtilTest {
 
   @Test
   void testCalculateSamplingProbability() {
-    assertThat(calculateSamplingProbability(0L)).isEqualTo(0.);
-    assertThat(calculateSamplingProbability(0x40000000000000L)).isEqualTo(0.25);
+    assertThat(calculateSamplingProbability(getMinThreshold())).isOne();
+    assertThat(calculateSamplingProbability(0xc0000000000000L)).isEqualTo(0.25);
     assertThat(calculateSamplingProbability(0x80000000000000L)).isEqualTo(0.5);
-    assertThat(calculateSamplingProbability(0x100000000000000L)).isEqualTo(1.);
+    assertThat(calculateSamplingProbability(getMaxThreshold())).isZero();
     assertThatIllegalArgumentException().isThrownBy(() -> calculateSamplingProbability(-1));
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> calculateSamplingProbability(0x100000000000001L));
+        .isThrownBy(() -> calculateSamplingProbability(getMaxThreshold() + 1));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> calculateSamplingProbability(getMinThreshold() - 1));
   }
 
   @Test
   void testCalculateThreshold() {
-    assertThat(calculateThreshold(0.)).isEqualTo(0L);
-    assertThat(calculateThreshold(0.25)).isEqualTo(0x40000000000000L);
+    assertThat(calculateThreshold(0.)).isEqualTo(getMaxThreshold());
+    assertThat(calculateThreshold(0.25)).isEqualTo(0xc0000000000000L);
     assertThat(calculateThreshold(0.5)).isEqualTo(0x80000000000000L);
-    assertThat(calculateThreshold(1.)).isEqualTo(0x100000000000000L);
+    assertThat(calculateThreshold(1.)).isEqualTo(getMinThreshold());
     assertThatIllegalArgumentException().isThrownBy(() -> calculateThreshold(Math.nextDown(0.)));
     assertThatIllegalArgumentException().isThrownBy(() -> calculateThreshold(Math.nextUp(1.)));
     assertThatIllegalArgumentException()
@@ -56,8 +60,13 @@ public class ConsistentSamplingUtilTest {
   }
 
   @Test
+  void testGetMinThreshold() {
+    assertThat(getMinThreshold()).isZero();
+  }
+
+  @Test
   void testGetMaxThreshold() {
-    assertThat(ConsistentSamplingUtil.getMaxThreshold()).isEqualTo(0x100000000000000L);
+    assertThat(getMaxThreshold()).isEqualTo(0x100000000000000L);
   }
 
   @Test
@@ -67,12 +76,12 @@ public class ConsistentSamplingUtilTest {
 
   @Test
   void testCalculateAdjustedCount() {
-    assertThat(calculateAdjustedCount(0L)).isZero();
-    assertThat(calculateAdjustedCount(0x40000000000000L)).isEqualTo(4.);
+    assertThat(calculateAdjustedCount(getMinThreshold())).isOne();
+    assertThat(calculateAdjustedCount(0xc0000000000000L)).isEqualTo(4.);
     assertThat(calculateAdjustedCount(0x80000000000000L)).isEqualTo(2.);
-    assertThat(calculateAdjustedCount(0x100000000000000L)).isOne();
-    assertThat(calculateAdjustedCount(-1)).isOne();
-    assertThat(calculateAdjustedCount(0x100000000000001L)).isOne();
+    assertThat(calculateAdjustedCount(getMaxThreshold())).isInfinite();
+    assertThat(calculateAdjustedCount(-1)).isZero();
+    assertThat(calculateAdjustedCount(0x100000000000001L)).isZero();
   }
 
   @Test

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtilTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtilTest.java
@@ -79,9 +79,12 @@ public class ConsistentSamplingUtilTest {
     assertThat(calculateAdjustedCount(getMinThreshold())).isOne();
     assertThat(calculateAdjustedCount(0xc0000000000000L)).isEqualTo(4.);
     assertThat(calculateAdjustedCount(0x80000000000000L)).isEqualTo(2.);
+    assertThat(calculateAdjustedCount(getMaxThreshold() - 1)).isEqualTo(0x1p56);
     assertThat(calculateAdjustedCount(getMaxThreshold())).isInfinite();
-    assertThat(calculateAdjustedCount(-1)).isZero();
-    assertThat(calculateAdjustedCount(0x100000000000001L)).isZero();
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> calculateAdjustedCount(getMinThreshold() - 1));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> calculateAdjustedCount(getMaxThreshold() + 1));
   }
 
   @Test


### PR DESCRIPTION
**Description:**

As agreed in the last Sampling SIG meeting (see https://github.com/open-telemetry/oteps/pull/235#issuecomment-1845647087), the sampling probability information will be encoded as "rejection threshold" instead of an "acceptance threshold". This PR reflects this decision.