### PR TITLE
Add kafka.request.time.avg

### DIFF
--- a/jmx-metrics/docs/target-systems/kafka.md
+++ b/jmx-metrics/docs/target-systems/kafka.md
@@ -42,6 +42,12 @@ These metrics are sourced from Kafka's exposed Yammer metrics for each instance:
 * Attributes: `type`
 * Instrument Type: DoubleValueObserver
 
+* Name: `kafka.request.time.avg`
+* Description: The average time the broker has taken to service requests
+* Unit: `ms`
+* Attributes: `type`
+* Instrument Type: DoubleValueObserver
+
 * Name: `kafka.network.io`
 * Description: The bytes received or sent by the broker
 * Unit: `by`

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
@@ -127,6 +127,15 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
                 attrs -> attrs.containsOnly(entry("type", "fetchfollower")),
                 attrs -> attrs.containsOnly(entry("type", "fetchconsumer"))),
         metric ->
+            assertGaugeWithAttributes(
+                metric,
+                "kafka.request.time.avg",
+                "The average time the broker has taken to service requests",
+                "ms",
+                attrs -> attrs.containsOnly(entry("type", "produce")),
+                attrs -> attrs.containsOnly(entry("type", "fetchfollower")),
+                attrs -> attrs.containsOnly(entry("type", "fetchconsumer"))),
+        metric ->
             assertGauge(
                 metric,
                 "kafka.partition.count",

--- a/jmx-metrics/src/main/resources/target-systems/kafka.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/kafka.groovy
@@ -86,8 +86,14 @@ otel.instrument(requestTime,
     "type" : { mbean -> mbean.name().getKeyProperty("request").toLowerCase() },
   ],
   "99thPercentile", otel.&doubleValueCallback)
-
-
+otel.instrument(requestTime,
+  "kafka.request.time.avg",
+  "The average time the broker has taken to service requests",
+  "ms",
+  [
+    "type" : { mbean -> mbean.name().getKeyProperty("request").toLowerCase() },
+  ],
+  "Mean", otel.&doubleValueCallback)
 
 def network = otel.mbeans(["kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec",
                           "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"])


### PR DESCRIPTION
**Description:**
This PR adds metric `kafka.request.time.avg` for `kafka.network:type=RequestMetrics,name=TotalTimeMs,request={Produce,FetchConsumer,FetchFollower}`. It does so by collecting from the `Mean` attribute.

**Existing Issue(s):**
This is a small addition so didn't open an issue.

**Testing:**
Added test case in `KafkaIntegrationTest.java`

**Documentation:**
Added documentation in `kafka.md`

**Outstanding items:**

< Anything that these changes are intentionally missing
  that will be needed or can be helpful in the future. >
