### PR TITLE
[disk-buffering] Ensure no sign propagation for flags byte 

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/LogRecordDataMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/LogRecordDataMapper.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs;
 
 import static io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.SpanDataMapper.flagsFromInt;
+import static io.opentelemetry.contrib.disk.buffering.internal.utils.ProtobufTools.toUnsignedInt;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Severity;
@@ -45,7 +46,8 @@ public final class LogRecordDataMapper {
       logRecord.body(bodyToAnyValue(source.getBody()));
     }
 
-    logRecord.flags(source.getSpanContext().getTraceFlags().asByte());
+    byte flags = source.getSpanContext().getTraceFlags().asByte();
+    logRecord.flags(toUnsignedInt(flags));
 
     addExtrasToProtoBuilder(source, logRecord);
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/SpanDataMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/SpanDataMapper.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans;
 
+import static io.opentelemetry.contrib.disk.buffering.internal.utils.ProtobufTools.toUnsignedInt;
+
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
@@ -309,7 +311,7 @@ public final class SpanDataMapper {
     SpanContext spanContext = source.getSpanContext();
     builder.trace_id(ByteStringMapper.getInstance().stringToProto(spanContext.getTraceId()));
     builder.span_id(ByteStringMapper.getInstance().stringToProto(spanContext.getSpanId()));
-    builder.flags = spanContext.getTraceFlags().asByte();
+    builder.flags = toUnsignedInt(spanContext.getTraceFlags().asByte());
     builder.attributes.addAll(attributesToProto(source.getAttributes()));
     builder.dropped_attributes_count(
         source.getTotalAttributeCount() - source.getAttributes().size());

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
@@ -48,4 +48,12 @@ public final class ProtobufTools {
     }
     throw new IllegalStateException();
   }
+
+  /**
+   * Vendored {@link Byte#toUnsignedInt(byte)} to support Android. Also helps with accidental sign
+   * propagation.
+   */
+  public static int toUnsignedInt(byte x) {
+    return ((int) x) & 0xff;
+  }
 }


### PR DESCRIPTION
Because bytes are signed in java, when we use the `TraceFlags.asByte()` we need to make sure we mask off the lower 8 bits correctly, otherwise the sign bit will propagate. Yup.