### PR TITLE
[disk-buffering] Split serializer

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.io.IOException;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class LogRecordFromDiskExporter implements FromDiskExporter {
         FromDiskExporterImpl.<LogRecordData>builder()
             .setFolderName("logs")
             .setStorageConfiguration(config)
-            .setDeserializer(SignalSerializer.ofLogs())
+            .setDeserializer(SignalDeserializer.ofLogs())
             .setExportFunction(exporter::export)
             .build();
     return new LogRecordFromDiskExporter(delegate);

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class MetricFromDiskExporter implements FromDiskExporter {
         FromDiskExporterImpl.<MetricData>builder()
             .setFolderName("metrics")
             .setStorageConfiguration(config)
-            .setDeserializer(SignalSerializer.ofMetrics())
+            .setDeserializer(SignalDeserializer.ofMetrics())
             .setExportFunction(exporter::export)
             .build();
     return new MetricFromDiskExporter(delegate);

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
@@ -24,7 +24,7 @@ public class SpanFromDiskExporter implements FromDiskExporter {
         FromDiskExporterImpl.<SpanData>builder()
             .setFolderName("spans")
             .setStorageConfiguration(config)
-            .setDeserializer(SignalSerializer.ofSpans())
+            .setDeserializer(SignalDeserializer.ofSpans())
             .setExportFunction(exporter::export)
             .build();
     return new SpanFromDiskExporter(delegate);

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
@@ -5,40 +5,29 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.exporter;
 
+import static java.util.Collections.emptyList;
+
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.StorageBuilder;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 
 public class FromDiskExporterBuilder<T> {
 
-  private SignalSerializer<T> serializer = noopSerializer();
+  private SignalDeserializer<T> serializer = noopDeserializer();
   private Function<Collection<T>, CompletableResultCode> exportFunction =
       x -> CompletableResultCode.ofFailure();
 
   @NotNull
-  private static <T> SignalSerializer<T> noopSerializer() {
-    return new SignalSerializer<T>() {
-
-      @Override
-      public byte[] serialize(Collection<T> ts) {
-        return new byte[0];
-      }
-
-      @Override
-      public List<T> deserialize(byte[] source) {
-        return Collections.emptyList();
-      }
-    };
+  private static <T> SignalDeserializer<T> noopDeserializer() {
+    return x -> emptyList();
   }
 
   private final StorageBuilder storageBuilder = Storage.builder();
@@ -62,7 +51,7 @@ public class FromDiskExporterBuilder<T> {
   }
 
   @CanIgnoreReturnValue
-  public FromDiskExporterBuilder<T> setDeserializer(SignalSerializer<T> serializer) {
+  public FromDiskExporterBuilder<T> setDeserializer(SignalDeserializer<T> serializer) {
     this.serializer = serializer;
     return this;
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
@@ -9,7 +9,7 @@ import static java.util.Collections.emptyList;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.StorageBuilder;
 import io.opentelemetry.sdk.common.Clock;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.exporter;
 
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -22,12 +22,12 @@ import java.util.logging.Logger;
  */
 public final class FromDiskExporterImpl<EXPORT_DATA> implements FromDiskExporter {
   private final Storage storage;
-  private final SignalSerializer<EXPORT_DATA> deserializer;
+  private final SignalDeserializer<EXPORT_DATA> deserializer;
   private final Function<Collection<EXPORT_DATA>, CompletableResultCode> exportFunction;
   private static final Logger logger = Logger.getLogger(FromDiskExporterImpl.class.getName());
 
   FromDiskExporterImpl(
-      SignalSerializer<EXPORT_DATA> deserializer,
+      SignalDeserializer<EXPORT_DATA> deserializer,
       Function<Collection<EXPORT_DATA>, CompletableResultCode> exportFunction,
       Storage storage) {
     this.deserializer = deserializer;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.exporter;
 
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
@@ -14,25 +14,11 @@ import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 
 public final class ToDiskExporterBuilder<T> {
 
-  private SignalSerializer<T> serializer =
-      new SignalSerializer<T>() {
-
-        @Override
-        public byte[] serialize(Collection<T> ts) {
-          return new byte[0];
-        }
-
-        @Override
-        public List<T> deserialize(byte[] source) {
-          return Collections.emptyList();
-        }
-      };
+  private SignalSerializer<T> serializer = ts -> new byte[0];
 
   private final StorageBuilder storageBuilder = Storage.builder();
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
+
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.ProtoLogsDataMapper;
+import io.opentelemetry.proto.logs.v1.LogsData;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import java.io.IOException;
+import java.util.List;
+
+public final class LogRecordDataDeserializer implements SignalDeserializer<LogRecordData> {
+  private static final LogRecordDataDeserializer INSTANCE = new LogRecordDataDeserializer();
+
+  private LogRecordDataDeserializer() {}
+
+  static LogRecordDataDeserializer getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public List<LogRecordData> deserialize(byte[] source) {
+    try {
+      return ProtoLogsDataMapper.getInstance().fromProto(LogsData.ADAPTER.decode(source));
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
+
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.metrics.ProtoMetricsDataMapper;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import java.io.IOException;
+import java.util.List;
+
+public final class MetricDataDeerializer implements SignalDeserializer<MetricData> {
+  private static final MetricDataDeerializer INSTANCE = new MetricDataDeerializer();
+
+  private MetricDataDeerializer() {}
+
+  static MetricDataDeerializer getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public List<MetricData> deserialize(byte[] source) {
+    try {
+      return ProtoMetricsDataMapper.getInstance().fromProto(MetricsData.ADAPTER.decode(source));
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
@@ -11,12 +11,12 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.util.List;
 
-public final class MetricDataDeerializer implements SignalDeserializer<MetricData> {
-  private static final MetricDataDeerializer INSTANCE = new MetricDataDeerializer();
+public final class MetricDataDeserializer implements SignalDeserializer<MetricData> {
+  private static final MetricDataDeserializer INSTANCE = new MetricDataDeserializer();
 
-  private MetricDataDeerializer() {}
+  private MetricDataDeserializer() {}
 
-  static MetricDataDeerializer getInstance() {
+  static MetricDataDeserializer getInstance() {
     return INSTANCE;
   }
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
@@ -17,7 +17,7 @@ public interface SignalDeserializer<SDK_ITEM> {
   }
 
   static SignalDeserializer<MetricData> ofMetrics() {
-    return MetricDataDeerializer.getInstance();
+    return MetricDataDeserializer.getInstance();
   }
 
   static SignalDeserializer<LogRecordData> ofLogs() {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers;
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -13,15 +13,15 @@ import java.util.List;
 public interface SignalDeserializer<SDK_ITEM> {
 
   static SignalDeserializer<SpanData> ofSpans() {
-    return SpanDataSerializer.getInstance();
+    return SpanDataDeserializer.getInstance();
   }
 
   static SignalDeserializer<MetricData> ofMetrics() {
-    return MetricDataSerializer.getInstance();
+    return MetricDataDeerializer.getInstance();
   }
 
   static SignalDeserializer<LogRecordData> ofLogs() {
-    return LogRecordDataSerializer.getInstance();
+    return LogRecordDataDeserializer.getInstance();
   }
 
   List<SDK_ITEM> deserialize(byte[] source);

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
+
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.ProtoSpansDataMapper;
+import io.opentelemetry.proto.trace.v1.TracesData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.util.List;
+
+public final class SpanDataDeserializer implements SignalDeserializer<SpanData> {
+  private static final SpanDataDeserializer INSTANCE = new SpanDataDeserializer();
+
+  private SpanDataDeserializer() {}
+
+  static SpanDataDeserializer getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public List<SpanData> deserialize(byte[] source) {
+    try {
+      return ProtoSpansDataMapper.getInstance().fromProto(TracesData.ADAPTER.decode(source));
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializer.java
@@ -12,10 +12,8 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 
-public final class LogRecordDataSerializer
-    implements SignalSerializer<LogRecordData>, SignalDeserializer<LogRecordData> {
+public final class LogRecordDataSerializer implements SignalSerializer<LogRecordData> {
   private static final LogRecordDataSerializer INSTANCE = new LogRecordDataSerializer();
 
   private LogRecordDataSerializer() {}
@@ -34,15 +32,6 @@ public final class LogRecordDataSerializer
       return out.toByteArray();
     } catch (IOException e) {
       throw new IllegalStateException(e);
-    }
-  }
-
-  @Override
-  public List<LogRecordData> deserialize(byte[] source) {
-    try {
-      return ProtoLogsDataMapper.getInstance().fromProto(LogsData.ADAPTER.decode(source));
-    } catch (IOException e) {
-      throw new IllegalArgumentException(e);
     }
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializer.java
@@ -14,7 +14,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-public final class LogRecordDataSerializer implements SignalSerializer<LogRecordData> {
+public final class LogRecordDataSerializer
+    implements SignalSerializer<LogRecordData>, SignalDeserializer<LogRecordData> {
   private static final LogRecordDataSerializer INSTANCE = new LogRecordDataSerializer();
 
   private LogRecordDataSerializer() {}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializer.java
@@ -14,7 +14,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-public final class MetricDataSerializer implements SignalSerializer<MetricData> {
+public final class MetricDataSerializer
+    implements SignalSerializer<MetricData>, SignalDeserializer<MetricData> {
   private static final MetricDataSerializer INSTANCE = new MetricDataSerializer();
 
   private MetricDataSerializer() {}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializer.java
@@ -12,10 +12,8 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 
-public final class MetricDataSerializer
-    implements SignalSerializer<MetricData>, SignalDeserializer<MetricData> {
+public final class MetricDataSerializer implements SignalSerializer<MetricData> {
   private static final MetricDataSerializer INSTANCE = new MetricDataSerializer();
 
   private MetricDataSerializer() {}
@@ -34,15 +32,6 @@ public final class MetricDataSerializer
       return out.toByteArray();
     } catch (IOException e) {
       throw new IllegalStateException(e);
-    }
-  }
-
-  @Override
-  public List<MetricData> deserialize(byte[] source) {
-    try {
-      return ProtoMetricsDataMapper.getInstance().fromProto(MetricsData.ADAPTER.decode(source));
-    } catch (IOException e) {
-      throw new IllegalArgumentException(e);
     }
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SignalDeserializer.java
@@ -8,21 +8,21 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.serialize
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import java.util.Collection;
+import java.util.List;
 
-public interface SignalSerializer<SDK_ITEM> {
+public interface SignalDeserializer<SDK_ITEM> {
 
-  static SignalSerializer<SpanData> ofSpans() {
+  static SignalDeserializer<SpanData> ofSpans() {
     return SpanDataSerializer.getInstance();
   }
 
-  static SignalSerializer<MetricData> ofMetrics() {
+  static SignalDeserializer<MetricData> ofMetrics() {
     return MetricDataSerializer.getInstance();
   }
 
-  static SignalSerializer<LogRecordData> ofLogs() {
+  static SignalDeserializer<LogRecordData> ofLogs() {
     return LogRecordDataSerializer.getInstance();
   }
 
-  byte[] serialize(Collection<SDK_ITEM> items);
+  List<SDK_ITEM> deserialize(byte[] source);
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializer.java
@@ -14,7 +14,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-public final class SpanDataSerializer implements SignalSerializer<SpanData> {
+public final class SpanDataSerializer
+    implements SignalSerializer<SpanData>, SignalDeserializer<SpanData> {
   private static final SpanDataSerializer INSTANCE = new SpanDataSerializer();
 
   private SpanDataSerializer() {}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializer.java
@@ -12,10 +12,8 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 
-public final class SpanDataSerializer
-    implements SignalSerializer<SpanData>, SignalDeserializer<SpanData> {
+public final class SpanDataSerializer implements SignalSerializer<SpanData> {
   private static final SpanDataSerializer INSTANCE = new SpanDataSerializer();
 
   private SpanDataSerializer() {}
@@ -34,15 +32,6 @@ public final class SpanDataSerializer
       return out.toByteArray();
     } catch (IOException e) {
       throw new IllegalStateException(e);
-    }
-  }
-
-  @Override
-  public List<SpanData> deserialize(byte[] source) {
-    try {
-      return ProtoSpansDataMapper.getInstance().fromProto(TracesData.ADAPTER.decode(source));
-    } catch (IOException e) {
-      throw new IllegalArgumentException(e);
     }
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.TestData;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.TestData;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 @SuppressWarnings("unchecked")
 class FromDiskExporterImplTest {
   private SpanExporter wrapped;
-  private SignalSerializer<SpanData> serializer;
+  private SignalDeserializer<SpanData> deserializer;
   private Clock clock;
   private FromDiskExporterImpl<SpanData> exporter;
   private final List<SpanData> deserializedData = Collections.emptyList();
@@ -50,7 +50,7 @@ class FromDiskExporterImplTest {
         FromDiskExporterImpl.<SpanData>builder()
             .setFolderName(STORAGE_FOLDER_NAME)
             .setStorageConfiguration(TestData.getDefaultConfiguration(rootDir))
-            .setDeserializer(serializer)
+            .setDeserializer(deserializer)
             .setExportFunction(wrapped::export)
             .setStorageClock(clock)
             .build();
@@ -94,8 +94,8 @@ class FromDiskExporterImplTest {
   }
 
   private void setUpSerializer() {
-    serializer = mock();
-    doReturn(deserializedData).when(serializer).deserialize(any());
+    deserializer = mock();
+    doReturn(deserializedData).when(deserializer).deserialize(any());
   }
 
   private static Clock createClockMock() {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
@@ -20,7 +20,7 @@ import io.opentelemetry.contrib.disk.buffering.internal.StorageConfiguration;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterBuilder;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.ToDiskExporter;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializerTest.java
@@ -52,4 +52,9 @@ class LogRecordDataSerializerTest extends BaseSignalSerializerTest<LogRecordData
   protected SignalSerializer<LogRecordData> getSerializer() {
     return SignalSerializer.ofLogs();
   }
+
+  @Override
+  protected SignalDeserializer<LogRecordData> getDeserializer() {
+    return SignalDeserializer.ofLogs();
+  }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/LogRecordDataSerializerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.serialize
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.models.LogRecordDataImpl;
 import io.opentelemetry.contrib.disk.buffering.testutils.BaseSignalSerializerTest;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializerTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.testutils.BaseSignalSerializerTest;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/MetricDataSerializerTest.java
@@ -274,4 +274,9 @@ class MetricDataSerializerTest extends BaseSignalSerializerTest<MetricData> {
   protected SignalSerializer<MetricData> getSerializer() {
     return SignalSerializer.ofMetrics();
   }
+
+  @Override
+  protected SignalDeserializer<MetricData> getDeserializer() {
+    return SignalDeserializer.ofMetrics();
+  }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializerTest.java
@@ -78,4 +78,9 @@ class SpanDataSerializerTest extends BaseSignalSerializerTest<SpanData> {
   protected SignalSerializer<SpanData> getSerializer() {
     return SignalSerializer.ofSpans();
   }
+
+  @Override
+  protected SignalDeserializer<SpanData> getDeserializer() {
+    return SignalDeserializer.ofSpans();
+  }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SpanDataSerializerTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers;
 
 import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
 import io.opentelemetry.contrib.disk.buffering.testutils.BaseSignalSerializerTest;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.mock;
 
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.contrib.disk.buffering.internal.files.TemporaryFileProvider;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.models.LogRecordDataImpl;
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.contrib.disk.buffering.internal.files.TemporaryFileProvider;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.models.LogRecordDataImpl;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
@@ -45,6 +46,7 @@ class ReadableFileTest {
   private TemporaryFileProvider temporaryFileProvider;
   private static final long CREATED_TIME_MILLIS = 1000L;
   private static final SignalSerializer<LogRecordData> SERIALIZER = SignalSerializer.ofLogs();
+  private static final SignalDeserializer<LogRecordData> DESERIALIZER = SignalDeserializer.ofLogs();
   private static final LogRecordData FIRST_LOG_RECORD =
       LogRecordDataImpl.builder()
           .setResource(TestData.RESOURCE_FULL)
@@ -233,6 +235,6 @@ class ReadableFileTest {
   }
 
   private static LogRecordData deserialize(byte[] data) {
-    return SERIALIZER.deserialize(data).get(0);
+    return DESERIALIZER.deserialize(data).get(0);
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.testutils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.DelimitedProtoStreamReader;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.StreamReader;
@@ -25,7 +26,7 @@ public abstract class BaseSignalSerializerTest<SIGNAL_SDK_ITEM> {
   protected List<SIGNAL_SDK_ITEM> deserialize(byte[] source) {
     try (ByteArrayInputStream in = new ByteArrayInputStream(source)) {
       StreamReader streamReader = DelimitedProtoStreamReader.Factory.getInstance().create(in);
-      return getSerializer().deserialize(Objects.requireNonNull(streamReader.read()).content);
+      return getDeserializer().deserialize(Objects.requireNonNull(streamReader.read()).content);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -42,4 +43,6 @@ public abstract class BaseSignalSerializerTest<SIGNAL_SDK_ITEM> {
   }
 
   protected abstract SignalSerializer<SIGNAL_SDK_ITEM> getSerializer();
+
+  protected abstract SignalDeserializer<SIGNAL_SDK_ITEM> getDeserializer();
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
@@ -7,7 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.testutils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.DelimitedProtoStreamReader;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.StreamReader;


### PR DESCRIPTION
Single responsibility principle -- Split the `SignalSerializer` interface into `SignalSerializer` and `SignalDeserializer`. This cleans up a few things after the last refactor.

Note: The tests are currently testing both directions (serialize/deserialize), so I didn't feel like it was really necessary to decompose those in this PR. If someone else did that I wouldn't complain, but it felt a bit like overkill.