### PR TITLE
Implement Metrics incubator APIs to accept advice

### DIFF
--- a/micrometer-meter-provider/build.gradle.kts
+++ b/micrometer-meter-provider/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   api("io.opentelemetry:opentelemetry-sdk-metrics")
   api("io.opentelemetry:opentelemetry-extension-incubator")
 
-  compileOnly("io.micrometer:micrometer-core:1.1.0") // do not auto-update this version
+  compileOnly("io.micrometer:micrometer-core:1.5.0") // do not auto-update this version
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
 
   annotationProcessor("com.google.auto.service:auto-service")

--- a/micrometer-meter-provider/build.gradle.kts
+++ b/micrometer-meter-provider/build.gradle.kts
@@ -9,6 +9,7 @@ otelJava.moduleName.set("io.opentelemetry.contrib.metrics.micrometer")
 dependencies {
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-sdk-metrics")
+  api("io.opentelemetry:opentelemetry-extension-incubator")
 
   compileOnly("io.micrometer:micrometer-core:1.1.0") // do not auto-update this version
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")

--- a/micrometer-meter-provider/src/integrationTest/java/io/opentelemetry/contrib/metrics/micrometer/PrometheusIntegrationTest.java
+++ b/micrometer-meter-provider/src/integrationTest/java/io/opentelemetry/contrib/metrics/micrometer/PrometheusIntegrationTest.java
@@ -12,11 +12,19 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
 import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.api.metrics.ObservableDoubleCounter;
@@ -25,6 +33,16 @@ import io.opentelemetry.api.metrics.ObservableDoubleUpDownCounter;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleCounterBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleGaugeBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleUpDownCounterBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongCounterBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongGaugeBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongHistogramBuilder;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongUpDownCounterBuilder;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +50,12 @@ import org.junit.jupiter.api.Test;
 
 public class PrometheusIntegrationTest {
   private static final AttributeKey<String> KEY1 = AttributeKey.stringKey("key1");
+  private static final AttributeKey<String> KEY2 = AttributeKey.stringKey("key2");
+  private static final String VALUE1 = "value1";
+  private static final String VALUE2 = "value2";
+
+  private static final Attributes FIRST_ATTRIBUTES = Attributes.of(KEY1, VALUE1, KEY2, VALUE1);
+  private static final Attributes SECOND_ATTRIBUTES = Attributes.of(KEY1, VALUE1, KEY2, VALUE2);
 
   PrometheusMeterRegistry prometheusMeterRegistry;
 
@@ -60,8 +84,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    longCounter.add(1, Attributes.of(KEY1, "value1"));
-    longCounter.add(2, Attributes.of(KEY1, "value2"));
+    longCounter.add(1, FIRST_ATTRIBUTES);
+    longCounter.add(2, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
 
@@ -69,9 +93,32 @@ public class PrometheusIntegrationTest {
         .contains("# HELP longCounter_units_total LongCounter test")
         .contains("# TYPE longCounter_units_total counter")
         .contains(
-            "longCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longCounter_units_total{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longCounter_units_total{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+            "longCounter_units_total{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+  }
+
+  @Test
+  void longCounterWithAttributesAdvice() {
+    LongCounterBuilder builder =
+        meter.counterBuilder("longCounter").setDescription("LongCounter test").setUnit("units");
+
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    LongCounter longCounter = builder.build();
+
+    longCounter.add(1, FIRST_ATTRIBUTES);
+    longCounter.add(2, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+
+    assertThat(output)
+        .contains("# HELP longCounter_units_total LongCounter test")
+        .contains("# TYPE longCounter_units_total counter")
+        .contains(
+            "longCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 3.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
   }
 
   @Test
@@ -84,8 +131,8 @@ public class PrometheusIntegrationTest {
             .buildWithCallback(
                 onlyOnce(
                     measurement -> {
-                      measurement.record(1, Attributes.of(KEY1, "value1"));
-                      measurement.record(2, Attributes.of(KEY1, "value2"));
+                      measurement.record(1, FIRST_ATTRIBUTES);
+                      measurement.record(2, SECOND_ATTRIBUTES);
                     }))) {
 
       String output = scrapeFor("longCounter");
@@ -95,9 +142,37 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE longCounter_units_total counter")
           .contains("# HELP longCounter_units_total LongCounter test")
           .contains(
-              "longCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+              "longCounter_units_total{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
           .contains(
-              "longCounter_units_total{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+              "longCounter_units_total{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+    }
+  }
+
+  @Test
+  void observableLongCounterWithAttributesAdvice() {
+    LongCounterBuilder builder =
+        meter.counterBuilder("longCounter").setDescription("LongCounter test").setUnit("units");
+
+    ((ExtendedLongCounterBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableLongCounter observableLongCounter =
+        builder.buildWithCallback(
+            onlyOnce(
+                measurement -> {
+                  measurement.record(1, FIRST_ATTRIBUTES);
+                  measurement.record(2, SECOND_ATTRIBUTES);
+                }))) {
+
+      String output = scrapeFor("longCounter");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE longCounter_units_total counter")
+          .contains("# HELP longCounter_units_total LongCounter test")
+          .contains(
+              "longCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 
@@ -111,8 +186,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    doubleCounter.add(1.5, Attributes.of(KEY1, "value1"));
-    doubleCounter.add(2.5, Attributes.of(KEY1, "value2"));
+    doubleCounter.add(1.5, FIRST_ATTRIBUTES);
+    doubleCounter.add(2.5, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
 
@@ -120,9 +195,37 @@ public class PrometheusIntegrationTest {
         .contains("# HELP doubleCounter_units_total DoubleCounter test")
         .contains("# TYPE doubleCounter_units_total counter")
         .contains(
-            "doubleCounter_units_total{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
+            "doubleCounter_units_total{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
         .contains(
-            "doubleCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5");
+            "doubleCounter_units_total{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+  }
+
+  @Test
+  void doubleCounterWithAttributesAdvice() {
+
+    DoubleCounterBuilder builder =
+        meter
+            .counterBuilder("doubleCounter")
+            .ofDoubles()
+            .setDescription("DoubleCounter test")
+            .setUnit("units");
+
+    ((ExtendedDoubleCounterBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    DoubleCounter doubleCounter = builder.build();
+
+    doubleCounter.add(1.5, FIRST_ATTRIBUTES);
+    doubleCounter.add(2.5, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+
+    assertThat(output)
+        .contains("# HELP doubleCounter_units_total DoubleCounter test")
+        .contains("# TYPE doubleCounter_units_total counter")
+        .contains(
+            "doubleCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
   }
 
   @Test
@@ -136,8 +239,8 @@ public class PrometheusIntegrationTest {
             .buildWithCallback(
                 onlyOnce(
                     measurement -> {
-                      measurement.record(1.5, Attributes.of(KEY1, "value1"));
-                      measurement.record(2.5, Attributes.of(KEY1, "value2"));
+                      measurement.record(1.5, FIRST_ATTRIBUTES);
+                      measurement.record(2.5, SECOND_ATTRIBUTES);
                     }))) {
 
       String output = scrapeFor("doubleCounter");
@@ -147,9 +250,41 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE doubleCounter_units_total counter")
           .contains("# HELP doubleCounter_units_total DoubleCounter test")
           .contains(
-              "doubleCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+              "doubleCounter_units_total{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
           .contains(
-              "doubleCounter_units_total{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+              "doubleCounter_units_total{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+    }
+  }
+
+  @Test
+  void observableDoubleCounterWithAttributesAdvice() {
+    DoubleCounterBuilder builder =
+        meter
+            .counterBuilder("doubleCounter")
+            .ofDoubles()
+            .setDescription("DoubleCounter test")
+            .setUnit("units");
+
+    ((ExtendedDoubleCounterBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableDoubleCounter observableDoubleCounter =
+        builder.buildWithCallback(
+            onlyOnce(
+                measurement -> {
+                  measurement.record(1.0, FIRST_ATTRIBUTES);
+                  measurement.record(2.0, SECOND_ATTRIBUTES);
+                }))) {
+
+      String output = scrapeFor("doubleCounter");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE doubleCounter_units_total counter")
+          .contains("# HELP doubleCounter_units_total DoubleCounter test")
+          .contains(
+              "doubleCounter_units_total{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 
@@ -162,8 +297,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    longUpDownCounter.add(1, Attributes.of(KEY1, "value1"));
-    longUpDownCounter.add(2, Attributes.of(KEY1, "value2"));
+    longUpDownCounter.add(1, FIRST_ATTRIBUTES);
+    longUpDownCounter.add(2, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
 
@@ -171,20 +306,59 @@ public class PrometheusIntegrationTest {
         .contains("# HELP longUpDownCounter_units LongUpDownCounter test")
         .contains("# TYPE longUpDownCounter_units gauge")
         .contains(
-            "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+            "longUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
 
-    longUpDownCounter.add(1, Attributes.of(KEY1, "value1"));
-    longUpDownCounter.add(2, Attributes.of(KEY1, "value2"));
+    longUpDownCounter.add(1, FIRST_ATTRIBUTES);
+    longUpDownCounter.add(2, SECOND_ATTRIBUTES);
 
     output = prometheusMeterRegistry.scrape();
 
     assertThat(output)
         .contains(
-            "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+            "longUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
         .contains(
-            "longUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0");
+            "longUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0");
+  }
+
+  @Test
+  void longUpDownCounterWithAttributesAdvice() {
+
+    LongUpDownCounterBuilder builder =
+        meter
+            .upDownCounterBuilder("longUpDownCounter")
+            .setDescription("LongUpDownCounter test")
+            .setUnit("units");
+
+    ((ExtendedLongUpDownCounterBuilder) builder)
+        .setAttributesAdvice(Collections.singletonList(KEY1));
+
+    LongUpDownCounter longUpDownCounter = builder.build();
+
+    longUpDownCounter.add(1, FIRST_ATTRIBUTES);
+    longUpDownCounter.add(2, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+
+    assertThat(output)
+        .contains("# HELP longUpDownCounter_units LongUpDownCounter test")
+        .contains("# TYPE longUpDownCounter_units gauge")
+        .contains(
+            "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 3.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
+
+    longUpDownCounter.add(1, FIRST_ATTRIBUTES);
+    longUpDownCounter.add(2, SECOND_ATTRIBUTES);
+
+    output = prometheusMeterRegistry.scrape();
+
+    assertThat(output)
+        .contains(
+            "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 6.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
   }
 
   @Test
@@ -196,8 +370,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .buildWithCallback(
                 measurement -> {
-                  measurement.record(1, Attributes.of(KEY1, "value1"));
-                  measurement.record(-2, Attributes.of(KEY1, "value2"));
+                  measurement.record(1, FIRST_ATTRIBUTES);
+                  measurement.record(-2, SECOND_ATTRIBUTES);
                 })) {
 
       String output = scrapeFor("longUpDownCounter");
@@ -207,9 +381,40 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE longUpDownCounter_units gauge")
           .contains("# HELP longUpDownCounter_units LongUpDownCounter test")
           .contains(
-              "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+              "longUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
           .contains(
-              "longUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.0");
+              "longUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.0");
+    }
+  }
+
+  @Test
+  void observableLongUpDownCounterWithAttributesAdvice() {
+    LongUpDownCounterBuilder builder =
+        meter
+            .upDownCounterBuilder("longUpDownCounter")
+            .setDescription("LongUpDownCounter test")
+            .setUnit("units");
+
+    ((ExtendedLongUpDownCounterBuilder) builder)
+        .setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableLongUpDownCounter observableLongUpDownCounter =
+        builder.buildWithCallback(
+            measurement -> {
+              measurement.record(1, FIRST_ATTRIBUTES);
+              measurement.record(-2, SECOND_ATTRIBUTES);
+            })) {
+
+      String output = scrapeFor("longUpDownCounter");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE longUpDownCounter_units gauge")
+          .contains("# HELP longUpDownCounter_units LongUpDownCounter test")
+          .contains(
+              "longUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.0")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 
@@ -223,8 +428,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    doubleUpDownCounter.add(1.5, Attributes.of(KEY1, "value1"));
-    doubleUpDownCounter.add(2.5, Attributes.of(KEY1, "value2"));
+    doubleUpDownCounter.add(1.5, FIRST_ATTRIBUTES);
+    doubleUpDownCounter.add(2.5, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
 
@@ -232,20 +437,48 @@ public class PrometheusIntegrationTest {
         .contains("# HELP doubleUpDownCounter_units DoubleUpDownCounter test")
         .contains("# TYPE doubleUpDownCounter_units gauge")
         .contains(
-            "doubleUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+            "doubleUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
         .contains(
-            "doubleUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+            "doubleUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
 
-    doubleUpDownCounter.add(0.5, Attributes.of(KEY1, "value1"));
-    doubleUpDownCounter.add(-1.5, Attributes.of(KEY1, "value2"));
+    doubleUpDownCounter.add(0.5, FIRST_ATTRIBUTES);
+    doubleUpDownCounter.add(-1.5, SECOND_ATTRIBUTES);
 
     output = prometheusMeterRegistry.scrape();
 
     assertThat(output)
         .contains(
-            "doubleUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+            "doubleUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
         .contains(
-            "doubleUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0");
+            "doubleUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0");
+  }
+
+  @Test
+  void doubleUpDownCounterWithAttributesAdvice() {
+    DoubleUpDownCounterBuilder builder =
+        meter
+            .upDownCounterBuilder("doubleUpDownCounter")
+            .ofDoubles()
+            .setDescription("DoubleUpDownCounter test")
+            .setUnit("units");
+
+    ((ExtendedDoubleUpDownCounterBuilder) builder)
+        .setAttributesAdvice(Collections.singletonList(KEY1));
+
+    DoubleUpDownCounter doubleUpDownCounter = builder.build();
+
+    doubleUpDownCounter.add(1.5, FIRST_ATTRIBUTES);
+    doubleUpDownCounter.add(2.5, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+
+    assertThat(output)
+        .contains("# HELP doubleUpDownCounter_units DoubleUpDownCounter test")
+        .contains("# TYPE doubleUpDownCounter_units gauge")
+        .contains(
+            "doubleUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
   }
 
   @Test
@@ -259,8 +492,8 @@ public class PrometheusIntegrationTest {
             .buildWithCallback(
                 onlyOnce(
                     measurement -> {
-                      measurement.record(1.5, Attributes.of(KEY1, "value1"));
-                      measurement.record(-2.5, Attributes.of(KEY1, "value2"));
+                      measurement.record(1.5, FIRST_ATTRIBUTES);
+                      measurement.record(-2.5, SECOND_ATTRIBUTES);
                     }))) {
 
       String output = scrapeFor("doubleUpDownCounter");
@@ -270,9 +503,42 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE doubleUpDownCounter_units gauge")
           .contains("# HELP doubleUpDownCounter_units DoubleUpDownCounter test")
           .contains(
-              "doubleUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+              "doubleUpDownCounter_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
           .contains(
-              "doubleUpDownCounter_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.5");
+              "doubleUpDownCounter_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.5");
+    }
+  }
+
+  @Test
+  void observableDoubleUpDownCounterWithAttributesAdvice() {
+    DoubleUpDownCounterBuilder builder =
+        meter
+            .upDownCounterBuilder("doubleUpDownCounter")
+            .ofDoubles()
+            .setDescription("DoubleUpDownCounter test")
+            .setUnit("units");
+
+    ((ExtendedDoubleUpDownCounterBuilder) builder)
+        .setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableDoubleUpDownCounter observableDoubleUpDownCounter =
+        builder.buildWithCallback(
+            onlyOnce(
+                measurement -> {
+                  measurement.record(1.5, FIRST_ATTRIBUTES);
+                  measurement.record(-2.5, SECOND_ATTRIBUTES);
+                }))) {
+
+      String output = scrapeFor("doubleUpDownCounter");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE doubleUpDownCounter_units gauge")
+          .contains("# HELP doubleUpDownCounter_units DoubleUpDownCounter test")
+          .contains(
+              "doubleUpDownCounter_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} -2.5")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 
@@ -285,38 +551,138 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    doubleHistogram.record(1.5, Attributes.of(KEY1, "value1"));
-    doubleHistogram.record(2.5, Attributes.of(KEY1, "value2"));
+    doubleHistogram.record(1.5, FIRST_ATTRIBUTES);
+    doubleHistogram.record(2.5, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
     assertThat(output)
         .contains("# HELP doubleHistogram_units DoubleHistogram test")
         .contains("# TYPE doubleHistogram_units summary")
         .contains(
-            "doubleHistogram_units_count{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "doubleHistogram_units_sum{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
         .contains(
-            "doubleHistogram_units_count{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "doubleHistogram_units_sum{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
         .contains("# HELP doubleHistogram_units_max DoubleHistogram test")
         .contains("# TYPE doubleHistogram_units_max gauge")
         .contains(
-            "doubleHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
         .contains(
-            "doubleHistogram_units_max{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
 
-    doubleHistogram.record(2.5, Attributes.of(KEY1, "value1"));
+    doubleHistogram.record(2.5, FIRST_ATTRIBUTES);
 
     output = prometheusMeterRegistry.scrape();
     assertThat(output)
         .contains(
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .contains(
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0")
+        .contains(
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+  }
+
+  @Test
+  void doubleHistogramWithAttributesAdvice() {
+
+    DoubleHistogramBuilder builder =
+        meter
+            .histogramBuilder("doubleHistogram")
+            .setDescription("DoubleHistogram test")
+            .setUnit("units");
+
+    ((ExtendedDoubleHistogramBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    DoubleHistogram doubleHistogram = builder.build();
+
+    doubleHistogram.record(1.5, FIRST_ATTRIBUTES);
+    doubleHistogram.record(2.5, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains("# HELP doubleHistogram_units DoubleHistogram test")
+        .contains("# TYPE doubleHistogram_units summary")
+        .contains(
             "doubleHistogram_units_count{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
         .contains(
             "doubleHistogram_units_sum{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0")
+        .contains("# HELP doubleHistogram_units_max DoubleHistogram test")
+        .contains("# TYPE doubleHistogram_units_max gauge")
         .contains(
-            "doubleHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+            "doubleHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
+  }
+
+  @Test
+  void doubleHistogramWithExplicitBucketBoundaries() {
+    DoubleHistogram doubleHistogram =
+        meter
+            .histogramBuilder("doubleHistogram")
+            .setExplicitBucketBoundariesAdvice(Arrays.asList(1.0, 2.0, 3.0))
+            .setDescription("DoubleHistogram test")
+            .setUnit("units")
+            .build();
+
+    doubleHistogram.record(1.5, FIRST_ATTRIBUTES);
+    doubleHistogram.record(2.5, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains("# HELP doubleHistogram_units DoubleHistogram test")
+        .contains("# TYPE doubleHistogram_units histogram")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 0.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 1.0")
+        .contains(
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 0.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 0.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 1.0")
+        .contains(
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
+        .contains("# HELP doubleHistogram_units_max DoubleHistogram test")
+        .contains("# TYPE doubleHistogram_units_max gauge")
+        .contains(
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+        .contains(
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+
+    doubleHistogram.record(2.5, FIRST_ATTRIBUTES);
+
+    output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 0.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 1.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 2.0")
+        .contains(
+            "doubleHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 2.0")
+        .contains(
+            "doubleHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .contains(
+            "doubleHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 4.0")
+        .contains(
+            "doubleHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
   }
 
   @Test
@@ -329,38 +695,139 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .build();
 
-    longHistogram.record(1, Attributes.of(KEY1, "value1"));
-    longHistogram.record(2, Attributes.of(KEY1, "value2"));
+    longHistogram.record(1, FIRST_ATTRIBUTES);
+    longHistogram.record(2, SECOND_ATTRIBUTES);
 
     String output = prometheusMeterRegistry.scrape();
     assertThat(output)
         .contains("# HELP longHistogram_units LongHistogram test")
         .contains("# TYPE longHistogram_units summary")
         .contains(
-            "longHistogram_units_count{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longHistogram_units_sum{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longHistogram_units_count{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longHistogram_units_count{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longHistogram_units_sum{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
         .contains("# HELP longHistogram_units_max LongHistogram test")
         .contains("# TYPE longHistogram_units_max gauge")
         .contains(
-            "longHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+            "longHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
         .contains(
-            "longHistogram_units_max{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+            "longHistogram_units_max{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
 
-    longHistogram.record(2, Attributes.of(KEY1, "value1"));
+    longHistogram.record(2, FIRST_ATTRIBUTES);
 
     output = prometheusMeterRegistry.scrape();
     assertThat(output)
         .contains(
+            "longHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .contains(
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 3.0")
+        .contains(
+            "longHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+  }
+
+  @Test
+  void longHistogramWithAttributesAdvice() {
+    LongHistogramBuilder builder =
+        meter
+            .histogramBuilder("longHistogram")
+            .ofLongs()
+            .setDescription("LongHistogram test")
+            .setUnit("units");
+
+    ((ExtendedLongHistogramBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    LongHistogram longHistogram = builder.build();
+
+    longHistogram.record(1, FIRST_ATTRIBUTES);
+    longHistogram.record(2, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains("# HELP longHistogram_units LongHistogram test")
+        .contains("# TYPE longHistogram_units summary")
+        .contains(
             "longHistogram_units_count{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
         .contains(
             "longHistogram_units_sum{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 3.0")
+        .contains("# HELP longHistogram_units_max LongHistogram test")
+        .contains("# TYPE longHistogram_units_max gauge")
         .contains(
-            "longHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+            "longHistogram_units_max{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .doesNotContain("key2=\"value1\"")
+        .doesNotContain("key2=\"value2\"");
+  }
+
+  @Test
+  void longHistogramWithExplicitBucketBoundaries() {
+    LongHistogram longHistogram =
+        meter
+            .histogramBuilder("longHistogram")
+            .ofLongs()
+            .setExplicitBucketBoundariesAdvice(Arrays.asList(1L, 2L, 3L))
+            .setDescription("LongHistogram test")
+            .setUnit("units")
+            .build();
+
+    longHistogram.record(1, FIRST_ATTRIBUTES);
+    longHistogram.record(2, SECOND_ATTRIBUTES);
+
+    String output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains("# HELP longHistogram_units LongHistogram test")
+        .contains("# TYPE longHistogram_units histogram")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 1.0")
+        .contains(
+            "longHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 0.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 1.0")
+        .contains(
+            "longHistogram_units_count{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .contains("# HELP longHistogram_units_max LongHistogram test")
+        .contains("# TYPE longHistogram_units_max gauge")
+        .contains(
+            "longHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_max{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+
+    longHistogram.record(2, FIRST_ATTRIBUTES);
+
+    output = prometheusMeterRegistry.scrape();
+    assertThat(output)
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"1.0\",} 1.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"2.0\",} 2.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"3.0\",} 2.0")
+        .contains(
+            "longHistogram_units_bucket{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",le=\"+Inf\",} 2.0")
+        .contains(
+            "longHistogram_units_count{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+        .contains(
+            "longHistogram_units_sum{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 3.0")
+        .contains(
+            "longHistogram_units_max{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
   }
 
   @Test
@@ -372,8 +839,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .buildWithCallback(
                 measurement -> {
-                  measurement.record(1.5, Attributes.of(KEY1, "value1"));
-                  measurement.record(2.5, Attributes.of(KEY1, "value2"));
+                  measurement.record(1.5, FIRST_ATTRIBUTES);
+                  measurement.record(2.5, SECOND_ATTRIBUTES);
                 })) {
 
       String output = scrapeFor("doubleGauge");
@@ -383,9 +850,36 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE doubleGauge_units gauge")
           .contains("# HELP doubleGauge_units DoubleGauge test")
           .contains(
-              "doubleGauge_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
+              "doubleGauge_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.5")
           .contains(
-              "doubleGauge_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+              "doubleGauge_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5");
+    }
+  }
+
+  @Test
+  void observableDoubleGaugeWithAttributesAdvice() {
+    DoubleGaugeBuilder builder =
+        meter.gaugeBuilder("doubleGauge").setDescription("DoubleGauge test").setUnit("units");
+
+    ((ExtendedDoubleGaugeBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableDoubleGauge observableDoubleGauge =
+        builder.buildWithCallback(
+            measurement -> {
+              measurement.record(1.5, FIRST_ATTRIBUTES);
+              measurement.record(2.5, SECOND_ATTRIBUTES);
+            })) {
+
+      String output = scrapeFor("doubleGauge");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE doubleGauge_units gauge")
+          .contains("# HELP doubleGauge_units DoubleGauge test")
+          .contains(
+              "doubleGauge_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.5")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 
@@ -399,8 +893,8 @@ public class PrometheusIntegrationTest {
             .setUnit("units")
             .buildWithCallback(
                 measurement -> {
-                  measurement.record(1, Attributes.of(KEY1, "value1"));
-                  measurement.record(2, Attributes.of(KEY1, "value2"));
+                  measurement.record(1, FIRST_ATTRIBUTES);
+                  measurement.record(2, SECOND_ATTRIBUTES);
                 })) {
 
       String output = scrapeFor("longGauge");
@@ -410,9 +904,36 @@ public class PrometheusIntegrationTest {
           .contains("# TYPE longGauge_units gauge")
           .contains("# HELP longGauge_units LongGauge test")
           .contains(
-              "longGauge_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
+              "longGauge_units{key1=\"value1\",key2=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 1.0")
           .contains(
-              "longGauge_units{key1=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+              "longGauge_units{key1=\"value1\",key2=\"value2\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0");
+    }
+  }
+
+  @Test
+  void observableLongGaugeWithAttributesAdvice() {
+    LongGaugeBuilder builder =
+        meter.gaugeBuilder("longGauge").ofLongs().setDescription("LongGauge test").setUnit("units");
+
+    ((ExtendedLongGaugeBuilder) builder).setAttributesAdvice(Collections.singletonList(KEY1));
+
+    try (ObservableLongGauge observableLongGauge =
+        builder.buildWithCallback(
+            measurement -> {
+              measurement.record(1, FIRST_ATTRIBUTES);
+              measurement.record(2, SECOND_ATTRIBUTES);
+            })) {
+
+      String output = scrapeFor("longGauge");
+      assertThat(output)
+          .contains("# HELP otel_polling_meter")
+          .contains("# TYPE otel_polling_meter untyped")
+          .contains("# TYPE longGauge_units gauge")
+          .contains("# HELP longGauge_units LongGauge test")
+          .contains(
+              "longGauge_units{key1=\"value1\",otel_instrumentation_name=\"integrationTest\",otel_instrumentation_version=\"1.0\",} 2.0")
+          .doesNotContain("key2=\"value1\"")
+          .doesNotContain("key2=\"value2\"");
     }
   }
 

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractCounter.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractCounter.java
@@ -35,7 +35,7 @@ abstract class AbstractCounter extends AbstractInstrument {
 
   protected final void setMonotonically(Attributes attributes, double value) {
     counterMap
-        .computeIfAbsent(attributesOrEmpty(attributes), this::createAsyncCounter)
+        .computeIfAbsent(effectiveAttributes(attributes), this::createAsyncCounter)
         .setMonotonically(value);
   }
 

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractCounter.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractCounter.java
@@ -27,7 +27,13 @@ abstract class AbstractCounter extends AbstractInstrument {
         .register(meterRegistry());
   }
 
-  protected final void record(double value, Attributes attributes) {
+  protected final void increment(Attributes attributes, double value) {
+    if (value >= 0.0) {
+      counter(attributes).increment(value);
+    }
+  }
+
+  protected final void setMonotonically(Attributes attributes, double value) {
     counterMap
         .computeIfAbsent(attributesOrEmpty(attributes), this::createAsyncCounter)
         .setMonotonically(value);

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractGauge.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractGauge.java
@@ -18,8 +18,8 @@ abstract class AbstractGauge extends AbstractInstrument {
     super(instrumentState);
   }
 
-  protected final void recordImpl(double value, Attributes attributes) {
-    gaugeMap.computeIfAbsent(attributesOrEmpty(attributes), this::createAsyncGauge).set(value);
+  protected final void record(Attributes attributes, double value) {
+    gaugeMap.computeIfAbsent(effectiveAttributes(attributes), this::createAsyncGauge).set(value);
   }
 
   private AtomicDoubleCounter createAsyncGauge(Attributes attributes) {

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractGauge.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractGauge.java
@@ -18,7 +18,7 @@ abstract class AbstractGauge extends AbstractInstrument {
     super(instrumentState);
   }
 
-  protected final void record(double value, Attributes attributes) {
+  protected final void recordImpl(double value, Attributes attributes) {
     gaugeMap.computeIfAbsent(attributesOrEmpty(attributes), this::createAsyncGauge).set(value);
   }
 

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
@@ -8,10 +8,15 @@ package io.opentelemetry.contrib.metrics.micrometer.internal.instruments;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.InstrumentState;
+import java.util.List;
+import javax.annotation.Nullable;
 
 abstract class AbstractHistogram extends AbstractInstrument {
+  @Nullable private final List<? extends Number> explicitBucketBoundaries;
+
   protected AbstractHistogram(InstrumentState instrumentState) {
     super(instrumentState);
+    this.explicitBucketBoundaries = instrumentState.explicitBucketBoundaries();
   }
 
   public DistributionSummary distribution(Attributes attributes) {
@@ -19,6 +24,19 @@ abstract class AbstractHistogram extends AbstractInstrument {
         .tags(attributesToTags(attributes))
         .description(description())
         .baseUnit(unit())
+        .sla(sla(explicitBucketBoundaries))
         .register(meterRegistry());
+  }
+
+  @Nullable
+  private static long[] sla(@Nullable List<? extends Number> explicitBucketBoundaries) {
+    if (explicitBucketBoundaries == null) {
+      return null;
+    }
+    long[] sla = new long[explicitBucketBoundaries.size()];
+    for (int i = 0; i < explicitBucketBoundaries.size(); i++) {
+      sla[i] = explicitBucketBoundaries.get(i).longValue();
+    }
+    return sla;
   }
 }

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
@@ -24,19 +24,26 @@ abstract class AbstractHistogram extends AbstractInstrument {
         .tags(attributesToTags(attributes))
         .description(description())
         .baseUnit(unit())
-        .sla(sla(explicitBucketBoundaries))
+        .serviceLevelObjectives(serviceLevelObjectives(explicitBucketBoundaries))
+        .publishPercentileHistogram(publishPercentileHistogram(explicitBucketBoundaries))
         .register(meterRegistry());
   }
 
   @Nullable
-  private static long[] sla(@Nullable List<? extends Number> explicitBucketBoundaries) {
+  private static double[] serviceLevelObjectives(
+      @Nullable List<? extends Number> explicitBucketBoundaries) {
     if (explicitBucketBoundaries == null) {
       return null;
     }
-    long[] sla = new long[explicitBucketBoundaries.size()];
+    double[] slos = new double[explicitBucketBoundaries.size()];
     for (int i = 0; i < explicitBucketBoundaries.size(); i++) {
-      sla[i] = explicitBucketBoundaries.get(i).longValue();
+      slos[i] = explicitBucketBoundaries.get(i).doubleValue();
     }
-    return sla;
+    return slos;
+  }
+
+  private static boolean publishPercentileHistogram(
+      @Nullable List<? extends Number> explicitBucketBoundaries) {
+    return explicitBucketBoundaries != null;
   }
 }

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractHistogram.java
@@ -16,7 +16,7 @@ abstract class AbstractHistogram extends AbstractInstrument {
 
   protected AbstractHistogram(InstrumentState instrumentState) {
     super(instrumentState);
-    this.explicitBucketBoundaries = instrumentState.explicitBucketBoundaries();
+    this.explicitBucketBoundaries = instrumentState.explicitBucketBoundariesAdvice();
   }
 
   public DistributionSummary distribution(Attributes attributes) {
@@ -25,7 +25,6 @@ abstract class AbstractHistogram extends AbstractInstrument {
         .description(description())
         .baseUnit(unit())
         .serviceLevelObjectives(serviceLevelObjectives(explicitBucketBoundaries))
-        .publishPercentileHistogram(publishPercentileHistogram(explicitBucketBoundaries))
         .register(meterRegistry());
   }
 
@@ -40,10 +39,5 @@ abstract class AbstractHistogram extends AbstractInstrument {
       slos[i] = explicitBucketBoundaries.get(i).doubleValue();
     }
     return slos;
-  }
-
-  private static boolean publishPercentileHistogram(
-      @Nullable List<? extends Number> explicitBucketBoundaries) {
-    return explicitBucketBoundaries != null;
   }
 }

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractInstrumentBuilder.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractInstrumentBuilder.java
@@ -6,8 +6,10 @@
 package io.opentelemetry.contrib.metrics.micrometer.internal.instruments;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.InstrumentState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import java.util.List;
 import javax.annotation.Nullable;
 
 abstract class AbstractInstrumentBuilder<BUILDER extends AbstractInstrumentBuilder<BUILDER>> {
@@ -15,21 +17,21 @@ abstract class AbstractInstrumentBuilder<BUILDER extends AbstractInstrumentBuild
   protected final String name;
   @Nullable protected String description;
   @Nullable protected String unit;
+  @Nullable protected List<AttributeKey<?>> attributes;
+  @Nullable protected List<? extends Number> explicitBucketBoundaries;
 
   protected AbstractInstrumentBuilder(MeterSharedState meterSharedState, String name) {
     this.meterSharedState = meterSharedState;
     this.name = name;
   }
 
-  protected AbstractInstrumentBuilder(
-      MeterSharedState meterSharedState,
-      String name,
-      @Nullable String description,
-      @Nullable String unit) {
-    this.meterSharedState = meterSharedState;
-    this.name = name;
-    this.description = description;
-    this.unit = unit;
+  protected AbstractInstrumentBuilder(AbstractInstrumentBuilder<?> parent) {
+    this.meterSharedState = parent.meterSharedState;
+    this.name = parent.name;
+    this.description = parent.description;
+    this.unit = parent.unit;
+    this.attributes = parent.attributes;
+    this.explicitBucketBoundaries = parent.explicitBucketBoundaries;
   }
 
   protected abstract BUILDER self();
@@ -46,7 +48,20 @@ abstract class AbstractInstrumentBuilder<BUILDER extends AbstractInstrumentBuild
     return self();
   }
 
+  @CanIgnoreReturnValue
+  public BUILDER setAttributesAdvice(List<AttributeKey<?>> attributes) {
+    this.attributes = attributes;
+    return self();
+  }
+
+  @CanIgnoreReturnValue
+  public BUILDER setExplicitBucketBoundaries(List<? extends Number> explicitBucketBoundaries) {
+    this.explicitBucketBoundaries = explicitBucketBoundaries;
+    return self();
+  }
+
   protected InstrumentState createInstrumentState() {
-    return new InstrumentState(meterSharedState, name, description, unit);
+    return new InstrumentState(
+        meterSharedState, name, description, unit, attributes, explicitBucketBoundaries);
   }
 }

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractUpDownCounter.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractUpDownCounter.java
@@ -19,11 +19,15 @@ abstract class AbstractUpDownCounter extends AbstractInstrument {
   }
 
   protected final void add(Attributes attributes, double value) {
-    counterMap.computeIfAbsent(attributesOrEmpty(attributes), this::createCounter).increment(value);
+    counter(attributes).increment(value);
   }
 
   protected final void record(Attributes attributes, double value) {
-    counterMap.computeIfAbsent(attributesOrEmpty(attributes), this::createCounter).set(value);
+    counter(attributes).set(value);
+  }
+
+  protected final AtomicDoubleCounter counter(Attributes attributes) {
+    return counterMap.computeIfAbsent(effectiveAttributes(attributes), this::createCounter);
   }
 
   private AtomicDoubleCounter createCounter(Attributes attributes) {

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractUpDownCounter.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/AbstractUpDownCounter.java
@@ -22,7 +22,7 @@ abstract class AbstractUpDownCounter extends AbstractInstrument {
     counterMap.computeIfAbsent(attributesOrEmpty(attributes), this::createCounter).increment(value);
   }
 
-  protected final void record(double value, Attributes attributes) {
+  protected final void record(Attributes attributes, double value) {
     counterMap.computeIfAbsent(attributesOrEmpty(attributes), this::createCounter).set(value);
   }
 

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGauge.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGauge.java
@@ -25,22 +25,22 @@ public final class MicrometerDoubleGauge extends AbstractGauge
 
   @Override
   public void set(double value) {
-    recordImpl(value, Attributes.empty());
+    record(Attributes.empty(), value);
   }
 
   @Override
   public void set(double value, Attributes attributes) {
-    recordImpl(value, attributes);
+    record(attributes, value);
   }
 
   @Override
   public void record(double value) {
-    recordImpl(value, Attributes.empty());
+    record(Attributes.empty(), value);
   }
 
   @Override
   public void record(double value, Attributes attributes) {
-    recordImpl(value, attributes);
+    record(attributes, value);
   }
 
   public static DoubleGaugeBuilder builder(MeterSharedState meterSharedState, String name) {

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogram.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogram.java
@@ -12,6 +12,8 @@ import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.InstrumentState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import java.util.List;
 
 public final class MicrometerDoubleHistogram extends AbstractHistogram implements DoubleHistogram {
 
@@ -38,10 +40,15 @@ public final class MicrometerDoubleHistogram extends AbstractHistogram implement
     return new Builder(meterSharedState, name);
   }
 
-  private static class Builder extends AbstractInstrumentBuilder<Builder>
-      implements DoubleHistogramBuilder {
+  static final class Builder extends AbstractInstrumentBuilder<Builder>
+      implements DoubleHistogramBuilder, ExtendedDoubleHistogramBuilder {
     private Builder(MeterSharedState meterSharedState, String name) {
       super(meterSharedState, name);
+    }
+
+    @Override
+    public DoubleHistogramBuilder setExplicitBucketBoundariesAdvice(List<Double> bucketBoundaries) {
+      return super.setExplicitBucketBoundaries(bucketBoundaries);
     }
 
     @Override
@@ -51,7 +58,7 @@ public final class MicrometerDoubleHistogram extends AbstractHistogram implement
 
     @Override
     public LongHistogramBuilder ofLongs() {
-      return MicrometerLongHistogram.builder(meterSharedState, name, description, unit);
+      return MicrometerLongHistogram.builder(this);
     }
 
     @Override

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGauge.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGauge.java
@@ -26,22 +26,22 @@ public final class MicrometerLongGauge extends AbstractGauge
 
   @Override
   public void set(long value) {
-    recordImpl((double) value, Attributes.empty());
+    record(Attributes.empty(), (double) value);
   }
 
   @Override
   public void set(long value, Attributes attributes) {
-    recordImpl((double) value, attributes);
+    record(attributes, (double) value);
   }
 
   @Override
   public void record(long value) {
-    recordImpl((double) value, Attributes.empty());
+    record(Attributes.empty(), (double) value);
   }
 
   @Override
   public void record(long value, Attributes attributes) {
-    recordImpl((double) value, attributes);
+    record(attributes, (double) value);
   }
 
   static final class Builder extends AbstractInstrumentBuilder<Builder>

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogram.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogram.java
@@ -10,8 +10,8 @@ import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.InstrumentState;
-import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
-import javax.annotation.Nullable;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongHistogramBuilder;
+import java.util.List;
 
 final class MicrometerLongHistogram extends AbstractHistogram implements LongHistogram {
 
@@ -34,22 +34,19 @@ final class MicrometerLongHistogram extends AbstractHistogram implements LongHis
     distribution(attributes).record((double) value);
   }
 
-  public static LongHistogramBuilder builder(
-      MeterSharedState meterSharedState,
-      String name,
-      @Nullable String description,
-      @Nullable String unit) {
-    return new Builder(meterSharedState, name, description, unit);
+  public static LongHistogramBuilder builder(MicrometerDoubleHistogram.Builder parent) {
+    return new Builder(parent);
   }
 
-  private static class Builder extends AbstractInstrumentBuilder<Builder>
-      implements LongHistogramBuilder {
-    private Builder(
-        MeterSharedState meterSharedState,
-        String name,
-        @Nullable String description,
-        @Nullable String unit) {
-      super(meterSharedState, name, description, unit);
+  static final class Builder extends AbstractInstrumentBuilder<Builder>
+      implements LongHistogramBuilder, ExtendedLongHistogramBuilder {
+    private Builder(MicrometerDoubleHistogram.Builder parent) {
+      super(parent);
+    }
+
+    @Override
+    public LongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
+      return super.setExplicitBucketBoundaries(bucketBoundaries);
     }
 
     @Override

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/state/InstrumentState.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/state/InstrumentState.java
@@ -7,7 +7,11 @@ package io.opentelemetry.contrib.metrics.micrometer.internal.state;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.contrib.metrics.micrometer.CallbackRegistration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -21,16 +25,26 @@ public final class InstrumentState {
   private final String name;
   @Nullable private final String description;
   @Nullable private final String unit;
+  @Nullable private final Set<AttributeKey<?>> attributes;
+  @Nullable private final List<? extends Number> explicitBucketBoundaries;
 
   public InstrumentState(
       MeterSharedState meterSharedState,
       String name,
       @Nullable String description,
-      @Nullable String unit) {
+      @Nullable String unit,
+      @Nullable List<AttributeKey<?>> attributes,
+      @Nullable List<? extends Number> explicitBucketBoundaries) {
     this.meterSharedState = meterSharedState;
     this.name = name;
     this.description = description;
     this.unit = unit;
+    if (attributes == null) {
+      this.attributes = null;
+    } else {
+      this.attributes = new HashSet<>(attributes);
+    }
+    this.explicitBucketBoundaries = explicitBucketBoundaries;
   }
 
   public MeterRegistry meterRegistry() {
@@ -61,5 +75,15 @@ public final class InstrumentState {
   @Nullable
   public String unit() {
     return unit;
+  }
+
+  @Nullable
+  public Set<AttributeKey<?>> attributes() {
+    return attributes;
+  }
+
+  @Nullable
+  public List<? extends Number> explicitBucketBoundaries() {
+    return explicitBucketBoundaries;
   }
 }

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/state/InstrumentState.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/internal/state/InstrumentState.java
@@ -9,9 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.contrib.metrics.micrometer.CallbackRegistration;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -25,7 +23,7 @@ public final class InstrumentState {
   private final String name;
   @Nullable private final String description;
   @Nullable private final String unit;
-  @Nullable private final Set<AttributeKey<?>> attributes;
+  @Nullable private final List<AttributeKey<?>> attributes;
   @Nullable private final List<? extends Number> explicitBucketBoundaries;
 
   public InstrumentState(
@@ -39,11 +37,7 @@ public final class InstrumentState {
     this.name = name;
     this.description = description;
     this.unit = unit;
-    if (attributes == null) {
-      this.attributes = null;
-    } else {
-      this.attributes = new HashSet<>(attributes);
-    }
+    this.attributes = attributes;
     this.explicitBucketBoundaries = explicitBucketBoundaries;
   }
 
@@ -78,12 +72,12 @@ public final class InstrumentState {
   }
 
   @Nullable
-  public Set<AttributeKey<?>> attributes() {
+  public List<AttributeKey<?>> attributesAdvice() {
     return attributes;
   }
 
   @Nullable
-  public List<? extends Number> explicitBucketBoundaries() {
+  public List<? extends Number> explicitBucketBoundariesAdvice() {
     return explicitBucketBoundaries;
   }
 }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleCounterTest.java
@@ -12,15 +12,19 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleCounter;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
 import io.opentelemetry.api.metrics.ObservableDoubleCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleCounterBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -175,6 +179,59 @@ public class MicrometerDoubleCounterTest {
   }
 
   @Test
+  void addWithAttributesAndAdvice() {
+    DoubleCounterBuilder builder =
+        MicrometerLongCounter.builder(meterSharedState, "counter")
+            .ofDoubles()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    DoubleCounter underTest = builder.build();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    underTest.add(10.0, attributes);
+
+    Counter counter = meterRegistry.find("counter").counter();
+    assertThat(counter).isNotNull();
+    Meter.Id id = counter.getId();
+    assertThat(id.getName()).isEqualTo("counter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(counter.count()).isEqualTo(10.0);
+
+    // test that counter can be increased
+    underTest.add(10.0, attributes);
+    assertThat(counter.count()).isEqualTo(20.0);
+
+    // test that counter cannot be decreased
+    underTest.add(-5.0, attributes);
+    assertThat(counter.count()).isEqualTo(20.0);
+
+    double expectedCount = 20.0;
+    for (double value : RandomUtils.randomDoubles(10, 0.0, 10.0)) {
+      expectedCount += value;
+
+      underTest.add(value, attributes);
+      assertThat(counter.count()).isEqualTo(expectedCount);
+    }
+  }
+
+  @Test
   void observable() {
     AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
     ObservableDoubleCounter underTest =
@@ -237,6 +294,71 @@ public class MicrometerDoubleCounterTest {
             .setUnit("unit")
             .buildWithCallback(
                 measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
+
+    assertThat(callbacks).hasSize(1);
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    atomicDoubleCounter.set(10.0);
+    callbackRegistrar.run();
+    FunctionCounter counter = meterRegistry.find("counter").functionCounter();
+    assertThat(counter).isNotNull();
+    Meter.Id id = counter.getId();
+    assertThat(id.getName()).isEqualTo("counter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(counter.count()).isEqualTo(10.0);
+
+    // test that counter can be increased
+    atomicDoubleCounter.set(20.0);
+    callbackRegistrar.run();
+    assertThat(counter.count()).isEqualTo(20.0);
+
+    // test that counter cannot be decreased
+    atomicDoubleCounter.set(5.0);
+    callbackRegistrar.run();
+    assertThat(counter.count()).isEqualTo(20.0);
+
+    double expectedCount = 10.0;
+    for (double value : RandomUtils.randomDoubles(10, 0.0, 500.0)) {
+      expectedCount += value;
+
+      atomicDoubleCounter.set(expectedCount);
+      callbackRegistrar.run();
+      assertThat(counter.count()).isEqualTo(expectedCount);
+    }
+
+    underTest.close();
+
+    assertThat(callbacks).isEmpty();
+  }
+
+  @Test
+  void observableWithAttributesAndAdvice() {
+    DoubleCounterBuilder builder =
+        MicrometerLongCounter.builder(meterSharedState, "counter")
+            .ofDoubles()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    ObservableDoubleCounter underTest =
+        builder.buildWithCallback(
+            measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
 
     assertThat(callbacks).hasSize(1);
 

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleCounterTest.java
@@ -179,7 +179,7 @@ public class MicrometerDoubleCounterTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
     DoubleCounterBuilder builder =
         MicrometerLongCounter.builder(meterSharedState, "counter")
             .ofDoubles()
@@ -339,7 +339,7 @@ public class MicrometerDoubleCounterTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     DoubleCounterBuilder builder =
         MicrometerLongCounter.builder(meterSharedState, "counter")
             .ofDoubles()

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGaugeTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGaugeTest.java
@@ -123,7 +123,7 @@ public class MicrometerDoubleGaugeTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
     Attributes attributes =
         Attributes.builder().put("key", "value").put("unwanted", "value").build();

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGaugeTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleGaugeTest.java
@@ -11,13 +11,17 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleGaugeBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +93,55 @@ public class MicrometerDoubleGaugeTest {
             .setUnit("unit")
             .buildWithCallback(
                 measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
+
+    assertThat(callbacks).hasSize(1);
+
+    atomicDoubleCounter.set(10.0);
+    callbackRegistrar.run();
+    Gauge gauge = meterRegistry.find("gauge").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("gauge");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    for (double value : RandomUtils.randomDoubles(10, 0.0, 500.0)) {
+      atomicDoubleCounter.set(value);
+      callbackRegistrar.run();
+      assertThat(gauge.value()).isEqualTo(value);
+    }
+
+    underTest.close();
+
+    assertThat(callbacks).isEmpty();
+  }
+
+  @Test
+  void observableWithAttributesAndAdvice() {
+    AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    DoubleGaugeBuilder builder =
+        MicrometerDoubleGauge.builder(meterSharedState, "gauge")
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleGaugeBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    ObservableDoubleGauge underTest =
+        builder.buildWithCallback(
+            measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
 
     assertThat(callbacks).hasSize(1);
 

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
@@ -160,7 +160,7 @@ public class MicrometerDoubleHistogramTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
 
     DoubleHistogramBuilder builder =
         MicrometerDoubleHistogram.builder(meterSharedState, "histogram")

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
@@ -11,13 +11,17 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleHistogramBuilder;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,6 +152,55 @@ public class MicrometerDoubleHistogramTest {
       expectedTotal += value;
 
       underTest.record(value, attributes, Context.root());
+      assertThat(summary.count()).isEqualTo(expectedCount);
+      assertThat(summary.totalAmount()).isEqualTo(expectedTotal);
+    }
+  }
+
+  @Test
+  void addWithAttributesAndAdvice() {
+
+    DoubleHistogramBuilder builder =
+        MicrometerDoubleHistogram.builder(meterSharedState, "histogram")
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleHistogramBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    DoubleHistogram underTest = builder.build();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    underTest.record(10.0, attributes);
+
+    DistributionSummary summary = meterRegistry.find("histogram").summary();
+    assertThat(summary).isNotNull();
+    Meter.Id id = summary.getId();
+    assertThat(id.getName()).isEqualTo("histogram");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(summary.count()).isEqualTo(1);
+    assertThat(summary.totalAmount()).isEqualTo(10.0);
+
+    long expectedCount = 1;
+    double expectedTotal = 10.0;
+    for (double value : RandomUtils.randomDoubles(10, 0.0, 10.0)) {
+      expectedCount += 1;
+      expectedTotal += value;
+
+      underTest.record(value, attributes);
       assertThat(summary.count()).isEqualTo(expectedCount);
       assertThat(summary.totalAmount()).isEqualTo(expectedTotal);
     }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleHistogramTest.java
@@ -240,9 +240,6 @@ public class MicrometerDoubleHistogramTest {
     assertThat(counts)
         .hasSize(3)
         .containsExactly(
-            new CountAtBucket(10.0, 1),
-            new CountAtBucket(20.0, 2),
-            new CountAtBucket(30.0, 3)
-        );
+            new CountAtBucket(10.0, 1), new CountAtBucket(20.0, 2), new CountAtBucket(30.0, 3));
   }
 }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleUpDownCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleUpDownCounterTest.java
@@ -163,7 +163,7 @@ public class MicrometerDoubleUpDownCounterTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
     DoubleUpDownCounterBuilder builder =
         MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
             .ofDoubles()
@@ -300,7 +300,7 @@ public class MicrometerDoubleUpDownCounterTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     DoubleUpDownCounterBuilder builder =
         MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
             .ofDoubles()

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleUpDownCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerDoubleUpDownCounterTest.java
@@ -11,15 +11,19 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.ObservableDoubleUpDownCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedDoubleUpDownCounterBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -159,6 +163,54 @@ public class MicrometerDoubleUpDownCounterTest {
   }
 
   @Test
+  void addWithAttributesAndAdvice() {
+    DoubleUpDownCounterBuilder builder =
+        MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
+            .ofDoubles()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleUpDownCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    DoubleUpDownCounter underTest = builder.build();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    underTest.add(10.0, attributes);
+
+    Gauge gauge = meterRegistry.find("upDownCounter").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("upDownCounter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    underTest.add(-10.0, attributes);
+    assertThat(gauge.value()).isEqualTo(0.0);
+
+    double expectedCount = 0.0;
+    for (double value : RandomUtils.randomDoubles(10, -500.0, 500.0)) {
+      expectedCount += value;
+
+      underTest.add(value, attributes);
+      assertThat(gauge.value()).isEqualTo(expectedCount);
+    }
+  }
+
+  @Test
   void observable() {
     AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
     ObservableDoubleUpDownCounter underTest =
@@ -212,6 +264,62 @@ public class MicrometerDoubleUpDownCounterTest {
             .setUnit("unit")
             .buildWithCallback(
                 measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
+
+    assertThat(callbacks).hasSize(1);
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    atomicDoubleCounter.set(10.0);
+    callbackRegistrar.run();
+    Gauge gauge = meterRegistry.find("upDownCounter").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("upDownCounter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    atomicDoubleCounter.set(0.0);
+    callbackRegistrar.run();
+    assertThat(gauge.value()).isEqualTo(0.0);
+
+    for (double value : RandomUtils.randomDoubles(10, -500.0, 500.0)) {
+      atomicDoubleCounter.set(value);
+      callbackRegistrar.run();
+      assertThat(gauge.value()).isEqualTo(value);
+    }
+
+    underTest.close();
+
+    assertThat(callbacks).isEmpty();
+  }
+
+  @Test
+  void observableWithAttributesAndAdvice() {
+    DoubleUpDownCounterBuilder builder =
+        MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
+            .ofDoubles()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedDoubleUpDownCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    AtomicDoubleCounter atomicDoubleCounter = new AtomicDoubleCounter();
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    ObservableDoubleUpDownCounter underTest =
+        builder.buildWithCallback(
+            measurement -> measurement.record(atomicDoubleCounter.current(), attributes));
 
     assertThat(callbacks).hasSize(1);
 

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongCounterTest.java
@@ -180,7 +180,7 @@ public class MicrometerLongCounterTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
     LongCounterBuilder builder =
         MicrometerLongCounter.builder(meterSharedState, "counter")
             .setDescription("description")
@@ -335,7 +335,7 @@ public class MicrometerLongCounterTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     LongCounterBuilder builder =
         MicrometerLongCounter.builder(meterSharedState, "counter")
             .setDescription("description")

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGaugeTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGaugeTest.java
@@ -11,13 +11,17 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongGaugeBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,6 +94,55 @@ public class MicrometerLongGaugeTest {
             .setDescription("description")
             .setUnit("unit")
             .buildWithCallback(measurement -> measurement.record(atomicLong.get(), attributes));
+
+    assertThat(callbacks).hasSize(1);
+
+    atomicLong.set(10L);
+    callbackRegistrar.run();
+    Gauge gauge = meterRegistry.find("gauge").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("gauge");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    for (long value : RandomUtils.randomLongs(10, -500L, 500L)) {
+      atomicLong.set(value);
+      callbackRegistrar.run();
+      assertThat(gauge.value()).isEqualTo((double) value);
+    }
+
+    underTest.close();
+
+    assertThat(callbacks).isEmpty();
+  }
+
+  @Test
+  void observableWithAttributesAndAdvice() {
+    LongGaugeBuilder builder =
+        MicrometerDoubleGauge.builder(meterSharedState, "gauge")
+            .ofLongs()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedLongGaugeBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    AtomicLong atomicLong = new AtomicLong();
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    ObservableLongGauge underTest =
+        builder.buildWithCallback(measurement -> measurement.record(atomicLong.get(), attributes));
 
     assertThat(callbacks).hasSize(1);
 

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGaugeTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongGaugeTest.java
@@ -124,7 +124,7 @@ public class MicrometerLongGaugeTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     LongGaugeBuilder builder =
         MicrometerDoubleGauge.builder(meterSharedState, "gauge")
             .ofLongs()

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
@@ -163,7 +163,7 @@ public class MicrometerLongHistogramTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
     LongHistogramBuilder builder =
         MicrometerDoubleHistogram.builder(meterSharedState, "histogram")
             .ofLongs()

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
@@ -11,13 +11,17 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongHistogramBuilder;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,6 +155,55 @@ public class MicrometerLongHistogramTest {
       expectedTotal += value;
 
       underTest.record(value, attributes, Context.root());
+      assertThat(summary.count()).isEqualTo(expectedCount);
+      assertThat(summary.totalAmount()).isEqualTo(expectedTotal);
+    }
+  }
+
+  @Test
+  void addWithAttributesAndAdvice() {
+    LongHistogramBuilder builder =
+        MicrometerDoubleHistogram.builder(meterSharedState, "histogram")
+            .ofLongs()
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedLongHistogramBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    LongHistogram underTest = builder.build();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    underTest.record(10, attributes);
+
+    DistributionSummary summary = meterRegistry.find("histogram").summary();
+    assertThat(summary).isNotNull();
+    Meter.Id id = summary.getId();
+    assertThat(id.getName()).isEqualTo("histogram");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(summary.count()).isEqualTo(1);
+    assertThat(summary.totalAmount()).isEqualTo(10.0);
+
+    long expectedCount = 1;
+    double expectedTotal = 10.0;
+    for (long value : RandomUtils.randomLongs(10, 0L, 10L)) {
+      expectedCount += 1;
+      expectedTotal += value;
+
+      underTest.record(value, attributes);
       assertThat(summary.count()).isEqualTo(expectedCount);
       assertThat(summary.totalAmount()).isEqualTo(expectedTotal);
     }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
@@ -244,9 +244,6 @@ public class MicrometerLongHistogramTest {
     assertThat(counts)
         .hasSize(3)
         .containsExactly(
-            new CountAtBucket(10.0, 1),
-            new CountAtBucket(20.0, 2),
-            new CountAtBucket(30.0, 3)
-        );
+            new CountAtBucket(10.0, 1), new CountAtBucket(20.0, 2), new CountAtBucket(30.0, 3));
   }
 }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongHistogramTest.java
@@ -10,6 +10,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -207,5 +209,44 @@ public class MicrometerLongHistogramTest {
       assertThat(summary.count()).isEqualTo(expectedCount);
       assertThat(summary.totalAmount()).isEqualTo(expectedTotal);
     }
+  }
+
+  @Test
+  void addWithExplicitBucketBoundaries() {
+    LongHistogram underTest =
+        MicrometerDoubleHistogram.builder(meterSharedState, "histogram")
+            .ofLongs()
+            .setDescription("description")
+            .setUnit("unit")
+            .setExplicitBucketBoundariesAdvice(Arrays.asList(10L, 20L, 30L))
+            .build();
+
+    underTest.record(5L);
+    underTest.record(15L);
+    underTest.record(25L);
+    underTest.record(35L);
+
+    DistributionSummary summary = meterRegistry.find("histogram").summary();
+    assertThat(summary).isNotNull();
+    Meter.Id id = summary.getId();
+    assertThat(id.getName()).isEqualTo("histogram");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(summary.count()).isEqualTo(4);
+    assertThat(summary.totalAmount()).isEqualTo(80.0);
+
+    HistogramSnapshot snapshot = summary.takeSnapshot();
+    CountAtBucket[] counts = snapshot.histogramCounts();
+    assertThat(counts)
+        .hasSize(3)
+        .containsExactly(
+            new CountAtBucket(10.0, 1),
+            new CountAtBucket(20.0, 2),
+            new CountAtBucket(30.0, 3)
+        );
   }
 }

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongUpDownCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongUpDownCounterTest.java
@@ -176,7 +176,7 @@ public class MicrometerLongUpDownCounterTest {
   }
 
   @Test
-  void addWithAttributesAndAdvice() {
+  void addWithAttributesAndAttributesAdvice() {
     LongUpDownCounterBuilder builder =
         MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
             .setDescription("description")
@@ -326,7 +326,7 @@ public class MicrometerLongUpDownCounterTest {
   }
 
   @Test
-  void observableWithAttributesAndAdvice() {
+  void observableWithAttributesAndAttributesAdvice() {
     LongUpDownCounterBuilder builder =
         MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
             .setDescription("description")

--- a/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongUpDownCounterTest.java
+++ b/micrometer-meter-provider/src/test/java/io/opentelemetry/contrib/metrics/micrometer/internal/instruments/MicrometerLongUpDownCounterTest.java
@@ -11,15 +11,19 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.metrics.micrometer.TestCallbackRegistrar;
 import io.opentelemetry.contrib.metrics.micrometer.internal.Constants;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterProviderSharedState;
 import io.opentelemetry.contrib.metrics.micrometer.internal.state.MeterSharedState;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongUpDownCounterBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -172,6 +176,58 @@ public class MicrometerLongUpDownCounterTest {
   }
 
   @Test
+  void addWithAttributesAndAdvice() {
+    LongUpDownCounterBuilder builder =
+        MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedLongUpDownCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    LongUpDownCounter underTest = builder.build();
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    underTest.add(10, attributes);
+
+    Gauge gauge = meterRegistry.find("upDownCounter").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("upDownCounter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    // test that counter can be increased
+    underTest.add(10, attributes);
+    assertThat(gauge.value()).isEqualTo(20.0);
+
+    // test that counter can be decreased
+    underTest.add(-5, attributes);
+    assertThat(gauge.value()).isEqualTo(15.0);
+
+    double expectedCount = 15.0;
+    for (long value : RandomUtils.randomLongs(10, -500L, 500L)) {
+      expectedCount += value;
+
+      underTest.add(value, attributes);
+      assertThat(gauge.value()).isEqualTo(expectedCount);
+    }
+  }
+
+  @Test
   void observable() {
     AtomicLong atomicLong = new AtomicLong();
     ObservableLongUpDownCounter underTest =
@@ -228,6 +284,66 @@ public class MicrometerLongUpDownCounterTest {
             .setDescription("description")
             .setUnit("unit")
             .buildWithCallback(measurement -> measurement.record(atomicLong.get(), attributes));
+
+    assertThat(callbacks).hasSize(1);
+
+    assertThat(meterRegistry.getMeters()).isEmpty();
+
+    atomicLong.set(10L);
+    callbackRegistrar.run();
+    Gauge gauge = meterRegistry.find("upDownCounter").gauge();
+    assertThat(gauge).isNotNull();
+    Meter.Id id = gauge.getId();
+    assertThat(id.getName()).isEqualTo("upDownCounter");
+    assertThat(id.getTags())
+        .containsExactlyInAnyOrder(
+            Tag.of("key", "value"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_NAME, "meter"),
+            Tag.of(Constants.OTEL_INSTRUMENTATION_VERSION, "1.0"));
+    assertThat(id.getDescription()).isEqualTo("description");
+    assertThat(id.getBaseUnit()).isEqualTo("unit");
+    assertThat(gauge.value()).isEqualTo(10.0);
+
+    // test that counter can be increased
+    atomicLong.set(20L);
+    callbackRegistrar.run();
+    assertThat(gauge.value()).isEqualTo(20.0);
+
+    // test that counter can be decreased
+    atomicLong.set(15L);
+    callbackRegistrar.run();
+    assertThat(gauge.value()).isEqualTo(15.0);
+
+    for (long value : RandomUtils.randomLongs(10, 0L, 500L)) {
+      atomicLong.set(value);
+      callbackRegistrar.run();
+      assertThat(gauge.value()).isEqualTo((double) value);
+    }
+
+    underTest.close();
+
+    assertThat(callbacks).isEmpty();
+  }
+
+  @Test
+  void observableWithAttributesAndAdvice() {
+    LongUpDownCounterBuilder builder =
+        MicrometerLongUpDownCounter.builder(meterSharedState, "upDownCounter")
+            .setDescription("description")
+            .setUnit("unit");
+
+    ((ExtendedLongUpDownCounterBuilder) builder)
+        .setAttributesAdvice(
+            Arrays.asList(
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_NAME),
+                AttributeKey.stringKey(Constants.OTEL_INSTRUMENTATION_VERSION),
+                AttributeKey.stringKey("key")));
+
+    AtomicLong atomicLong = new AtomicLong();
+    Attributes attributes =
+        Attributes.builder().put("key", "value").put("unwanted", "value").build();
+    ObservableLongUpDownCounter underTest =
+        builder.buildWithCallback(measurement -> measurement.record(atomicLong.get(), attributes));
 
     assertThat(callbacks).hasSize(1);
 


### PR DESCRIPTION
**Description:**

Feature addition - Adds support for OTel Metrics APIs to support explicit bucket boundaries advice which is translated as service level objectives in Micrometer distribution summaries.

Feature addition - Adds support for OTel Metrics incubator API to support advice to filter the attributes used as metrics dimensions.  This is necessary to be used with OTel Instrumentation which relies on attributes advice to filter out high-cardinality attributes.

**Existing Issue(s):**

N/A

**Testing:**

Unit testing complete.  Integration tests TBD.

**Documentation:**

TBD

**Outstanding items:**

Need to add documentation.
