### PR TITLE
Update GCP resource detector info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ feature or via instrumentation, this project is hopefully for you.
 * [zstd Compressor](./compressors/compressor-zstd/README.md)
 * [Consistent Sampling](./consistent-sampling/README.md)
 * [Disk Buffering](./disk-buffering/README.md)
+* [GCP Resources](./gcp-resources/README.md)
 * [JMX Metric Gatherer](./jmx-metrics/README.md)
 * [No-Op API](./noop-api/README.md)
 * [OpenTelemetry Maven Extension](./maven-extension/README.md)

--- a/gcp-resources/README.md
+++ b/gcp-resources/README.md
@@ -49,6 +49,12 @@ spec:
 Additionally, the container name will only be discovered via the environment variable `CONTAINER_NAME`
 which much be included in the environment.
 
+## Usage with Auto-Instrumentation
+
+With the release of [v2.2.0 of the OpenTelemetry Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.2.0), the GCP resource detector is now included with the Java agent.
+
+For users of Java Agent v2.2.0 and later, the GCP resource detectors can be enabled by following the instructions provided [here](https://opentelemetry.io/docs/languages/java/automatic/configuration/#enable-resource-providers-that-are-disabled-by-default).
+
 ## Component Owners
 
 - [Josh Suereth](https://github.com/jsuereth), Google


### PR DESCRIPTION
**Description:**

Contains documentation changes regarding the GCP resource detector.

**Testing:**
 - `./gradlew assemble`

**Documentation:**

 - Adds GCP Resource Detector to the list of provided libraries
 - Updates GCP Resource Detector Readme with the instructions to enable it when using with Java auto agent.
