### PR TITLE
migrate gradle/gradle-build-action to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 17
 
       - name: Build
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: build -x test
           cache-read-only: ${{ github.event_name == 'pull_request' }}
@@ -61,7 +61,7 @@ jobs:
           java-version: 17
 
       - name: Build
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: >
             test
@@ -84,7 +84,7 @@ jobs:
           java-version: 17
 
       - name: Integration test
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: integrationTest
           cache-read-only: ${{ github.event_name == 'pull_request' }}
@@ -136,7 +136,7 @@ jobs:
           java-version: 17
 
       - name: Build and publish snapshots
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         # skipping release branches because the versions in those branches are not snapshots
         # (also this skips pull requests)
         if: ${{ github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java-contrib' }}

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -27,7 +27,7 @@ jobs:
           # see https://github.com/github/codeql-action/issues/1555#issuecomment-1452228433
           tools: latest
 
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
           # skipping build cache is needed so that all modules will be analyzed
           arguments: assemble --no-build-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         name: Build
         with:
           arguments: build
@@ -37,7 +37,7 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         name: Integration test
         with:
           arguments: integrationTest
@@ -119,7 +119,7 @@ jobs:
           java-version: 17
 
       - name: Build and publish artifacts
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assemble publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:


### PR DESCRIPTION
**Description:**

See <https://github.com/gradle/gradle-build-action/blob/main/README.md>:

> As of `v3` this action has been superceded by `gradle/actions/setup-gradle`.
> Any workflow that uses `gradle/gradle-build-action@v3` will transparently delegate to `gradle/actions/setup-gradle@v3`.
>
> Users are encouraged to update their workflows, replacing:
> ```
> uses: gradle/gradle-build-action@v3
> ```
>
> with
> ```
> uses: gradle/actions/setup-gradle@v3
> ```
>
> See the [setup-gradle documentation](https://github.com/gradle/actions/tree/main/setup-gradle) for up-to-date documentation for `gradle/actions/setup-gradle`.

**Existing Issue(s):**

< Link any applicable issues. >

**Testing:**

< Describe what testing was performed and any tests were added. >

**Documentation:**

< Describe the documentation added.
  Please be sure to modify relevant existing documentation if needed. >

**Outstanding items:**

< Anything that these changes are intentionally missing
  that will be needed or can be helpful in the future. >
