### PR TITLE
In Tomcat Version 10.1.19 Spring Boot 3.2.4 Tomcat Bean Name Is Tomca…

### DIFF
--- a/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
@@ -42,3 +42,29 @@ otel.instrument(beantomcatconnectors, "tomcat.threads", "The number of threads",
   ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
   ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)
 
+def beantomcatnewmanager = otel.mbean("Tomcat:type=Manager,host=localhost,context=*")
+otel.instrument(beantomcatnewmanager, "tomcat.sessions", "The number of active sessions.", "sessions", "activeSessions", otel.&doubleValueCallback)
+
+def beantomcatnewrequestProcessor = otel.mbean("Tomcat:type=GlobalRequestProcessor,name=*")
+otel.instrument(beantomcatnewrequestProcessor, "tomcat.errors", "The number of errors encountered.", "errors",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
+    "errorCount", otel.&longCounterCallback)
+otel.instrument(beantomcatnewrequestProcessor, "tomcat.request_count", "The total requests.", "requests",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
+    "requestCount", otel.&longCounterCallback)
+otel.instrument(beantomcatnewrequestProcessor, "tomcat.max_time", "Maximum time to process a request.", "ms",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
+    "maxTime", otel.&longValueCallback)
+otel.instrument(beantomcatnewrequestProcessor, "tomcat.processing_time", "The total processing time.", "ms",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
+    "processingTime", otel.&longCounterCallback)
+otel.instrument(beantomcatnewrequestProcessor, "tomcat.traffic",
+    "The number of bytes transmitted and received.", "by",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name")}],
+    ["bytesReceived":["direction" : {"received"}], "bytesSent": ["direction" : {"sent"}]],
+    otel.&longCounterCallback)
+
+def beantomcatnewconnectors = otel.mbean("Tomcat:type=ThreadPool,name=*")
+otel.instrument(beantomcatnewconnectors, "tomcat.threads", "The number of threads", "threads",
+    ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
+    ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)


### PR DESCRIPTION
…t And Not Catalina

**Description:**
Not getting metrics for Tomcat Version 10.1.19 Spring Boot 3.2.4.
```
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"Apr 12, 2024 1:33:00 PM org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite doInvoke","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"WARNING: Failed to fetch MBean Catalina:type=Manager,host=localhost,context=*.","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"Apr 12, 2024 1:33:00 PM java_util_logging_Logger$warning$0 call","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"WARNING: No active MBeans.  Be sure to fetch() before updating any applicable instruments.","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"Apr 12, 2024 1:33:00 PM org.codehaus.groovy.runtime.callsite.PlainObjectMetaMethodSite doInvoke","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"WARNING: Failed to fetch MBean Catalina:type=GlobalRequestProcessor,name=*.","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"Apr 12, 2024 1:33:00 PM java_util_logging_Logger$warning$0 call","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"WARNING: No active MBeans.  Be sure to fetch() before updating any applicable instruments.","kind":"receiver","name":"jmx/0","data_type":"metrics"}
2024-04-12T13:33:00Z D! {"caller":"subprocess/subprocess.go:280","msg":"WARNING: Failed to fetch MBean Catalina:type=ThreadPool,name=*.","kind":"receiver","name":"jmx/0","data_type":"metrics"}
```

```
[ec2-user@ip-172-31-57-2 ~]$ sudo java --add-exports jdk.jconsole/sun.tools.jconsole=ALL-UNNAMED -jar jmxterm-1.0.2-uber.jar -v verbose
Delete /root/.jmxterm_history if you encounter error right after launching me.
Welcome to JMX terminal. Type "help" for available commands.
$>open 495425
#Connection to 495425 is opened
$>beans
#domain = JMImplementation:
JMImplementation:type=MBeanServerDelegate
#domain = Tomcat:
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Filter,name=Tomcat WebSocket (JSR356) Filter
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Filter,name=characterEncodingFilter
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Filter,name=formContentFilter
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Filter,name=requestContextFilter
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Filter,name=webMvcObservationFilter
Tomcat:J2EEApplication=none,J2EEServer=none,WebModule=//localhost/,j2eeType=Servlet,name=dispatcherServlet
Tomcat:J2EEApplication=none,J2EEServer=none,j2eeType=WebModule,name=//localhost/
Tomcat:context=/,host=localhost,name=Cache,type=WebResourceRoot
Tomcat:context=/,host=localhost,name=NonLoginAuthenticator,type=Valve
Tomcat:context=/,host=localhost,name=StandardContextValve,type=Valve
Tomcat:context=/,host=localhost,type=Loader
Tomcat:context=/,host=localhost,type=Manager
Tomcat:context=/,host=localhost,type=NamingResources
Tomcat:context=/,host=localhost,type=TomcatEmbeddedWebappClassLoader
Tomcat:context=/,host=localhost,type=WebResourceRoot
Tomcat:host=localhost,name=ErrorReportValve,type=Valve
Tomcat:host=localhost,name=StandardHostValve,type=Valve
Tomcat:host=localhost,type=Host
Tomcat:name="http-nio-8090",type=GlobalRequestProcessor
Tomcat:name="http-nio-8090",type=SocketProperties
Tomcat:name="http-nio-8090",type=ThreadPool
Tomcat:name=StandardEngineValve,type=Valve
Tomcat:port=8090,type=Connector
Tomcat:port=8090,type=ProtocolHandler
Tomcat:realmPath=/realm0,type=Realm
Tomcat:type=Engine
Tomcat:type=MBeanFactory
Tomcat:type=Mapper
Tomcat:type=NamingResources
Tomcat:type=Server
Tomcat:type=Service
Tomcat:type=StringCache
Tomcat:type=UtilityExecutor
```

**Existing Issue(s):**
#1270

**Testing:**
Build jar. Create hacked collector version that does not check hash and version number of jar. Start Collector and see metrics in CW. 
<img width="1728" alt="Screenshot 2024-04-12 at 9 45 59 AM" src="https://github.com/open-telemetry/opentelemetry-java-contrib/assets/81644108/9de4eb51-0180-463e-894e-3968129a589f">

**Documentation:**
N/A

**Outstanding items:**
