### PR TITLE
Disable by default metrics and logs

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/OpenTelemetrySdkService.java
@@ -53,7 +53,8 @@ public final class OpenTelemetrySdkService implements Initializable, Disposable 
       if (sdkProviderShutdown.isSuccess()) {
         logger.debug("OpenTelemetry: SDK Trace Provider shut down");
       } else {
-        logger.warn("OpenTelemetry: Failure to shutdown SDK Trace Provider (done: {})",
+        logger.warn(
+            "OpenTelemetry: Failure to shutdown SDK Trace Provider (done: {})",
             sdkProviderShutdown.isDone());
       }
       this.openTelemetrySdk = null;


### PR DESCRIPTION
**Description:**

Disable by default metrics and logs as there are now enabled by default.

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1227

**Testing:**

There is unfortunately no testing framework for Maven extensions.

**Documentation:**

TODO, verification in progress

**Outstanding items:**

None
