### PR TITLE
Assume random trace ID and set th-field only for sampled spans

### DIFF
--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
@@ -10,8 +10,12 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 final class ConsistentAlwaysOffSampler extends ConsistentSampler {
 
-  ConsistentAlwaysOffSampler(RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  private static final ConsistentAlwaysOffSampler INSTANCE = new ConsistentAlwaysOffSampler();
+
+  private ConsistentAlwaysOffSampler() {}
+
+  static ConsistentAlwaysOffSampler getInstance() {
+    return INSTANCE;
   }
 
   @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOnSampler.java
@@ -12,8 +12,12 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 final class ConsistentAlwaysOnSampler extends ConsistentSampler {
 
-  ConsistentAlwaysOnSampler(RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  private static final ConsistentAlwaysOnSampler INSTANCE = new ConsistentAlwaysOnSampler();
+
+  private ConsistentAlwaysOnSampler() {}
+
+  static ConsistentAlwaysOnSampler getInstance() {
+    return INSTANCE;
   }
 
   @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedAndSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedAndSampler.java
@@ -21,11 +21,7 @@ final class ConsistentComposedAndSampler extends ConsistentSampler {
   private final ConsistentSampler sampler2;
   private final String description;
 
-  ConsistentComposedAndSampler(
-      ConsistentSampler sampler1,
-      ConsistentSampler sampler2,
-      RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  ConsistentComposedAndSampler(ConsistentSampler sampler1, ConsistentSampler sampler2) {
     this.sampler1 = requireNonNull(sampler1);
     this.sampler2 = requireNonNull(sampler2);
     this.description =

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedOrSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentComposedOrSampler.java
@@ -21,11 +21,7 @@ final class ConsistentComposedOrSampler extends ConsistentSampler {
   private final ConsistentSampler sampler2;
   private final String description;
 
-  ConsistentComposedOrSampler(
-      ConsistentSampler sampler1,
-      ConsistentSampler sampler2,
-      RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  ConsistentComposedOrSampler(ConsistentSampler sampler1, ConsistentSampler sampler2) {
     this.sampler1 = requireNonNull(sampler1);
     this.sampler2 = requireNonNull(sampler2);
     this.description =

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSampler.java
@@ -13,9 +13,7 @@ public class ConsistentFixedThresholdSampler extends ConsistentSampler {
   private final long threshold;
   private final String description;
 
-  protected ConsistentFixedThresholdSampler(
-      long threshold, RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  protected ConsistentFixedThresholdSampler(long threshold) {
     checkThreshold(threshold);
     this.threshold = threshold;
 

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentParentBasedSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentParentBasedSampler.java
@@ -26,11 +26,8 @@ final class ConsistentParentBasedSampler extends ConsistentSampler {
    * thread-safe random generator.
    *
    * @param rootSampler the root sampler
-   * @param randomValueGenerator the function to use for generating the r-value
    */
-  ConsistentParentBasedSampler(
-      ConsistentSampler rootSampler, RandomValueGenerator randomValueGenerator) {
-    super(randomValueGenerator);
+  ConsistentParentBasedSampler(ConsistentSampler rootSampler) {
     this.rootSampler = requireNonNull(rootSampler);
     this.description =
         "ConsistentParentBasedSampler{rootSampler=" + rootSampler.getDescription() + '}';

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
@@ -96,15 +96,12 @@ final class ConsistentRateLimitingSampler extends ConsistentSampler {
    * @param targetSpansPerSecondLimit the desired spans per second limit
    * @param adaptationTimeSeconds the typical time to adapt to a new load (time constant used for
    *     exponential smoothing)
-   * @param randomValueGenerator the function to use for generating the r-value
    * @param nanoTimeSupplier a supplier for the current nano time
    */
   ConsistentRateLimitingSampler(
       double targetSpansPerSecondLimit,
       double adaptationTimeSeconds,
-      RandomValueGenerator randomValueGenerator,
       LongSupplier nanoTimeSupplier) {
-    super(randomValueGenerator);
 
     if (targetSpansPerSecondLimit < 0.0) {
       throw new IllegalArgumentException("Limit for sampled spans per second must be nonnegative!");

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplingUtil.java
@@ -115,7 +115,7 @@ public final class ConsistentSamplingUtil {
     }
   }
 
-  private static final char[] HEX_DIGITS = {
+  static final char[] HEX_DIGITS = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
   };
 

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSamplerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.sampler.consistent56;
 
-import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMaxRandomValue;
+import static io.opentelemetry.contrib.sampler.consistent56.TestUtil.generateRandomTraceId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Attributes;
@@ -29,27 +29,22 @@ class ConsistentRateLimitingSamplerTest {
   private long[] nanoTime;
   private LongSupplier nanoTimeSupplier;
   private Context parentContext;
-  private String traceId;
   private String name;
   private SpanKind spanKind;
   private Attributes attributes;
   private List<LinkData> parentLinks;
-
-  private static RandomValueGenerator randomValueGenerator() {
-    SplittableRandom random = new SplittableRandom(0L);
-    return s -> random.nextLong() & getMaxRandomValue();
-  }
+  private SplittableRandom random;
 
   @BeforeEach
   void init() {
     nanoTime = new long[] {0L};
     nanoTimeSupplier = () -> nanoTime[0];
     parentContext = Context.root();
-    traceId = "0123456789abcdef0123456789abcdef";
     name = "name";
     spanKind = SpanKind.SERVER;
     attributes = Attributes.empty();
     parentLinks = Collections.emptyList();
+    random = new SplittableRandom(0L);
   }
 
   private void advanceTime(long nanosIncrement) {
@@ -68,10 +63,7 @@ class ConsistentRateLimitingSamplerTest {
 
     ConsistentSampler sampler =
         ConsistentSampler.rateLimited(
-            targetSpansPerSecondLimit,
-            adaptationTimeSeconds,
-            randomValueGenerator(),
-            nanoTimeSupplier);
+            targetSpansPerSecondLimit, adaptationTimeSeconds, nanoTimeSupplier);
 
     long nanosBetweenSpans = TimeUnit.MICROSECONDS.toNanos(100);
     int numSpans = 1000000;
@@ -81,7 +73,13 @@ class ConsistentRateLimitingSamplerTest {
     for (int i = 0; i < numSpans; ++i) {
       advanceTime(nanosBetweenSpans);
       SamplingResult samplingResult =
-          sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+          sampler.shouldSample(
+              parentContext,
+              generateRandomTraceId(random),
+              name,
+              spanKind,
+              attributes,
+              parentLinks);
       if (SamplingDecision.RECORD_AND_SAMPLE.equals(samplingResult.getDecision())) {
         spanSampledNanos.add(getCurrentTimeNanos());
       }
@@ -104,10 +102,7 @@ class ConsistentRateLimitingSamplerTest {
 
     ConsistentSampler sampler =
         ConsistentSampler.rateLimited(
-            targetSpansPerSecondLimit,
-            adaptationTimeSeconds,
-            randomValueGenerator(),
-            nanoTimeSupplier);
+            targetSpansPerSecondLimit, adaptationTimeSeconds, nanoTimeSupplier);
 
     long nanosBetweenSpans1 = TimeUnit.MICROSECONDS.toNanos(100);
     long nanosBetweenSpans2 = TimeUnit.MICROSECONDS.toNanos(10);
@@ -119,7 +114,13 @@ class ConsistentRateLimitingSamplerTest {
     for (int i = 0; i < numSpans1; ++i) {
       advanceTime(nanosBetweenSpans1);
       SamplingResult samplingResult =
-          sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+          sampler.shouldSample(
+              parentContext,
+              generateRandomTraceId(random),
+              name,
+              spanKind,
+              attributes,
+              parentLinks);
       if (SamplingDecision.RECORD_AND_SAMPLE.equals(samplingResult.getDecision())) {
         spanSampledNanos.add(getCurrentTimeNanos());
       }
@@ -127,7 +128,13 @@ class ConsistentRateLimitingSamplerTest {
     for (int i = 0; i < numSpans2; ++i) {
       advanceTime(nanosBetweenSpans2);
       SamplingResult samplingResult =
-          sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+          sampler.shouldSample(
+              parentContext,
+              generateRandomTraceId(random),
+              name,
+              spanKind,
+              attributes,
+              parentLinks);
       if (SamplingDecision.RECORD_AND_SAMPLE.equals(samplingResult.getDecision())) {
         spanSampledNanos.add(getCurrentTimeNanos());
       }
@@ -162,10 +169,7 @@ class ConsistentRateLimitingSamplerTest {
 
     ConsistentSampler sampler =
         ConsistentSampler.rateLimited(
-            targetSpansPerSecondLimit,
-            adaptationTimeSeconds,
-            randomValueGenerator(),
-            nanoTimeSupplier);
+            targetSpansPerSecondLimit, adaptationTimeSeconds, nanoTimeSupplier);
 
     long nanosBetweenSpans1 = TimeUnit.MICROSECONDS.toNanos(10);
     long nanosBetweenSpans2 = TimeUnit.MICROSECONDS.toNanos(100);
@@ -177,7 +181,13 @@ class ConsistentRateLimitingSamplerTest {
     for (int i = 0; i < numSpans1; ++i) {
       advanceTime(nanosBetweenSpans1);
       SamplingResult samplingResult =
-          sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+          sampler.shouldSample(
+              parentContext,
+              generateRandomTraceId(random),
+              name,
+              spanKind,
+              attributes,
+              parentLinks);
       if (SamplingDecision.RECORD_AND_SAMPLE.equals(samplingResult.getDecision())) {
         spanSampledNanos.add(getCurrentTimeNanos());
       }
@@ -185,7 +195,13 @@ class ConsistentRateLimitingSamplerTest {
     for (int i = 0; i < numSpans2; ++i) {
       advanceTime(nanosBetweenSpans2);
       SamplingResult samplingResult =
-          sampler.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+          sampler.shouldSample(
+              parentContext,
+              generateRandomTraceId(random),
+              name,
+              spanKind,
+              attributes,
+              parentLinks);
       if (SamplingDecision.RECORD_AND_SAMPLE.equals(samplingResult.getDecision())) {
         spanSampledNanos.add(getCurrentTimeNanos());
       }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/TestUtil.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/TestUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler.consistent56;
+
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.HEX_DIGITS;
+
+import java.util.SplittableRandom;
+
+public final class TestUtil {
+
+  private TestUtil() {}
+
+  static String generateRandomTraceId(SplittableRandom random) {
+    StringBuilder sb = new StringBuilder(16);
+    long hi = random.nextLong();
+    long lo = random.nextLong();
+    for (int i = 0; i < 64; i += 4) {
+      sb.append(HEX_DIGITS[(int) (hi >>> i) & 0xF]);
+    }
+    for (int i = 0; i < 64; i += 4) {
+      sb.append(HEX_DIGITS[(int) (lo >>> i) & 0xF]);
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
This PR reflects the latest agreements of the sampling SIG:
* assume least significant bits of trace ID are random by default
* remove th-field if not sampled

**Description:**

< Describe what is being changed or added.
  Ex. Bug fix  - Describe the bug and how this fixes it.
  Ex. Feature addition - Describe what this provides and why. >

**Existing Issue(s):**

< Link any applicable issues. >

**Testing:**

< Describe what testing was performed and any tests were added. >

**Documentation:**

< Describe the documentation added.
  Please be sure to modify relevant existing documentation if needed. >

**Outstanding items:**

< Anything that these changes are intentionally missing
  that will be needed or can be helpful in the future. >
