### PR TITLE
Fix link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### JMX metrics
 
-- Add support for newly named Tomcat MBean with Spring ([#1269])
+- Add support for newly named Tomcat MBean with Spring
+([#1269](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1269))
 
 ### Span stack traces - New 🌟
 


### PR DESCRIPTION
I botched the link to the PR in the changelog as part of the last release. This just fixes the link.