### PR TITLE
[jmx-metrics] Migrate SLF to be testImplementation() only.

### DIFF
--- a/jmx-metrics/build.gradle.kts
+++ b/jmx-metrics/build.gradle.kts
@@ -39,14 +39,14 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-exporter-logging")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
   implementation("io.opentelemetry:opentelemetry-exporter-prometheus")
-  implementation("org.slf4j:slf4j-api")
-  implementation("org.slf4j:slf4j-simple")
 
   annotationProcessor("com.google.auto.value:auto-value")
   compileOnly("com.google.auto.value:auto-value-annotations")
 
   runtimeOnly("org.terracotta:jmxremote_optional-tc:1.0.8")
 
+  testImplementation("org.slf4j:slf4j-api")
+  testImplementation("org.slf4j:slf4j-simple")
   testImplementation("org.junit-pioneer:junit-pioneer")
   testImplementation("org.awaitility:awaitility")
 }


### PR DESCRIPTION
Relates to #1266 

I only see usages of slf in the test classes, not in the main source, so this tweaks the dependency.