### PR TITLE
publish span stacktrace

### DIFF
--- a/span-stacktrace/build.gradle.kts
+++ b/span-stacktrace/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
   id("otel.java-conventions")
+  id("otel.publish-conventions")
 }
 
 description = "OpenTelemetry Java span stacktrace capture module"
+otelJava.moduleName.set("io.opentelemetry.contrib.stacktrace")
 
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk")


### PR DESCRIPTION
**Description:**

The span [stacktrace module](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/span-stacktrace) has been added and released in version 1.35.0, however it hasn't been published in maven central like all the other contrib modules.

This PR fixes the publication, which should be effective for the next release.
