### PR TITLE
migrate maven extension to current semconv

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-trace")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  implementation("io.opentelemetry:opentelemetry-semconv")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating:1.25.0-alpha")
   implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
   annotationProcessor("com.google.auto.value:auto-value")
@@ -59,10 +60,3 @@ tasks {
 }
 
 tasks.getByName("test").dependsOn("shadowJar")
-
-configurations.all {
-  resolutionStrategy {
-    // TODO this module still needs to be updated to the latest semconv
-    force("io.opentelemetry:opentelemetry-semconv:1.28.0-alpha")
-  }
-}

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/GoogleJibBuildHandler.java
@@ -9,7 +9,9 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,11 +88,11 @@ final class GoogleJibBuildHandler implements MojoGoalExecutionHandler {
     spanBuilder.setAttribute(
         MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL,
         "https://" + registryHostname);
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://" + registryHostname);
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(UrlAttributes.URL_FULL, "https://" + registryHostname);
+    spanBuilder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST");
     // Note: setting the "peer.service" helps visualization on Jaeger but
     // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
     // service will be instrumented and what it "service.name" would be
-    spanBuilder.setAttribute(SemanticAttributes.PEER_SERVICE, registryHostname);
+    spanBuilder.setAttribute(PeerIncubatingAttributes.PEER_SERVICE, registryHostname);
   }
 }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/MavenDeployHandler.java
@@ -9,7 +9,9 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -53,7 +55,7 @@ final class MavenDeployHandler implements MojoGoalExecutionHandler {
         // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
         // service will be instrumented and what it "service.name" would be
         spanBuilder.setAttribute(
-            SemanticAttributes.PEER_SERVICE, new URL(artifactRepositoryUrl).getHost());
+            PeerIncubatingAttributes.PEER_SERVICE, new URL(artifactRepositoryUrl).getHost());
       } catch (MalformedURLException e) {
         logger.debug("Ignore exception parsing artifact repository URL", e);
       }
@@ -68,8 +70,8 @@ final class MavenDeployHandler implements MojoGoalExecutionHandler {
               + artifact.getArtifactId()
               + '/'
               + artifact.getVersion();
-      spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, artifactRootUrl);
-      spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+      spanBuilder.setAttribute(UrlAttributes.URL_FULL, artifactRootUrl);
+      spanBuilder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST");
     }
   }
 

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykMonitorHandler.java
@@ -8,7 +8,10 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
@@ -24,10 +27,10 @@ final class SnykMonitorHandler implements MojoGoalExecutionHandler {
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);
-    spanBuilder.setAttribute(SemanticAttributes.PEER_SERVICE, "snyk.io");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://snyk.io/api/v1/monitor/maven");
-    spanBuilder.setAttribute(SemanticAttributes.RPC_METHOD, "monitor");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(PeerIncubatingAttributes.PEER_SERVICE, "snyk.io");
+    spanBuilder.setAttribute(UrlAttributes.URL_FULL, "https://snyk.io/api/v1/monitor/maven");
+    spanBuilder.setAttribute(RpcIncubatingAttributes.RPC_METHOD, "monitor");
+    spanBuilder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST");
   }
 
   @Override

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SnykTestHandler.java
@@ -8,7 +8,10 @@ package io.opentelemetry.maven.handler;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.util.Collections;
 import java.util.List;
 import org.apache.maven.execution.ExecutionEvent;
@@ -24,10 +27,10 @@ final class SnykTestHandler implements MojoGoalExecutionHandler {
   @Override
   public void enrichSpan(SpanBuilder spanBuilder, ExecutionEvent executionEvent) {
     spanBuilder.setSpanKind(SpanKind.CLIENT);
-    spanBuilder.setAttribute(SemanticAttributes.PEER_SERVICE, "snyk.io");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, "https://snyk.io/api/v1/test-dep-graph");
-    spanBuilder.setAttribute(SemanticAttributes.RPC_METHOD, "test");
-    spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+    spanBuilder.setAttribute(PeerIncubatingAttributes.PEER_SERVICE, "snyk.io");
+    spanBuilder.setAttribute(UrlAttributes.URL_FULL, "https://snyk.io/api/v1/test-dep-graph");
+    spanBuilder.setAttribute(RpcIncubatingAttributes.RPC_METHOD, "test");
+    spanBuilder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST");
   }
 
   @Override

--- a/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/handler/SpringBootBuildImageHandler.java
@@ -9,7 +9,9 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -99,14 +101,14 @@ final class SpringBootBuildImageHandler implements MojoGoalExecutionHandler {
             && (registryUrl.startsWith("http://") || registryUrl.startsWith("https://"))) {
           spanBuilder.setAttribute(
               MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL, registryUrl);
-          spanBuilder.setAttribute(SemanticAttributes.HTTP_URL, registryUrl);
-          spanBuilder.setAttribute(SemanticAttributes.HTTP_METHOD, "POST");
+          spanBuilder.setAttribute(UrlAttributes.URL_FULL, registryUrl);
+          spanBuilder.setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST");
           try {
             // Note: setting the "peer.service" helps visualization on Jaeger but
             // may not fully comply with the OTel "peer.service" spec as we don't know if the remote
             // service will be instrumented and what it "service.name" would be
             spanBuilder.setAttribute(
-                SemanticAttributes.PEER_SERVICE, new URL(registryUrl).getHost());
+                PeerIncubatingAttributes.PEER_SERVICE, new URL(registryUrl).getHost());
           } catch (MalformedURLException e) {
             logger.debug("Ignore exception parsing container registry URL", e);
           }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
@@ -9,7 +9,7 @@ import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ServiceAttributes;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
 
@@ -20,8 +20,8 @@ public class MavenResourceProvider implements ResourceProvider {
     //  Maven Plexus Launcher
     RuntimeInformation runtimeInformation = new DefaultRuntimeInformation();
     return Resource.builder()
-        .put(ResourceAttributes.SERVICE_NAME, MavenOtelSemanticAttributes.SERVICE_NAME_VALUE)
-        .put(ResourceAttributes.SERVICE_VERSION, runtimeInformation.getMavenVersion())
+        .put(ServiceAttributes.SERVICE_NAME, MavenOtelSemanticAttributes.SERVICE_NAME_VALUE)
+        .put(ServiceAttributes.SERVICE_VERSION, runtimeInformation.getMavenVersion())
         .build();
   }
 }

--- a/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/semconv/MavenOtelSemanticAttributes.java
@@ -9,22 +9,24 @@ import static io.opentelemetry.api.common.AttributeKey.stringArrayKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes;
 import java.util.List;
 
 /**
  * Semantic attributes for Maven executions.
  *
  * @see io.opentelemetry.api.common.Attributes
- * @see io.opentelemetry.semconv.trace.attributes.SemanticAttributes
  */
 public class MavenOtelSemanticAttributes {
 
-  /** See {@link ResourceAttributes#CONTAINER_IMAGE_NAME} */
+  /**
+   * See {@link
+   * io.opentelemetry.semconv.incubating.ContainerIncubatingAttributes#CONTAINER_IMAGE_NAME}
+   */
   public static final AttributeKey<String> MAVEN_BUILD_CONTAINER_IMAGE_NAME =
       stringKey("maven.build.container.image.name");
 
-  /** See {@link ResourceAttributes#CONTAINER_IMAGE_TAG} */
+  /** See {@link ContainerIncubatingAttributes#CONTAINER_IMAGE_TAGS} */
   public static final AttributeKey<List<String>> MAVEN_BUILD_CONTAINER_IMAGE_TAGS =
       stringArrayKey("maven.build.container.image.tags");
 

--- a/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/handler/MojoGoalExecutionHandlerTest.java
@@ -13,7 +13,10 @@ import io.opentelemetry.maven.MavenGoal;
 import io.opentelemetry.maven.semconv.MavenOtelSemanticAttributes;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.PeerIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -75,13 +78,14 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_REPOSITORY_ID))
           .isEqualTo("snapshots");
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_METHOD)).isEqualTo("POST");
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(HttpAttributes.HTTP_REQUEST_METHOD)).isEqualTo("POST");
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL))
           .isEqualTo(
               "https://maven.example.com/repository/maven-snapshots/io/opentelemetry/contrib/maven/test-jar/1.0-SNAPSHOT");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_REPOSITORY_URL))
           .isEqualTo("https://maven.example.com/repository/maven-snapshots/");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("maven.example.com");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE))
+          .isEqualTo("maven.example.com");
 
       assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
     }
@@ -124,8 +128,8 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("latest"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
     }
@@ -168,8 +172,8 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("${project.version}"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
     }
@@ -209,8 +213,8 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Arrays.asList("latest", "${project.version}"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://docker.io");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("docker.io");
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL)).isEqualTo("https://docker.io");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("docker.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://docker.io");
     }
@@ -250,8 +254,8 @@ public class MojoGoalExecutionHandlerTest {
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_IMAGE_TAGS))
           .isEqualTo(Collections.singletonList("1.0-SNAPSHOT"));
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL)).isEqualTo("https://gcr.io");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("gcr.io");
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL)).isEqualTo("https://gcr.io");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("gcr.io");
       assertThat(span.getAttribute(MavenOtelSemanticAttributes.MAVEN_BUILD_CONTAINER_REGISTRY_URL))
           .isEqualTo("https://gcr.io");
     }
@@ -286,10 +290,10 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL))
           .isEqualTo("https://snyk.io/api/v1/test-dep-graph");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
-      assertThat(span.getAttribute(SemanticAttributes.RPC_METHOD)).isEqualTo("test");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
+      assertThat(span.getAttribute(RpcIncubatingAttributes.RPC_METHOD)).isEqualTo("test");
     }
   }
 
@@ -322,10 +326,10 @@ public class MojoGoalExecutionHandlerTest {
 
       assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
-      assertThat(span.getAttribute(SemanticAttributes.HTTP_URL))
+      assertThat(span.getAttribute(UrlAttributes.URL_FULL))
           .isEqualTo("https://snyk.io/api/v1/monitor/maven");
-      assertThat(span.getAttribute(SemanticAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
-      assertThat(span.getAttribute(SemanticAttributes.RPC_METHOD)).isEqualTo("monitor");
+      assertThat(span.getAttribute(PeerIncubatingAttributes.PEER_SERVICE)).isEqualTo("snyk.io");
+      assertThat(span.getAttribute(RpcIncubatingAttributes.RPC_METHOD)).isEqualTo("monitor");
     }
   }
 


### PR DESCRIPTION
**Description:**

Maven extension relies on an older version of semantic conventions and an explicit exception was added in #1070.

This PR aligns maven extension with the new version of semconv.

Replaces #1055 that has become obsolete with current state of semconv.

Overlaps with #1059 but is simpler so easier to review and merge short term.