### PR TITLE
[jfr-connection] Pin JMC version for testing

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,6 +61,12 @@
     {
       "matchPackagePrefixes": ["com.diffplug.spotless"],
       "groupName": "spotless packages"
+    },
+    {
+      // pinned version for compatibility with java 8 JFR parsing
+      "matchPackagePrefixes": ["org.openjdk.jmc"],
+      "matchCurrentVersion": "8.3.1",
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,7 @@
     {
       // pinned version for compatibility with java 8 JFR parsing
       "matchPackagePrefixes": ["org.openjdk.jmc"],
-      "matchCurrentVersion": "8.3.1",
+      "matchUpdateTypes": ["major"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Supersedes #1287 
Supersedes #1286 

See [this discussion](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1287#issuecomment-2101577239) in #1287 about the root problem and how we're now going to just pin this jmc version to work around this.