### PR TITLE
add config support for BaggageSpanProcessor

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -21,6 +21,7 @@ components:
     - srprash
   baggage-procesor:
     - mikegoldsmith
+    - zeitlinger
   compressors:
     - jack-berg
   consistent-sampling:

--- a/baggage-processor/README.md
+++ b/baggage-processor/README.md
@@ -42,8 +42,18 @@ Pattern pattern = Pattern.compile("^key.+");
 new BaggageSpanProcessor(baggageKey -> pattern.matcher(baggageKey).matches())
 ```
 
+## Usage with SDK auto-configuration
+
+If you are using the OpenTelemetry SDK auto-configuration, you can add the span processor this
+library to configure the span processor.
+
+| Property                                  | Description                                                                                     |
+|-------------------------------------------|-------------------------------------------------------------------------------------------------|
+| otel.traces.baggage-to-attributes.include | Add baggage items to span attributes, e.g. `key1,key2` or `*` to add all baggage items as keys. |
+
 ## Component owners
 
 - [Mike Golsmith](https://github.com/MikeGoldsmith), Honeycomb
+- [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).

--- a/baggage-processor/README.md
+++ b/baggage-processor/README.md
@@ -49,7 +49,7 @@ library to configure the span processor.
 
 | Property                                  | Description                                                                                     |
 |-------------------------------------------|-------------------------------------------------------------------------------------------------|
-| otel.traces.baggage-to-attributes.include | Add baggage items to span attributes, e.g. `key1,key2` or `*` to add all baggage items as keys. |
+| otel.traces.baggage-to-attributes.include | Add baggage entries as span attributes, e.g. `key1,key2` or `*` to add all baggage items as keys. |
 
 ## Component owners
 

--- a/baggage-processor/README.md
+++ b/baggage-processor/README.md
@@ -47,9 +47,9 @@ new BaggageSpanProcessor(baggageKey -> pattern.matcher(baggageKey).matches())
 If you are using the OpenTelemetry SDK auto-configuration, you can add the span processor this
 library to configure the span processor.
 
-| Property                                  | Description                                                                                     |
-|-------------------------------------------|-------------------------------------------------------------------------------------------------|
-| otel.traces.baggage-to-attributes.include | Add baggage entries as span attributes, e.g. `key1,key2` or `*` to add all baggage items as keys. |
+| Property                                                         | Description                                                                                       |
+|------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| otel.java.experimental.span-attributes.copy-from-baggage.include | Add baggage entries as span attributes, e.g. `key1,key2` or `*` to add all baggage items as keys. |
 
 ## Component owners
 

--- a/baggage-processor/build.gradle.kts
+++ b/baggage-processor/build.gradle.kts
@@ -13,5 +13,8 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
   testImplementation("org.mockito:mockito-inline")
+  testImplementation("com.google.guava:guava")
+  testImplementation("org.awaitility:awaitility")
 }

--- a/baggage-processor/build.gradle.kts
+++ b/baggage-processor/build.gradle.kts
@@ -10,6 +10,8 @@ otelJava.moduleName.set("io.opentelemetry.contrib.baggage.processor")
 dependencies {
   api("io.opentelemetry:opentelemetry-api")
   api("io.opentelemetry:opentelemetry-sdk")
+  implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("org.mockito:mockito-inline")
 }

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
@@ -19,7 +19,8 @@ import java.util.function.Predicate;
 public class BaggageSpanProcessor implements SpanProcessor {
   private final Predicate<String> baggageKeyPredicate;
 
-  /** A {@link Predicate} that returns true for all baggage keys. */
+  /** use {@link #allowAllBaggageKeys()} instead */
+  @Deprecated
   public static final Predicate<String> allowAllBaggageKeys = baggageKey -> true;
 
   /**
@@ -28,6 +29,14 @@ public class BaggageSpanProcessor implements SpanProcessor {
    */
   public BaggageSpanProcessor(Predicate<String> baggageKeyPredicate) {
     this.baggageKeyPredicate = baggageKeyPredicate;
+  }
+
+  /**
+   * Creates a new {@link BaggageSpanProcessor} that copies all baggage entries into the newly
+   * created {@link io.opentelemetry.api.trace.Span}.
+   */
+  public static BaggageSpanProcessor allowAllBaggageKeys() {
+    return new BaggageSpanProcessor(baggageKey -> true);
   }
 
   @Override

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
@@ -20,8 +20,7 @@ public class BaggageSpanProcessor implements SpanProcessor {
   private final Predicate<String> baggageKeyPredicate;
 
   /** use {@link #allowAllBaggageKeys()} instead */
-  @Deprecated
-  public static final Predicate<String> allowAllBaggageKeys = baggageKey -> true;
+  @Deprecated public static final Predicate<String> allowAllBaggageKeys = baggageKey -> true;
 
   /**
    * Creates a new {@link BaggageSpanProcessor} that copies only baggage entries with keys that pass

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.baggage.processor;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import java.util.List;
+
+public class BaggageSpanProcessorCustomizer implements AutoConfigurationCustomizerProvider {
+  @Override
+  public void customize(AutoConfigurationCustomizer autoConfigurationCustomizer) {
+    autoConfigurationCustomizer.addTracerProviderCustomizer(
+        (sdkTracerProviderBuilder, config) -> {
+          addSpanProcessor(sdkTracerProviderBuilder, config);
+          return sdkTracerProviderBuilder;
+        });
+  }
+
+  private static void addSpanProcessor(
+      SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
+    List<String> keys = config.getList("otel.traces.baggage-to-attributes.include");
+
+    if (keys.isEmpty()) {
+      return;
+    }
+
+    sdkTracerProviderBuilder.addSpanProcessor(createProcessor(keys));
+  }
+
+  static BaggageSpanProcessor createProcessor(List<String> keys) {
+    if (keys.size() == 1 && keys.get(0).equals("*")) {
+      return new BaggageSpanProcessor(BaggageSpanProcessor.allowAllBaggageKeys);
+    }
+    return new BaggageSpanProcessor(keys::contains);
+  }
+}

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
@@ -23,7 +23,8 @@ public class BaggageSpanProcessorCustomizer implements AutoConfigurationCustomiz
 
   private static void addSpanProcessor(
       SdkTracerProviderBuilder sdkTracerProviderBuilder, ConfigProperties config) {
-    List<String> keys = config.getList("otel.traces.baggage-to-attributes.include");
+    List<String> keys =
+        config.getList("otel.java.experimental.span-attributes.copy-from-baggage.include");
 
     if (keys.isEmpty()) {
       return;

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizer.java
@@ -35,7 +35,7 @@ public class BaggageSpanProcessorCustomizer implements AutoConfigurationCustomiz
 
   static BaggageSpanProcessor createProcessor(List<String> keys) {
     if (keys.size() == 1 && keys.get(0).equals("*")) {
-      return new BaggageSpanProcessor(BaggageSpanProcessor.allowAllBaggageKeys);
+      return BaggageSpanProcessor.allowAllBaggageKeys();
     }
     return new BaggageSpanProcessor(keys::contains);
   }

--- a/baggage-processor/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
+++ b/baggage-processor/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.contrib.baggage.processor.BaggageSpanProcessorCustomizer

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
@@ -34,7 +34,9 @@ class BaggageSpanProcessorCustomizerTest {
   void test_customizer() {
     assertCustomizer(Collections.emptyMap(), 0);
     assertCustomizer(
-        Collections.singletonMap("otel.traces.baggage-to-attributes.include", "key"), 1);
+        Collections.singletonMap(
+            "otel.java.experimental.span-attributes.copy-from-baggage.include", "key"),
+        1);
   }
 
   private static void assertCustomizer(

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
@@ -63,9 +63,10 @@ class BaggageSpanProcessorCustomizerTest {
     await()
         .atMost(Duration.ofSeconds(1))
         .untilAsserted(
-            () -> TracesAssert.assertThat(spanExporter.getFinishedSpanItems())
-                .hasTracesSatisfyingExactly(
-                    trace -> trace.hasSpansSatisfyingExactly(spanDataAssertConsumer)));
+            () ->
+                TracesAssert.assertThat(spanExporter.getFinishedSpanItems())
+                    .hasTracesSatisfyingExactly(
+                        trace -> trace.hasSpansSatisfyingExactly(spanDataAssertConsumer)));
   }
 
   private static OpenTelemetrySdk getOpenTelemetrySdk(

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
@@ -63,11 +63,9 @@ class BaggageSpanProcessorCustomizerTest {
     await()
         .atMost(Duration.ofSeconds(1))
         .untilAsserted(
-            () -> {
-              TracesAssert.assertThat(spanExporter.getFinishedSpanItems())
-                  .hasTracesSatisfyingExactly(
-                      trace -> trace.hasSpansSatisfyingExactly(spanDataAssertConsumer));
-            });
+            () -> TracesAssert.assertThat(spanExporter.getFinishedSpanItems())
+                .hasTracesSatisfyingExactly(
+                    trace -> trace.hasSpansSatisfyingExactly(spanDataAssertConsumer)));
   }
 
   private static OpenTelemetrySdk getOpenTelemetrySdk(

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorCustomizerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.baggage.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BaggageSpanProcessorCustomizerTest {
+
+  @Test
+  void test_customizer() {
+    assertCustomizer(Collections.emptyMap(), 0);
+    assertCustomizer(
+        Collections.singletonMap("otel.traces.baggage-to-attributes.include", "key"), 1);
+  }
+
+  private static void assertCustomizer(
+      Map<String, String> properties, int addedSpanProcessorTimes) {
+    AutoConfigurationCustomizer customizer = Mockito.mock(AutoConfigurationCustomizer.class);
+    new BaggageSpanProcessorCustomizer().customize(customizer);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<BiFunction<SdkTracerProviderBuilder, ConfigProperties, SdkTracerProviderBuilder>>
+        captor = ArgumentCaptor.forClass(BiFunction.class);
+    verify(customizer, times(1)).addTracerProviderCustomizer(captor.capture());
+
+    SdkTracerProviderBuilder builder = Mockito.mock(SdkTracerProviderBuilder.class);
+    SdkTracerProviderBuilder apply =
+        captor.getValue().apply(builder, DefaultConfigProperties.createFromMap(properties));
+    assertThat(apply).isSameAs(builder);
+
+    verify(builder, times(addedSpanProcessorTimes)).addSpanProcessor(Mockito.any());
+  }
+
+  @Test
+  public void test_baggageSpanProcessor_adds_attributes_to_spans(@Mock ReadWriteSpan span) {
+    try (BaggageSpanProcessor processor =
+        BaggageSpanProcessorCustomizer.createProcessor(Collections.singletonList("*"))) {
+      try (Scope ignore = Baggage.current().toBuilder().put("key", "value").build().makeCurrent()) {
+        processor.onStart(Context.current(), span);
+        verify(span).setAttribute("key", "value");
+      }
+    }
+  }
+
+  @Test
+  public void test_baggageSpanProcessor_adds_attributes_to_spans_when_key_filter_matches(
+      @Mock ReadWriteSpan span) {
+    try (BaggageSpanProcessor processor =
+        BaggageSpanProcessorCustomizer.createProcessor(Collections.singletonList("key"))) {
+      try (Scope ignore =
+          Baggage.current().toBuilder()
+              .put("key", "value")
+              .put("other", "value")
+              .build()
+              .makeCurrent()) {
+        processor.onStart(Context.current(), span);
+        verify(span).setAttribute("key", "value");
+        verify(span, Mockito.never()).setAttribute("other", "value");
+      }
+    }
+  }
+}

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessorTest.java
@@ -21,8 +21,7 @@ public class BaggageSpanProcessorTest {
 
   @Test
   public void test_baggageSpanProcessor_adds_attributes_to_spans(@Mock ReadWriteSpan span) {
-    try (BaggageSpanProcessor processor =
-        new BaggageSpanProcessor(BaggageSpanProcessor.allowAllBaggageKeys)) {
+    try (BaggageSpanProcessor processor = BaggageSpanProcessor.allowAllBaggageKeys()) {
       try (Scope ignore = Baggage.current().toBuilder().put("key", "value").build().makeCurrent()) {
         processor.onStart(Context.current(), span);
         Mockito.verify(span).setAttribute("key", "value");


### PR DESCRIPTION
Add config support for BaggageSpanProcessor to add it to java agent - simply by adding the library.