### PR TITLE
jfr-connection: fixes for using diagnostic command to start a recording

### DIFF
--- a/jfr-connection/build.gradle.kts
+++ b/jfr-connection/build.gradle.kts
@@ -9,4 +9,5 @@ otelJava.moduleName.set("io.opentelemetry.contrib.jfr.connection")
 dependencies {
   testImplementation("org.openjdk.jmc:common:8.3.1")
   testImplementation("org.openjdk.jmc:flightrecorder:8.3.1")
+  testImplementation("org.mockito:mockito-inline")
 }

--- a/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnection.java
+++ b/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnection.java
@@ -33,7 +33,7 @@ import javax.management.ReflectionException;
 final class FlightRecorderDiagnosticCommandConnection implements FlightRecorderConnection {
   private static final String DIAGNOSTIC_COMMAND_OBJECT_NAME =
       "com.sun.management:type=DiagnosticCommand";
-  private static final String JFR_START_REGEX = "Started recording (.+?)\\. .*";
+  private static final String JFR_START_REGEX = "Started recording (\\d+?)\\.";
   private static final Pattern JFR_START_PATTERN = Pattern.compile(JFR_START_REGEX, Pattern.DOTALL);
 
   // All JFR commands take String[] parameters
@@ -56,7 +56,11 @@ final class FlightRecorderDiagnosticCommandConnection implements FlightRecorderC
       ObjectInstance objectInstance =
           mBeanServerConnection.getObjectInstance(new ObjectName(DIAGNOSTIC_COMMAND_OBJECT_NAME));
       ObjectName objectName = objectInstance.getObjectName();
-      assertCommercialFeaturesUnlocked(mBeanServerConnection, objectName);
+
+      if (jdkHasUnlockCommercialFeatures()) {
+        assertCommercialFeaturesUnlocked(mBeanServerConnection, objectName);
+      }
+
       return new FlightRecorderDiagnosticCommandConnection(
           mBeanServerConnection, objectInstance.getObjectName());
     } catch (MalformedObjectNameException e) {
@@ -179,7 +183,7 @@ final class FlightRecorderDiagnosticCommandConnection implements FlightRecorderC
   @Override
   public void dumpRecording(long id, String outputFile) throws IOException, JfrConnectionException {
     try {
-      Object[] params = mkParams("filename=" + outputFile, "recording=" + id, "compress=true");
+      Object[] params = mkParams("filename=" + outputFile, "name=" + id);
       mBeanServerConnection.invoke(objectName, "jfrDump", params, signature);
     } catch (InstanceNotFoundException | MBeanException | ReflectionException e) {
       throw JfrConnectionException.canonicalJfrConnectionException(getClass(), "dumpRecording", e);
@@ -210,26 +214,34 @@ final class FlightRecorderDiagnosticCommandConnection implements FlightRecorderC
     throw new UnsupportedOperationException("closeRecording not supported on Java 8");
   }
 
+  // Do this check separate from assertCommercialFeatures because reliance
+  // on System properties makes it difficult to test.
+  private static boolean jdkHasUnlockCommercialFeatures() {
+    String javaVmVendor = System.getProperty("java.vm.vendor");
+    String javaVersion = System.getProperty("java.version");
+    return javaVmVendor.contains("Oracle Corporation") && javaVersion.matches("(?:^1\\.8|9|10).*");
+  }
+
   // visible for testing
   static void assertCommercialFeaturesUnlocked(
       MBeanServerConnection mBeanServerConnection, ObjectName objectName)
       throws IOException, JfrConnectionException {
+
     try {
       Object unlockedMessage =
           mBeanServerConnection.invoke(objectName, "vmCheckCommercialFeatures", null, null);
       if (unlockedMessage instanceof String) {
         boolean unlocked = ((String) unlockedMessage).contains("unlocked");
         if (!unlocked) {
-          throw new UnsupportedOperationException(
-              "Unlocking commercial features may be required. This must be explicitly enabled by adding -XX:+UnlockCommercialFeatures");
+          throw JfrConnectionException.canonicalJfrConnectionException(
+              FlightRecorderDiagnosticCommandConnection.class,
+              "assertCommercialFeaturesUnlocked",
+              new UnsupportedOperationException(
+                  "Unlocking commercial features may be required. This must be explicitly enabled by adding -XX:+UnlockCommercialFeatures"));
         }
       }
-    } catch (InstanceNotFoundException
-        | MBeanException
-        | ReflectionException
-        | UnsupportedOperationException e) {
-      throw JfrConnectionException.canonicalJfrConnectionException(
-          FlightRecorderDiagnosticCommandConnection.class, "assertCommercialFeaturesUnlocked", e);
+    } catch (InstanceNotFoundException | MBeanException | ReflectionException ignored) {
+      // If the MBean doesn't have the vmCheckCommercialFeatures method, then we can't check it.
     }
   }
 

--- a/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/RecordingOptions.java
+++ b/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/RecordingOptions.java
@@ -207,7 +207,7 @@ public class RecordingOptions {
      *   <li>"d" (days)
      * </ul>
      *
-     * For example, {@code "2 h"}, {@code "3 m"}.
+     * For example, {@code "2h"}, {@code "3m"}.
      *
      * <p>If the value is {@code null}, {@code duration} will be set to the default value, which is
      * "no limit".
@@ -388,7 +388,7 @@ public class RecordingOptions {
           case "m":
           case "h":
           case "d":
-            return Long.toString(value) + " " + units;
+            return Long.toString(value) + units;
           default:
             // fall through
         }

--- a/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/RecordingOptions.java
+++ b/jfr-connection/src/main/java/io/opentelemetry/contrib/jfr/connection/RecordingOptions.java
@@ -388,7 +388,7 @@ public class RecordingOptions {
           case "m":
           case "h":
           case "d":
-            return Long.toString(value) + units;
+            return value + units;
           default:
             // fall through
         }

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
@@ -7,19 +7,14 @@ package io.opentelemetry.contrib.jfr.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class FlightRecorderDiagnosticCommandConnectionTest {
 
@@ -74,32 +69,6 @@ class FlightRecorderDiagnosticCommandConnectionTest {
         connection.startRecording(
             new RecordingOptions.Builder().build(), RecordingConfiguration.PROFILE_CONFIGURATION);
     assertEquals(id, 99);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"5 s", "5m"})
-  void assertCanStartRecordingWithDuration(String duration) {
-    // Issue #1338
-
-    MBeanServerConnection mBeanServer = ManagementFactory.getPlatformMBeanServer();
-    RecordingOptions recordingOptions = new RecordingOptions.Builder().duration(duration).build();
-    RecordingConfiguration recordingConfiguration = RecordingConfiguration.PROFILE_CONFIGURATION;
-
-    try {
-      FlightRecorderConnection connection =
-          FlightRecorderDiagnosticCommandConnection.connect(mBeanServer);
-
-      try (Recording recording =
-          connection.newRecording(recordingOptions, recordingConfiguration)) {
-        recording.start();
-        recording.stop();
-      } catch (IOException e) {
-        // Recording is autoclose
-      }
-
-    } catch (IOException | JfrConnectionException e) {
-      fail(e);
-    }
   }
 
   MBeanServerConnection mockMbeanServer(

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
@@ -7,14 +7,19 @@ package io.opentelemetry.contrib.jfr.connection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class FlightRecorderDiagnosticCommandConnectionTest {
 
@@ -69,6 +74,32 @@ class FlightRecorderDiagnosticCommandConnectionTest {
         connection.startRecording(
             new RecordingOptions.Builder().build(), RecordingConfiguration.PROFILE_CONFIGURATION);
     assertEquals(id, 99);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"5 s", "5m"})
+  void assertCanStartRecordingWithDuration(String duration) {
+    // Issue #1338
+
+    MBeanServerConnection mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    RecordingOptions recordingOptions = new RecordingOptions.Builder().duration(duration).build();
+    RecordingConfiguration recordingConfiguration = RecordingConfiguration.PROFILE_CONFIGURATION;
+
+    try {
+      FlightRecorderConnection connection =
+          FlightRecorderDiagnosticCommandConnection.connect(mBeanServer);
+
+      try (Recording recording =
+          connection.newRecording(recordingOptions, recordingConfiguration)) {
+        recording.start();
+        recording.stop();
+      } catch (IOException e) {
+        // Recording is autoclose
+      }
+
+    } catch (IOException | JfrConnectionException e) {
+      fail(e);
+    }
   }
 
   MBeanServerConnection mockMbeanServer(

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingOptionsTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingOptionsTest.java
@@ -46,15 +46,15 @@ class RecordingOptionsTest {
   @Keep
   static Stream<Arguments> testGetMaxAge() {
     return Stream.of(
-        Arguments.of("3 ns", "3 ns"),
-        Arguments.of("3 us", "3 us"),
-        Arguments.of("3 ms", "3 ms"),
-        Arguments.of("3 s", "3 s"),
-        Arguments.of("3 m", "3 m"),
-        Arguments.of("3 h", "3 h"),
-        Arguments.of("3 h", "3 h"),
-        Arguments.of("+3 d", "3 d"),
-        Arguments.of("3ms", "3 ms"),
+        Arguments.of("3 ns", "3ns"),
+        Arguments.of("3 us", "3us"),
+        Arguments.of("3 ms", "3ms"),
+        Arguments.of("3 s", "3s"),
+        Arguments.of("3 m", "3m"),
+        Arguments.of("3 h", "3h"),
+        Arguments.of("3 h", "3h"),
+        Arguments.of("+3 d", "3d"),
+        Arguments.of("3ms", "3ms"),
         Arguments.of("0", "0"),
         Arguments.of("", "0"),
         Arguments.of((String) null, "0"));
@@ -209,15 +209,15 @@ class RecordingOptionsTest {
   @Keep
   private static Stream<Arguments> testGetDuration() {
     return Stream.of(
-        Arguments.of("3 ns", "3 ns"),
-        Arguments.of("3 us", "3 us"),
-        Arguments.of("3 ms", "3 ms"),
-        Arguments.of("3 s", "3 s"),
-        Arguments.of("3 m", "3 m"),
-        Arguments.of("3 h", "3 h"),
-        Arguments.of("3 h", "3 h"),
-        Arguments.of("+3 d", "3 d"),
-        Arguments.of("3ms", "3 ms"),
+        Arguments.of("3 ns", "3ns"),
+        Arguments.of("3 us", "3us"),
+        Arguments.of("3 ms", "3ms"),
+        Arguments.of("3 s", "3s"),
+        Arguments.of("3 m", "3m"),
+        Arguments.of("3 h", "3h"),
+        Arguments.of("3 h", "3h"),
+        Arguments.of("+3 d", "3d"),
+        Arguments.of("3ms", "3ms"),
         Arguments.of("0", "0"),
         Arguments.of("", "0"),
         Arguments.of(null, "0"));
@@ -263,12 +263,12 @@ class RecordingOptionsTest {
   void testGetRecordingOptions() {
     Map<String, String> expected = new HashMap<>();
     expected.put("name", "test");
-    expected.put("maxAge", "3 m");
+    expected.put("maxAge", "3m");
     expected.put("maxSize", "1048576");
     expected.put("dumpOnExit", "true");
     expected.put("destination", "test.jfr");
     expected.put("disk", "true");
-    expected.put("duration", "120 s");
+    expected.put("duration", "120s");
     RecordingOptions opts =
         new RecordingOptions.Builder()
             .name("test")

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingTest.java
@@ -329,6 +329,13 @@ class RecordingTest {
                 String getter =
                     "get" + key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
                 String expected = (String) compositeData.get("value");
+
+                // Special case for duration values. The FlightRecorderMXBean wants "<number><unit>"
+                // but returns "<number> <unit>", so we need to normalize the expected value.
+                if (expected != null && expected.matches("([-+]?\\d+)\\s*(\\w*)")) {
+                  expected = expected.replaceAll("\\s", "");
+                }
+
                 try {
                   Method method = RecordingOptions.class.getMethod(getter);
                   String actual = (String) method.invoke(recordingOptions);


### PR DESCRIPTION
**Description:**
Time based recording options (time and age) are sent with a space between the value and units, e.g. "6000 ms", which may cause an issue with Java 8/Diagnostic Command. 

In the course of testing, I found an issue with the code that checks to see if `-XX:+UnlockCommercialFeatures` needs to be set. The issue was that this check was applied always and would erroneously report that the user needed to UnlockCommercialFeatures even though the JVM was not an Oracle JVM. I addressed this by putting an additional check to see if the VM vendor is "Oracle Corporation" and the VM version is 1.8, 9, or 10. Oracle removed UnlockCommercialFeatures in JDK 11. 

**Existing Issue(s):**
Fixes #1338

**Testing:**
I tested locally with Oracle JVMs version 1.8, 11, 17 and 21, and also with Adoptium and Microsoft JVMs. 
Modified existing unit tests to accept `<value><units>` as oppsed to `<value> <units>`
Added unit test that starts a recording for a specified duration where the duration configured in the RecordingOptions as `5s` or `5 s`. This test is run with both the diagnostic command connection and with the MBean connection to ensure there are no differences. This test does not use Mock as do others. 

**Documentation:**
One place in the documentation had an example duration with a space between the value and units. I eliminated the space, although the code normalizes the string by eliminating any space. 

**Outstanding items:**

< Anything that these changes are intentionally missing
  that will be needed or can be helpful in the future. >
