### PR TITLE
Add AWS ECS cluster detection

### DIFF
--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/IncubatingAttributes.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/IncubatingAttributes.java
@@ -62,6 +62,8 @@ class IncubatingAttributes {
   public static final AttributeKey<String> K8S_CLUSTER_NAME =
       AttributeKey.stringKey("k8s.cluster.name");
 
+  public static final AttributeKey<String> AWS_ECS_CLUSTER_ARN =
+      AttributeKey.stringKey("aws.ecs.cluster.arn");
   public static final AttributeKey<String> AWS_ECS_CONTAINER_ARN =
       AttributeKey.stringKey("aws.ecs.container.arn");
   public static final AttributeKey<String> AWS_ECS_LAUNCHTYPE =

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.aws.resource;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_CLUSTER_ARN;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_CONTAINER_ARN;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_LAUNCHTYPE;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_TASK_ARN;
@@ -78,6 +79,7 @@ class EcsResourceTest {
             entry(CONTAINER_ID, "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946"),
             entry(CONTAINER_IMAGE_NAME, "nrdlngr/nginx-curl"),
             entry(io.opentelemetry.semconv.ResourceAttributes.CONTAINER_IMAGE_TAG, "latest"),
+            entry(AWS_ECS_CLUSTER_ARN, "arn:aws:ecs:us-east-2:012345678910:cluster/default"),
             entry(
                 AttributeKey.stringKey("aws.ecs.container.image.id"),
                 "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165"),
@@ -121,6 +123,7 @@ class EcsResourceTest {
             entry(
                 AttributeKey.stringKey("aws.ecs.container.image.id"),
                 "sha256:d691691e9652791a60114e67b365688d20d19940dde7c4736ea30e660d8d3553"),
+            entry(AWS_ECS_CLUSTER_ARN, "arn:aws:ecs:us-west-2:111122223333:cluster/default"),
             entry(
                 AWS_ECS_CONTAINER_ARN,
                 "arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9"),

--- a/aws-resources/src/test/resources/ecs-task-metadata-v4.json
+++ b/aws-resources/src/test/resources/ecs-task-metadata-v4.json
@@ -1,5 +1,5 @@
 {
-  "Cluster": "default",
+  "Cluster": "arn:aws:ecs:us-west-2:111122223333:cluster/default",
   "TaskARN": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
   "Family": "curltest",
   "Revision": "26",


### PR DESCRIPTION
**Description:**

< Describe what is being changed or added.
  Ex. Bug fix  - Describe the bug and how this fixes it.
  Ex. Feature addition - Describe what this provides and why. >

**[aws.ecs.cluster.arn](https://opentelemetry.io/docs/specs/semconv/attributes-registry/aws/)** is not populated in the ecs resource attributes.

This PR reads `Cluster` from ECS task metadata API, and sets `aws.ecs.cluster.arn` into resource attributes.

**Testing:**
UT passed.