### PR TITLE
Fix Tomcat metric definitions to aggregate multiple MBeans.

### DIFF
--- a/jmx-metrics/README.md
+++ b/jmx-metrics/README.md
@@ -35,6 +35,10 @@ Kafka metric-gathering scripts determined by the comma-separated list in `otel.j
 it will then run the scripts on the desired interval length of `otel.jmx.interval.milliseconds` and
 export the resulting metrics.
 
+Some metrics (e.g. `tomcat.sessions`) are configured to query multiple MBeans. By default, only the value in the first MBean
+is recorded for the metric and all other values are dropped. To aggregate the MBean values together, set the
+`otel.jmx.aggregate.across.mbeans` property to `true`.
+
 For custom metrics and unsupported targets, you can provide your own MBean querying scripts to produce
 OpenTelemetry instruments:
 

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -70,7 +70,7 @@ public class GroovyRunner {
     Binding binding = new Binding();
     binding.setVariable("log", logger);
 
-    OtelHelper otelHelper = new OtelHelper(jmxClient, this.groovyMetricEnvironment);
+    OtelHelper otelHelper = new OtelHelper(jmxClient, this.groovyMetricEnvironment, config.aggregateAcrossMBeans);
     binding.setVariable("otel", otelHelper);
 
     for (final Script script : scripts) {

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/GroovyRunner.java
@@ -70,7 +70,8 @@ public class GroovyRunner {
     Binding binding = new Binding();
     binding.setVariable("log", logger);
 
-    OtelHelper otelHelper = new OtelHelper(jmxClient, this.groovyMetricEnvironment, config.aggregateAcrossMBeans);
+    OtelHelper otelHelper =
+        new OtelHelper(jmxClient, this.groovyMetricEnvironment, config.aggregateAcrossMBeans);
     binding.setVariable("otel", otelHelper);
 
     for (final Script script : scripts) {

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/InstrumentHelper.groovy
@@ -181,18 +181,38 @@ class InstrumentHelper {
         return labels
     }
 
+    private static String getAggregationKey(String instrumentName, Map<String, String> labels) {
+        def labelsKey = labels.sort().collect { key, value -> "${key}:${value}" }.join(";")
+        return "${instrumentName}/${labelsKey}"
+    }
+
     // Create a closure for simple attributes that will retrieve mbean information on
     // callback to ensure that metrics are collected on request
     private Closure prepareUpdateClosure(List<GroovyMBean> mbeans, attributes) {
         return { result ->
+            def aggregations = [:] as Map<String, Aggregation>
+            boolean requireAggregation = mbeans.size() > 1 && instrumentIsValue(instrument)
             [mbeans, attributes].combinations().each { pair ->
                 def (mbean, attribute) = pair
                 def value = MBeanHelper.getBeanAttribute(mbean, attribute)
                 if (value != null) {
                     def labels = getLabels(mbean, labelFuncs, mBeanAttributes[attribute])
-                    logger.fine("Recording ${instrumentName} - ${instrument.method} w/ ${value} - ${labels}")
-                    recordDataPoint(instrument, result, value, GroovyMetricEnvironment.mapToAttributes(labels))
+                    if (requireAggregation) {
+                        def key = getAggregationKey(instrumentName, labels)
+                        if (aggregations[key] == null) {
+                            aggregations[key] = new Aggregation(labels)
+                        }
+                        logger.fine("Aggregating ${mbean.name()} ${instrumentName} - ${instrument.method} w/ ${value} - ${labels}")
+                        aggregations[key].add(value)
+                    } else {
+                        logger.fine("Recording ${mbean.name()} ${instrumentName} - ${instrument.method} w/ ${value} - ${labels}")
+                        recordDataPoint(instrument, result, value, GroovyMetricEnvironment.mapToAttributes(labels))
+                    }
                 }
+            }
+            aggregations.each { entry ->
+                logger.fine("Recording ${instrumentName} - ${instrument.method} - w/ ${entry.value.value} - ${entry.value.labels}")
+                recordDataPoint(instrument, result, entry.value.value, GroovyMetricEnvironment.mapToAttributes(entry.value.labels))
             }
         }
     }
@@ -253,6 +273,14 @@ class InstrumentHelper {
     }
 
     @PackageScope
+    static boolean instrumentIsValue(inst) {
+        return [
+            "doubleValueCallback",
+            "longValueCallback"
+        ].contains(inst.method)
+    }
+
+    @PackageScope
     static boolean instrumentIsCounter(inst) {
         return [
           "doubleCounter",
@@ -260,5 +288,19 @@ class InstrumentHelper {
           "longCounter",
           "longUpDownCounter"
         ].contains(inst.method)
+    }
+
+    static class Aggregation {
+        private final Map<String, String> labels
+        private def value
+
+        Aggregation(Map<String, String> labels) {
+            this.labels = labels
+            this.value = 0.0
+        }
+
+        void add(value) {
+            this.value += value
+        }
     }
 }

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -115,7 +115,8 @@ class JmxConfig {
     realm = properties.getProperty(JMX_REALM);
 
     registrySsl = Boolean.valueOf(properties.getProperty(REGISTRY_SSL));
-    aggregateAcrossMBeans = Boolean.parseBoolean(properties.getProperty(JMX_AGGREGATE_ACROSS_MBEANS));
+    aggregateAcrossMBeans =
+        Boolean.parseBoolean(properties.getProperty(JMX_AGGREGATE_ACROSS_MBEANS));
 
     // For the list of System Properties, if they have been set in the properties file
     // they need to be set in Java System Properties.

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/JmxConfig.java
@@ -31,6 +31,7 @@ class JmxConfig {
   static final String JMX_PASSWORD = PREFIX + "jmx.password";
   static final String JMX_REMOTE_PROFILE = PREFIX + "jmx.remote.profile";
   static final String JMX_REALM = PREFIX + "jmx.realm";
+  static final String JMX_AGGREGATE_ACROSS_MBEANS = PREFIX + "jmx.aggregate.across.mbeans";
 
   // These properties need to be copied into System Properties if provided via the property
   // file so that they are available to the JMX Connection builder
@@ -77,6 +78,8 @@ class JmxConfig {
   final boolean registrySsl;
   final Properties properties;
 
+  final boolean aggregateAcrossMBeans;
+
   JmxConfig(final Properties props) {
     properties = new Properties();
     // putAll() instead of using constructor defaults
@@ -112,6 +115,7 @@ class JmxConfig {
     realm = properties.getProperty(JMX_REALM);
 
     registrySsl = Boolean.valueOf(properties.getProperty(REGISTRY_SSL));
+    aggregateAcrossMBeans = Boolean.parseBoolean(properties.getProperty(JMX_AGGREGATE_ACROSS_MBEANS));
 
     // For the list of System Properties, if they have been set in the properties file
     // they need to be set in Java System Properties.

--- a/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
+++ b/jmx-metrics/src/main/groovy/io/opentelemetry/contrib/jmxmetrics/OtelHelper.groovy
@@ -22,10 +22,12 @@ class OtelHelper {
 
     private final JmxClient jmxClient
     private final GroovyMetricEnvironment groovyMetricEnvironment
+    private final boolean aggregateAcrossMBeans
 
-    OtelHelper(JmxClient jmxClient, GroovyMetricEnvironment groovyMetricEnvironment) {
+    OtelHelper(JmxClient jmxClient, GroovyMetricEnvironment groovyMetricEnvironment, boolean aggregateAcrossMBeans) {
         this.jmxClient = jmxClient
         this.groovyMetricEnvironment = groovyMetricEnvironment
+        this.aggregateAcrossMBeans = aggregateAcrossMBeans
     }
 
     /**
@@ -99,7 +101,7 @@ class OtelHelper {
      * attribute value(s).  The parameters map to the InstrumentHelper constructor.
      */
     InstrumentHelper instrument(MBeanHelper mBeanHelper, String instrumentName, String description, String unit, Map<String, Closure> labelFuncs, Map<String, Map<String, Closure>> attributes, Closure otelInstrument) {
-        def instrumentHelper = new InstrumentHelper(mBeanHelper, instrumentName, description, unit, labelFuncs, attributes, otelInstrument, groovyMetricEnvironment)
+        def instrumentHelper = new InstrumentHelper(mBeanHelper, instrumentName, description, unit, labelFuncs, attributes, otelInstrument, groovyMetricEnvironment, aggregateAcrossMBeans)
         instrumentHelper.update()
         return instrumentHelper
     }

--- a/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
@@ -15,10 +15,10 @@
  */
 
 
-def beantomcatmanager = otel.mbean("Catalina:type=Manager,host=localhost,context=*")
-otel.instrument(beantomcatmanager, "tomcat.sessions", "The number of active sessions.", "sessions", "activeSessions", otel.&doubleValueCallback)
+def beantomcatmanager = otel.mbeans("Catalina:type=Manager,host=localhost,context=*")
+otel.instrument(beantomcatmanager, "tomcat.sessions", "The number of active sessions.", "sessions", "activeSessions", otel.&longValueCallback)
 
-def beantomcatrequestProcessor = otel.mbean("Catalina:type=GlobalRequestProcessor,name=*")
+def beantomcatrequestProcessor = otel.mbeans("Catalina:type=GlobalRequestProcessor,name=*")
 otel.instrument(beantomcatrequestProcessor, "tomcat.errors", "The number of errors encountered.", "errors",
   ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
   "errorCount", otel.&longCounterCallback)
@@ -37,15 +37,15 @@ otel.instrument(beantomcatrequestProcessor, "tomcat.traffic",
   ["bytesReceived":["direction" : {"received"}], "bytesSent": ["direction" : {"sent"}]],
   otel.&longCounterCallback)
 
-def beantomcatconnectors = otel.mbean("Catalina:type=ThreadPool,name=*")
+def beantomcatconnectors = otel.mbeans("Catalina:type=ThreadPool,name=*")
 otel.instrument(beantomcatconnectors, "tomcat.threads", "The number of threads", "threads",
   ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
   ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)
 
-def beantomcatnewmanager = otel.mbean("Tomcat:type=Manager,host=localhost,context=*")
-otel.instrument(beantomcatnewmanager, "tomcat.sessions", "The number of active sessions.", "sessions", "activeSessions", otel.&doubleValueCallback)
+def beantomcatnewmanager = otel.mbeans("Tomcat:type=Manager,host=localhost,context=*")
+otel.instrument(beantomcatnewmanager, "tomcat.sessions", "The number of active sessions.", "sessions", "activeSessions", otel.&longValueCallback)
 
-def beantomcatnewrequestProcessor = otel.mbean("Tomcat:type=GlobalRequestProcessor,name=*")
+def beantomcatnewrequestProcessor = otel.mbeans("Tomcat:type=GlobalRequestProcessor,name=*")
 otel.instrument(beantomcatnewrequestProcessor, "tomcat.errors", "The number of errors encountered.", "errors",
     ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
     "errorCount", otel.&longCounterCallback)
@@ -64,7 +64,7 @@ otel.instrument(beantomcatnewrequestProcessor, "tomcat.traffic",
     ["bytesReceived":["direction" : {"received"}], "bytesSent": ["direction" : {"sent"}]],
     otel.&longCounterCallback)
 
-def beantomcatnewconnectors = otel.mbean("Tomcat:type=ThreadPool,name=*")
+def beantomcatnewconnectors = otel.mbeans("Tomcat:type=ThreadPool,name=*")
 otel.instrument(beantomcatnewconnectors, "tomcat.threads", "The number of threads", "threads",
     ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
     ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -540,8 +540,7 @@ class InstrumenterHelperTest {
 
     @SuppressWarnings("unchecked")
     private Consumer<DoublePointAssert>[] assertDoublePoint() {
-      return Stream.<Consumer<DoublePointAssert>>of(
-              point -> point.hasValue(123.456 * 4))
+      return Stream.<Consumer<DoublePointAssert>>of(point -> point.hasValue(123.456 * 4))
           .toArray(Consumer[]::new);
     }
 

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -96,7 +96,7 @@ class InstrumenterHelperTest {
     metricReader = InMemoryMetricReader.create();
     meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
     metricEnvironment = new GroovyMetricEnvironment(meterProvider, "otel.test");
-    otel = new OtelHelper(jmxClient, metricEnvironment);
+    otel = new OtelHelper(jmxClient, metricEnvironment, false);
   }
 
   @AfterEach
@@ -733,7 +733,8 @@ class InstrumenterHelperTest {
             labelFuncs,
             Collections.singletonMap(attribute, null),
             instrument,
-            metricEnvironment);
+            metricEnvironment,
+            false);
     instrumentHelper.update();
   }
 
@@ -754,7 +755,8 @@ class InstrumenterHelperTest {
             labelFuncs,
             attributes,
             instrument,
-            metricEnvironment);
+            metricEnvironment,
+            false);
     instrumentHelper.update();
   }
 

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -438,7 +438,13 @@ class InstrumenterHelperTest {
       String description = "multiple double gauge description";
 
       updateWithHelper(
-          mBeanHelper, instrumentMethod, instrumentName, description, "Double", new HashMap<>());
+          mBeanHelper,
+          instrumentMethod,
+          instrumentName,
+          description,
+          "Double",
+          new HashMap<>(),
+          /* aggregateAcrossMBeans= */ true);
 
       assertThat(metricReader.collectAllMetrics())
           .satisfiesExactly(
@@ -713,7 +719,13 @@ class InstrumenterHelperTest {
     labelFuncs.put(
         "labelTwo", (Closure<?>) Eval.me("{ mbean -> mbean.name().getKeyProperty('thing') }"));
     updateWithHelper(
-        mBeanHelper, instrumentMethod, instrumentName, description, attribute, labelFuncs);
+        mBeanHelper,
+        instrumentMethod,
+        instrumentName,
+        description,
+        attribute,
+        labelFuncs,
+        /* aggregateAcrossMBeans= */ false);
   }
 
   void updateWithHelper(
@@ -722,7 +734,8 @@ class InstrumenterHelperTest {
       String instrumentName,
       String description,
       String attribute,
-      Map<String, Closure<?>> labelFuncs) {
+      Map<String, Closure<?>> labelFuncs,
+      boolean aggregateAcrossMBeans) {
     Closure<?> instrument = (Closure<?>) Eval.me("otel", otel, "otel.&" + instrumentMethod);
     InstrumentHelper instrumentHelper =
         new InstrumentHelper(
@@ -734,7 +747,7 @@ class InstrumenterHelperTest {
             Collections.singletonMap(attribute, null),
             instrument,
             metricEnvironment,
-            false);
+            aggregateAcrossMBeans);
     instrumentHelper.update();
   }
 

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/InstrumenterHelperTest.java
@@ -429,7 +429,30 @@ class InstrumenterHelperTest {
     }
 
     @Test
-    void doubleValueCallbackMultipleMBeans() throws Exception {
+    void doubleValueCallbackMBeans() throws Exception {
+      String instrumentMethod = "doubleValueCallback";
+      String thingName = "multiple:type=" + instrumentMethod + ".Thing";
+      MBeanHelper mBeanHelper = registerThings(thingName);
+
+      String instrumentName = "multiple." + instrumentMethod + ".gauge";
+      String description = "multiple double gauge description";
+
+      updateWithHelper(
+          mBeanHelper, instrumentMethod, instrumentName, description, "Double", new HashMap<>());
+
+      assertThat(metricReader.collectAllMetrics())
+          .satisfiesExactly(
+              metric ->
+                  assertThat(metric)
+                      .hasName(instrumentName)
+                      .hasDescription(description)
+                      .hasUnit("1")
+                      .hasDoubleGaugeSatisfying(
+                          gauge -> gauge.hasPointsSatisfying(assertDoublePoint())));
+    }
+
+    @Test
+    void doubleValueCallbackListMBeans() throws Exception {
       String instrumentMethod = "doubleValueCallback";
       ArrayList<String> thingNames = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
@@ -513,6 +536,13 @@ class InstrumenterHelperTest {
                       .hasUnit("1")
                       .hasLongGaugeSatisfying(
                           gauge -> gauge.hasPointsSatisfying(assertLongPoints())));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<DoublePointAssert>[] assertDoublePoint() {
+      return Stream.<Consumer<DoublePointAssert>>of(
+              point -> point.hasValue(123.456 * 4))
+          .toArray(Consumer[]::new);
     }
 
     @SuppressWarnings("unchecked")
@@ -679,11 +709,22 @@ class InstrumenterHelperTest {
       String instrumentName,
       String description,
       String attribute) {
-    Closure<?> instrument = (Closure<?>) Eval.me("otel", otel, "otel.&" + instrumentMethod);
     Map<String, Closure<?>> labelFuncs = new HashMap<>();
     labelFuncs.put("labelOne", (Closure<?>) Eval.me("{ unused -> 'labelOneValue' }"));
     labelFuncs.put(
         "labelTwo", (Closure<?>) Eval.me("{ mbean -> mbean.name().getKeyProperty('thing') }"));
+    updateWithHelper(
+        mBeanHelper, instrumentMethod, instrumentName, description, attribute, labelFuncs);
+  }
+
+  void updateWithHelper(
+      MBeanHelper mBeanHelper,
+      String instrumentMethod,
+      String instrumentName,
+      String description,
+      String attribute,
+      Map<String, Closure<?>> labelFuncs) {
+    Closure<?> instrument = (Closure<?>) Eval.me("otel", otel, "otel.&" + instrumentMethod);
     InstrumentHelper instrumentHelper =
         new InstrumentHelper(
             mBeanHelper,

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/JmxConfigTest.java
@@ -52,6 +52,7 @@ class JmxConfigTest {
     assertThat(config.remoteProfile).isNull();
     assertThat(config.realm).isNull();
     assertThat(config.properties.getProperty("otel.metric.export.interval")).isEqualTo("10000");
+    assertThat(config.aggregateAcrossMBeans).isFalse();
   }
 
   @Test
@@ -87,6 +88,7 @@ class JmxConfigTest {
     assertThat(config.password).isEqualTo("myPassword");
     assertThat(config.remoteProfile).isEqualTo("myRemoteProfile");
     assertThat(config.realm).isEqualTo("myRealm");
+    assertThat(config.aggregateAcrossMBeans).isFalse();
   }
 
   @Test
@@ -109,6 +111,7 @@ class JmxConfigTest {
     assertThat(config.password).isEqualTo("myPassw\\ord");
     assertThat(config.remoteProfile).isEqualTo("SASL/DIGEST-MD5");
     assertThat(config.realm).isEqualTo("myRealm");
+    assertThat(config.aggregateAcrossMBeans).isTrue();
 
     // These properties are set from the config file loading into JmxConfig
     assertThat(System.getProperty("javax.net.ssl.keyStore")).isEqualTo("/my/key/store");

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperAsynchronousMetricTest.java
@@ -29,7 +29,7 @@ class OtelHelperAsynchronousMetricTest {
   void setUp() {
     metricReader = InMemoryMetricReader.create();
     meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
-    otel = new OtelHelper(null, new GroovyMetricEnvironment(meterProvider, "otel.test"));
+    otel = new OtelHelper(null, new GroovyMetricEnvironment(meterProvider, "otel.test"), false);
   }
 
   @Test

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperJmxTest.java
@@ -132,7 +132,7 @@ class OtelHelperJmxTest {
   }
 
   private static OtelHelper setupHelper(JmxConfig config) throws Exception {
-    return new OtelHelper(new JmxClient(config), new GroovyMetricEnvironment(config));
+    return new OtelHelper(new JmxClient(config), new GroovyMetricEnvironment(config), false);
   }
 
   private static void verifyClient(Properties props) throws Exception {

--- a/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.java
+++ b/jmx-metrics/src/test/java/io/opentelemetry/contrib/jmxmetrics/OtelHelperSynchronousMetricTest.java
@@ -33,7 +33,7 @@ class OtelHelperSynchronousMetricTest {
   void setUp() {
     metricReader = InMemoryMetricReader.create();
     meterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build();
-    otel = new OtelHelper(null, new GroovyMetricEnvironment(meterProvider, "otel.test"));
+    otel = new OtelHelper(null, new GroovyMetricEnvironment(meterProvider, "otel.test"), false);
   }
 
   @Test

--- a/jmx-metrics/src/test/resources/all.properties
+++ b/jmx-metrics/src/test/resources/all.properties
@@ -19,3 +19,4 @@ javax.net.ssl.keyStoreType=JKS
 javax.net.ssl.trustStore=/my/trust/store
 javax.net.ssl.trustStorePassword=def456
 javax.net.ssl.trustStoreType=JKS
+otel.jmx.aggregate.across.mbeans=true


### PR DESCRIPTION
**Description:** Bug fix - The current Tomcat metric definitions use the `otel.mbean` constructor function, which expects the query to the MBean server to return a single MBean. If multiple mbeans are returned, it takes the first one and drops the rest, which results in inaccurate/incomplete metric values. The tomcat metrics are all defined with wildcards (`*`), which are meant to match multiple MBeans.

Changed the Tomcat metric definitions to use `otel.mbeans` instead, so metric values aren't being dropped. Added an aggregation for `doubleValueCallback/longValueCallback` since both of those observable instruments will [only accept the first value](https://github.com/open-telemetry/opentelemetry-java/blob/b56af03b995f1d0da7a1bc91a9588600d02faabd/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/state/AsynchronousMetricStorage.java#L153) per collection interval.

**Existing Issue(s):** https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1360

**Testing:** Added a unit test in the `InstrumenterHelperTest` to account validate the aggregation.

<img width="1308" alt="image" src="https://github.com/open-telemetry/opentelemetry-java-contrib/assets/84729962/894242f9-6c8f-491e-948d-7cf2b6533e6a">

<img width="1233" alt="image" src="https://github.com/open-telemetry/opentelemetry-java-contrib/assets/84729962/42362891-12c2-4da7-b13f-fc8147c2cdb5">


**Documentation:** N/A

**Outstanding items:** Some activemq and jetty metric definitions need to be adjusted to `otel.mbeans` and tested.
