### PR TITLE
add span stacktrace config option

### DIFF
--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -47,6 +47,7 @@ Even if autoconfiguration is not yet supported, usages of this module must use t
 allow consistent configuration across usages.
 
 The following constants are provided as a convenience:
+
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION`
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
 

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -54,7 +54,7 @@ The following constants are provided as a convenience:
 This means the default for this feature will capture a stacktrace for all spans that last 5ms or more,
 disabling it must be allowed by setting a negative value to `otel.span.stacktrace.min.duration`.
 Setting `otel.span.stacktrace.min.duration` to zero means a stacktrace will be captured for all
-spans without span duration limit.
+spans.
 
 ## Component owners
 

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -50,6 +50,9 @@ The following constants are provided as a convenience:
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION`
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
 
+It means default this feature will capture a stacktrace for all spans that last 5ms or more,
+disabling it must be allowed by setting `otel.span.stacktrace.min.duration` zero or less.
+
 ## Component owners
 
 - [Jack Shirazi](https://github.com/jackshirazi), Elastic

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -51,9 +51,9 @@ The following constants are provided as a convenience:
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION`
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
 
-It means default this feature will capture a stacktrace for all spans that last 5ms or more,
+This means the default for this feature will capture a stacktrace for all spans that last 5ms or more,
 disabling it must be allowed by setting a negative value to `otel.span.stacktrace.min.duration`.
-Setting `otel.span.stacktrace.min.duration` to zero means stacktrace will be captured for all
+Setting `otel.span.stacktrace.min.duration` to zero means a stacktrace will be captured for all
 spans without span duration limit.
 
 ## Component owners

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -43,7 +43,7 @@ OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvid
 ### Configuration
 
 Even if autoconfiguration is not yet supported, usages of this module must use the
-`otel.span.stacktrace.min.duration` configuration option (in nanoseconds, defaults to 5ms) to
+`otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) to
 allow consistent configuration across usages.
 
 The following constants are provided as a convenience:

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -40,6 +40,16 @@ SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
 OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
 ```
 
+### Configuration
+
+Even if autoconfiguration is not yet supported, usages of this module must use the
+`otel.span.stacktrace.min.duration` configuration option (in nanoseconds, defaults to 5ms) to
+allow consistent configuration across usages.
+
+The following constants are provided as a convenience:
+- `StackTraceSpanProcessor.CONFIG_MIN_DURATION`
+- `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
+
 ## Component owners
 
 - [Jack Shirazi](https://github.com/jackshirazi), Elastic

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -27,6 +27,10 @@ will be ignored.
 InMemorySpanExporter spansExporter = InMemorySpanExporter.create();
 SpanProcessor exportProcessor = SimpleSpanProcessor.create(spansExporter);
 
+Map<String, String> configMap = new HashMap<>();
+configMap.put("otel.span.stacktrace.min.duration", "1ms");
+ConfigProperties config = DefaultConfigProperties.createFromMap(configMap);
+
 Predicate<ReadableSpan> filterPredicate = readableSpan -> {
   if(readableSpan.getAttribute(AttributeKey.stringKey("ignorespan")) != null){
     return false;
@@ -34,7 +38,7 @@ Predicate<ReadableSpan> filterPredicate = readableSpan -> {
   return true;
 };
 SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-    .addSpanProcessor(new StackTraceSpanProcessor(exportProcessor, 1000, filterPredicate))
+    .addSpanProcessor(new StackTraceSpanProcessor(exportProcessor, config, filterPredicate))
     .build();
 
 OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
@@ -42,19 +46,11 @@ OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvid
 
 ### Configuration
 
-Even if autoconfiguration is not yet supported, usages of this module must use the
-`otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) to
-allow consistent configuration across usages.
+The `otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) allows to configure
+the minimal duration for which spans should have a stacktrace captured.
 
-The following constants are provided as a convenience:
-
-- `StackTraceSpanProcessor.CONFIG_MIN_DURATION`
-- `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
-
-This means the default for this feature will capture a stacktrace for all spans that last 5ms or more,
-disabling it must be allowed by setting a negative value to `otel.span.stacktrace.min.duration`.
-Setting `otel.span.stacktrace.min.duration` to zero means a stacktrace will be captured for all
-spans.
+Setting `otel.span.stacktrace.min.duration` to zero will include all spans, and using a negative
+value will disable the feature.
 
 ## Component owners
 

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -28,7 +28,7 @@ InMemorySpanExporter spansExporter = InMemorySpanExporter.create();
 SpanProcessor exportProcessor = SimpleSpanProcessor.create(spansExporter);
 
 Map<String, String> configMap = new HashMap<>();
-configMap.put("otel.span.stacktrace.min.duration", "1ms");
+configMap.put("otel.java.experimental.span-stacktrace.min.duration", "1ms");
 ConfigProperties config = DefaultConfigProperties.createFromMap(configMap);
 
 Predicate<ReadableSpan> filterPredicate = readableSpan -> {
@@ -46,10 +46,10 @@ OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvid
 
 ### Configuration
 
-The `otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) allows configuring
+The `otel.java.experimental.span-stacktrace.min.duration` configuration option (defaults to 5ms) allows configuring
 the minimal duration for which spans should have a stacktrace captured.
 
-Setting `otel.span.stacktrace.min.duration` to zero will include all spans, and using a negative
+Setting `otel.java.experimental.span-stacktrace.min.duration` to zero will include all spans, and using a negative
 value will disable the feature.
 
 ## Component owners

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -52,7 +52,9 @@ The following constants are provided as a convenience:
 - `StackTraceSpanProcessor.CONFIG_MIN_DURATION_DEFAULT`
 
 It means default this feature will capture a stacktrace for all spans that last 5ms or more,
-disabling it must be allowed by setting `otel.span.stacktrace.min.duration` zero or less.
+disabling it must be allowed by setting a negative value to `otel.span.stacktrace.min.duration`.
+Setting `otel.span.stacktrace.min.duration` to zero means stacktrace will be captured for all
+spans without span duration limit.
 
 ## Component owners
 

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -20,7 +20,7 @@ section below to configure it.
 ### Manual SDK setup
 
 Here is an example registration of `StackTraceSpanProcessor` to capture stack trace for all
-the spans that have a duration >= 1000 ns. The spans that have an `ignorespan` string attribute
+the spans that have a duration >= 1 ms. The spans that have an `ignorespan` string attribute
 will be ignored.
 
 ```java

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -46,7 +46,7 @@ OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvid
 
 ### Configuration
 
-The `otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) allows to configure
+The `otel.span.stacktrace.min.duration` configuration option (defaults to 5ms) allows configuring
 the minimal duration for which spans should have a stacktrace captured.
 
 Setting `otel.span.stacktrace.min.duration` to zero will include all spans, and using a negative

--- a/span-stacktrace/build.gradle.kts
+++ b/span-stacktrace/build.gradle.kts
@@ -10,5 +10,10 @@ dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
 }

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -44,16 +44,13 @@ public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor
     this.minSpanDurationNanos = minSpanDurationNanos;
     this.filterPredicate = filterPredicate;
     if (minSpanDurationNanos < 0) {
-      logger.log(
-          Level.FINE,
-          "Stack traces capture is disabled");
+      logger.log(Level.FINE, "Stack traces capture is disabled");
     } else {
       logger.log(
           Level.FINE,
           "Stack traces will be added to spans with a minimum duration of {0} nanos",
           minSpanDurationNanos);
     }
-
   }
 
   /**
@@ -61,12 +58,13 @@ public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor
    * @param config configuration
    * @param filterPredicate extra filter function to exclude spans if needed
    */
-  public StackTraceSpanProcessor(SpanProcessor next, ConfigProperties config,
-      Predicate<ReadableSpan> filterPredicate) {
-    this(next, config.getDuration(CONFIG_MIN_DURATION, CONFIG_MIN_DURATION_DEFAULT).toNanos(),
+  public StackTraceSpanProcessor(
+      SpanProcessor next, ConfigProperties config, Predicate<ReadableSpan> filterPredicate) {
+    this(
+        next,
+        config.getDuration(CONFIG_MIN_DURATION, CONFIG_MIN_DURATION_DEFAULT).toNanos(),
         filterPredicate);
   }
-
 
   @Override
   protected boolean requiresStart() {

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -20,8 +20,8 @@ import java.util.logging.Logger;
 
 public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor {
 
-  public static final String CONFIG_MIN_DURATION = "otel.span.stacktrace.min.duration";
-  public static final Duration CONFIG_MIN_DURATION_DEFAULT = Duration.ofMillis(5);
+  private static final String CONFIG_MIN_DURATION = "otel.span.stacktrace.min.duration";
+  private static final Duration CONFIG_MIN_DURATION_DEFAULT = Duration.ofMillis(5);
 
   // inlined incubating attribute to prevent direct dependency on incubating semconv
   private static final AttributeKey<String> SPAN_STACKTRACE =

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -12,11 +12,15 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Duration;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor {
+
+  public static final String CONFIG_MIN_DURATION = "otel.span.stacktrace.min.duration";
+  public static final Duration CONFIG_MIN_DURATION_DEFAULT = Duration.ofMillis(5);
 
   // inlined incubating attribute to prevent direct dependency on incubating semconv
   private static final AttributeKey<String> SPAN_STACKTRACE =

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -20,7 +20,8 @@ import java.util.logging.Logger;
 
 public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor {
 
-  private static final String CONFIG_MIN_DURATION = "otel.java.experimental.span-stacktrace.min.duration";
+  private static final String CONFIG_MIN_DURATION =
+      "otel.java.experimental.span-stacktrace.min.duration";
   private static final Duration CONFIG_MIN_DURATION_DEFAULT = Duration.ofMillis(5);
 
   // inlined incubating attribute to prevent direct dependency on incubating semconv

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 
 public class StackTraceSpanProcessor extends AbstractSimpleChainingSpanProcessor {
 
-  private static final String CONFIG_MIN_DURATION = "otel.span.stacktrace.min.duration";
+  private static final String CONFIG_MIN_DURATION = "otel.java.experimental.span-stacktrace.min.duration";
   private static final Duration CONFIG_MIN_DURATION_DEFAULT = Duration.ofMillis(5);
 
   // inlined incubating attribute to prevent direct dependency on incubating semconv

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
@@ -13,58 +13,72 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.contrib.stacktrace.internal.TestUtils;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.semconv.incubating.CodeIncubatingAttributes;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class StackTraceSpanProcessorTest {
 
-  private InMemorySpanExporter spansExporter;
-  private SpanProcessor exportProcessor;
-
-  @BeforeEach
-  public void setup() {
-    spansExporter = InMemorySpanExporter.create();
-    exportProcessor = SimpleSpanProcessor.create(spansExporter);
+  private static long msToNs(int ms) {
+    return Duration.ofMillis(ms).toNanos();
   }
 
   @Test
   void durationAndFiltering() {
+    // on duration threshold
+    checkSpanWithStackTrace(span -> true, "1ms", msToNs(1));
     // over duration threshold
-    testSpan(span -> true, 11, 1);
+    checkSpanWithStackTrace(span -> true, "1ms", msToNs(2));
     // under duration threshold
-    testSpan(span -> true, 9, 0);
+    checkSpanWithoutStackTrace(span -> true, "2ms", msToNs(1));
 
     // filtering out span
-    testSpan(span -> false, 20, 0);
+    checkSpanWithoutStackTrace(span -> false, "1ms", 20);
+  }
+
+  @Test
+  void defaultConfig() {
+    long expectedDefault = msToNs(5);
+    checkSpanWithStackTrace(span -> true, null, expectedDefault);
+    checkSpanWithStackTrace(span -> true, null, expectedDefault + 1);
+    checkSpanWithoutStackTrace(span -> true, null, expectedDefault - 1);
+  }
+
+  @Test
+  void disabledConfig() {
+    checkSpanWithoutStackTrace(span -> true, "-1", 5);
   }
 
   @Test
   void spanWithExistingStackTrace() {
-    testSpan(
+    checkSpan(
         span -> true,
-        20,
-        1,
+        "1ms",
+        Duration.ofMillis(1).toNanos(),
         sb -> sb.setAttribute(CodeIncubatingAttributes.CODE_STACKTRACE, "hello"),
         stacktrace -> assertThat(stacktrace).isEqualTo("hello"));
   }
 
-  private void testSpan(
-      Predicate<ReadableSpan> filterPredicate, long spanDurationNanos, int expectedSpansCount) {
-    testSpan(
+  private static void checkSpanWithStackTrace(
+      Predicate<ReadableSpan> filterPredicate, String configString,
+      long spanDurationNanos) {
+    checkSpan(
         filterPredicate,
+        configString,
         spanDurationNanos,
-        expectedSpansCount,
         Function.identity(),
         (stackTrace) ->
             assertThat(stackTrace)
@@ -72,14 +86,39 @@ class StackTraceSpanProcessorTest {
                 .contains(StackTraceSpanProcessorTest.class.getCanonicalName()));
   }
 
-  private void testSpan(
+  private static void checkSpanWithoutStackTrace(
+      Predicate<ReadableSpan> filterPredicate, String configString,
+      long spanDurationNanos) {
+    checkSpan(
+        filterPredicate,
+        configString,
+        spanDurationNanos,
+        Function.identity(),
+        (stackTrace) ->
+            assertThat(stackTrace)
+                .describedAs("no stack trace expected")
+                .isNull());
+  }
+
+  private static void checkSpan(
       Predicate<ReadableSpan> filterPredicate,
+      String configString,
       long spanDurationNanos,
-      int expectedSpansCount,
       Function<SpanBuilder, SpanBuilder> customizeSpanBuilder,
       Consumer<String> stackTraceCheck) {
+
+    // they must be re-created as they are shutdown when the span processor is closed
+    InMemorySpanExporter spansExporter = InMemorySpanExporter.create();
+    SpanProcessor exportProcessor = SimpleSpanProcessor.create(spansExporter);
+
+    Map<String, String> configMap = new HashMap<>();
+    if (configString != null) {
+      configMap.put("otel.span.stacktrace.min.duration", configString);
+    }
+
     try (SpanProcessor processor =
-        new StackTraceSpanProcessor(exportProcessor, 10, filterPredicate)) {
+        new StackTraceSpanProcessor(exportProcessor,
+            DefaultConfigProperties.createFromMap(configMap), filterPredicate)) {
 
       OpenTelemetrySdk sdk = TestUtils.sdkWith(processor);
       Tracer tracer = sdk.getTracer("test");
@@ -96,14 +135,12 @@ class StackTraceSpanProcessorTest {
       }
 
       List<SpanData> finishedSpans = spansExporter.getFinishedSpanItems();
-      assertThat(finishedSpans).hasSize(expectedSpansCount);
+      assertThat(finishedSpans).hasSize(1);
 
-      if (!finishedSpans.isEmpty()) {
-        String stackTrace =
-            finishedSpans.get(0).getAttributes().get(CodeIncubatingAttributes.CODE_STACKTRACE);
+      String stackTrace = finishedSpans.get(0).getAttributes()
+          .get(CodeIncubatingAttributes.CODE_STACKTRACE);
 
-        stackTraceCheck.accept(stackTrace);
-      }
+      stackTraceCheck.accept(stackTrace);
     }
   }
 }

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
@@ -73,8 +73,7 @@ class StackTraceSpanProcessorTest {
   }
 
   private static void checkSpanWithStackTrace(
-      Predicate<ReadableSpan> filterPredicate, String configString,
-      long spanDurationNanos) {
+      Predicate<ReadableSpan> filterPredicate, String configString, long spanDurationNanos) {
     checkSpan(
         filterPredicate,
         configString,
@@ -87,17 +86,13 @@ class StackTraceSpanProcessorTest {
   }
 
   private static void checkSpanWithoutStackTrace(
-      Predicate<ReadableSpan> filterPredicate, String configString,
-      long spanDurationNanos) {
+      Predicate<ReadableSpan> filterPredicate, String configString, long spanDurationNanos) {
     checkSpan(
         filterPredicate,
         configString,
         spanDurationNanos,
         Function.identity(),
-        (stackTrace) ->
-            assertThat(stackTrace)
-                .describedAs("no stack trace expected")
-                .isNull());
+        (stackTrace) -> assertThat(stackTrace).describedAs("no stack trace expected").isNull());
   }
 
   private static void checkSpan(
@@ -117,8 +112,8 @@ class StackTraceSpanProcessorTest {
     }
 
     try (SpanProcessor processor =
-        new StackTraceSpanProcessor(exportProcessor,
-            DefaultConfigProperties.createFromMap(configMap), filterPredicate)) {
+        new StackTraceSpanProcessor(
+            exportProcessor, DefaultConfigProperties.createFromMap(configMap), filterPredicate)) {
 
       OpenTelemetrySdk sdk = TestUtils.sdkWith(processor);
       Tracer tracer = sdk.getTracer("test");
@@ -137,8 +132,8 @@ class StackTraceSpanProcessorTest {
       List<SpanData> finishedSpans = spansExporter.getFinishedSpanItems();
       assertThat(finishedSpans).hasSize(1);
 
-      String stackTrace = finishedSpans.get(0).getAttributes()
-          .get(CodeIncubatingAttributes.CODE_STACKTRACE);
+      String stackTrace =
+          finishedSpans.get(0).getAttributes().get(CodeIncubatingAttributes.CODE_STACKTRACE);
 
       stackTraceCheck.accept(stackTrace);
     }

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
@@ -108,7 +108,7 @@ class StackTraceSpanProcessorTest {
 
     Map<String, String> configMap = new HashMap<>();
     if (configString != null) {
-      configMap.put("otel.span.stacktrace.min.duration", configString);
+      configMap.put("otel.java.experimental.span-stacktrace.min.duration", configString);
     }
 
     try (SpanProcessor processor =


### PR DESCRIPTION
**Description:**

Span stacktrace module can't use autoconfiguration for now as it relies on a strict ordering of the span processors. The addition of `OnEnding` callback would unblock this but it's not available yet (https://github.com/open-telemetry/opentelemetry-java/pull/6367).

While autoconfiguration is still not supported, this PR adds a way to provide a `ConfigProperties` for configuration, which allows to
- define configuration option and default value
- implement configuration in a consistent way across usages

Configuration option name `otel.java.experimental.span-stacktrace.min.duration`
Default value: `5ms`
