### PR TITLE
Fix incorrect SDK version included in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,10 +132,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          instrumentation_version=$(grep -Po "val otelInstrumentationVersion = \"\K[0-9]+.[0-9]+.[0-9]+" dependencyManagement/build.gradle.kts)
+
           # conditional blocks not indented because of the heredoc
           if [[ $VERSION == *.0 ]]; then
           cat > /tmp/release-notes.txt << EOF
-          This release targets the OpenTelemetry SDK $VERSION.
+          This release targets the OpenTelemetry Java Instrumentation
+          [$instrumentation_version](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v$instrumentation_version).
 
           EOF
           else

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -7,13 +7,15 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
+val otelInstrumentationVersion = "2.7.0-alpha"
+
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.17.2",
   "com.google.guava:guava-bom:33.2.1-jre",
   "com.linecorp.armeria:armeria-bom:1.30.0",
   "org.junit:junit-bom:5.11.0",
   "io.grpc:grpc-bom:1.66.0",
-  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.7.0-alpha",
+  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}",
   "org.testcontainers:testcontainers-bom:1.20.1"
 )
 


### PR DESCRIPTION
It doesn't seem easy to get the SDK version automatically since we're using it through a transitive dependency on the instrumentation repo, so went with the easy fix to include link to the Instrumentation release where you can see the targeted SDK version.