### PR TITLE
[disk-buffering] Add debug mode for verbose logging.

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
@@ -25,6 +25,7 @@ public class LogRecordFromDiskExporter implements FromDiskExporter {
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofLogs())
             .setExportFunction(exporter::export)
+            .setDebugEnabled(config.isDebugEnabled())
             .build();
     return new LogRecordFromDiskExporter(delegate);
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class LogRecordFromDiskExporter implements FromDiskExporter {
       LogRecordExporter exporter, StorageConfiguration config) throws IOException {
     FromDiskExporterImpl<LogRecordData> delegate =
         FromDiskExporterImpl.<LogRecordData>builder()
-            .setFolderName("logs")
+            .setFolderName(SignalTypes.logs.name())
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofLogs())
             .setExportFunction(exporter::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordToDiskExporter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.disk.buffering;
 
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.ToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
@@ -32,7 +33,7 @@ public class LogRecordToDiskExporter implements LogRecordExporter {
       LogRecordExporter delegate, StorageConfiguration config) throws IOException {
     ToDiskExporter<LogRecordData> toDisk =
         ToDiskExporter.<LogRecordData>builder()
-            .setFolderName("logs")
+            .setFolderName(SignalTypes.logs.name())
             .setStorageConfiguration(config)
             .setSerializer(SignalSerializer.ofLogs())
             .setExportFunction(delegate::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class MetricFromDiskExporter implements FromDiskExporter {
       throws IOException {
     FromDiskExporterImpl<MetricData> delegate =
         FromDiskExporterImpl.<MetricData>builder()
-            .setFolderName("metrics")
+            .setFolderName(SignalTypes.metrics.name())
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofMetrics())
             .setExportFunction(exporter::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
@@ -25,6 +25,7 @@ public class MetricFromDiskExporter implements FromDiskExporter {
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofMetrics())
             .setExportFunction(exporter::export)
+            .setDebugEnabled(config.isDebugEnabled())
             .build();
     return new MetricFromDiskExporter(delegate);
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.disk.buffering;
 
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.ToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
@@ -42,7 +43,7 @@ public class MetricToDiskExporter implements MetricExporter {
       throws IOException {
     ToDiskExporter<MetricData> toDisk =
         ToDiskExporter.<MetricData>builder()
-            .setFolderName("metrics")
+            .setFolderName(SignalTypes.metrics.name())
             .setStorageConfiguration(config)
             .setSerializer(SignalSerializer.ofMetrics())
             .setExportFunction(delegate::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
@@ -25,6 +25,7 @@ public class SpanFromDiskExporter implements FromDiskExporter {
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofSpans())
             .setExportFunction(exporter::export)
+            .setDebugEnabled(config.isDebugEnabled())
             .build();
     return new SpanFromDiskExporter(delegate);
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.disk.buffering;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class SpanFromDiskExporter implements FromDiskExporter {
       throws IOException {
     FromDiskExporterImpl<SpanData> delegate =
         FromDiskExporterImpl.<SpanData>builder()
-            .setFolderName("spans")
+            .setFolderName(SignalTypes.spans.name())
             .setStorageConfiguration(config)
             .setDeserializer(SignalDeserializer.ofSpans())
             .setExportFunction(exporter::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanToDiskExporter.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.disk.buffering;
 
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.ToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -33,7 +34,7 @@ public class SpanToDiskExporter implements SpanExporter {
       throws IOException {
     ToDiskExporter<SpanData> toDisk =
         ToDiskExporter.<SpanData>builder()
-            .setFolderName("spans")
+            .setFolderName(SignalTypes.spans.name())
             .setStorageConfiguration(config)
             .setSerializer(SignalSerializer.ofSpans())
             .setExportFunction(delegate::export)

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/StorageConfiguration.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/StorageConfiguration.java
@@ -18,6 +18,9 @@ public abstract class StorageConfiguration {
   /** The root storage location for buffered telemetry. */
   public abstract File getRootDir();
 
+  /** Returns true if the storage has been configured with debug verbosity enabled. */
+  public abstract boolean isDebugEnabled();
+
   /** The max amount of time a file can receive new data. */
   public abstract long getMaxFileAgeForWriteMillis();
 
@@ -62,6 +65,7 @@ public abstract class StorageConfiguration {
         .setMaxFileAgeForWriteMillis(TimeUnit.SECONDS.toMillis(30))
         .setMinFileAgeForReadMillis(TimeUnit.SECONDS.toMillis(33))
         .setMaxFileAgeForReadMillis(TimeUnit.HOURS.toMillis(18))
+        .setDebugEnabled(false)
         .setTemporaryFileProvider(fileProvider);
   }
 
@@ -80,6 +84,8 @@ public abstract class StorageConfiguration {
     public abstract Builder setTemporaryFileProvider(TemporaryFileProvider value);
 
     public abstract Builder setRootDir(File rootDir);
+
+    public abstract Builder setDebugEnabled(boolean debugEnabled);
 
     public abstract StorageConfiguration build();
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
@@ -66,6 +66,11 @@ public class FromDiskExporterBuilder<T> {
   }
 
   @CanIgnoreReturnValue
+  public FromDiskExporterBuilder<T> enableDebug() {
+    return setDebugEnabled(true);
+  }
+
+  @CanIgnoreReturnValue
   public FromDiskExporterBuilder<T> setDebugEnabled(boolean debugEnabled) {
     this.debugEnabled = debugEnabled;
     return this;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterBuilder.java
@@ -25,6 +25,8 @@ public class FromDiskExporterBuilder<T> {
   private Function<Collection<T>, CompletableResultCode> exportFunction =
       x -> CompletableResultCode.ofFailure();
 
+  private boolean debugEnabled = false;
+
   @NotNull
   private static <T> SignalDeserializer<T> noopDeserializer() {
     return x -> emptyList();
@@ -63,8 +65,14 @@ public class FromDiskExporterBuilder<T> {
     return this;
   }
 
+  @CanIgnoreReturnValue
+  public FromDiskExporterBuilder<T> setDebugEnabled(boolean debugEnabled) {
+    this.debugEnabled = debugEnabled;
+    return this;
+  }
+
   public FromDiskExporterImpl<T> build() throws IOException {
     Storage storage = storageBuilder.build();
-    return new FromDiskExporterImpl<>(serializer, exportFunction, storage);
+    return new FromDiskExporterImpl<>(serializer, exportFunction, storage, debugEnabled);
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
@@ -11,6 +11,7 @@ import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.Readab
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -21,18 +22,21 @@ import java.util.logging.Logger;
  * another delegated exporter.
  */
 public final class FromDiskExporterImpl<EXPORT_DATA> implements FromDiskExporter {
+  private static final Logger logger = Logger.getLogger(FromDiskExporterImpl.class.getName());
   private final Storage storage;
   private final SignalDeserializer<EXPORT_DATA> deserializer;
   private final Function<Collection<EXPORT_DATA>, CompletableResultCode> exportFunction;
-  private static final Logger logger = Logger.getLogger(FromDiskExporterImpl.class.getName());
+  private final boolean debugEnabled;
 
   FromDiskExporterImpl(
       SignalDeserializer<EXPORT_DATA> deserializer,
       Function<Collection<EXPORT_DATA>, CompletableResultCode> exportFunction,
-      Storage storage) {
+      Storage storage,
+      boolean debugEnabled) {
     this.deserializer = deserializer;
     this.exportFunction = exportFunction;
     this.storage = storage;
+    this.debugEnabled = debugEnabled;
   }
 
   public static <T> FromDiskExporterBuilder<T> builder() {
@@ -44,22 +48,34 @@ public final class FromDiskExporterImpl<EXPORT_DATA> implements FromDiskExporter
    *
    * @param timeout The amount of time to wait for the wrapped exporter to finish.
    * @param unit The unit of the time provided.
-   * @return true if there was data available and it was successfully exported within the timeout
+   * @return true if there was data available, and it was successfully exported within the timeout
    *     provided. false otherwise.
    * @throws IOException If an unexpected error happens.
    */
   @Override
   public boolean exportStoredBatch(long timeout, TimeUnit unit) throws IOException {
-    logger.log(Level.INFO, "Attempting to export batch from disk.");
+    log("Attempting to export " + deserializer.signalType() + " batch from disk.");
     ReadableResult result =
         storage.readAndProcess(
             bytes -> {
-              logger.log(Level.INFO, "About to export stored batch.");
-              CompletableResultCode join =
-                  exportFunction.apply(deserializer.deserialize(bytes)).join(timeout, unit);
+              log(
+                  "Read "
+                      + bytes.length
+                      + " "
+                      + deserializer.signalType()
+                      + " bytes from storage.");
+              List<EXPORT_DATA> telemetry = deserializer.deserialize(bytes);
+              log("Now exporting batch of " + telemetry.size() + " " + deserializer.signalType());
+              CompletableResultCode join = exportFunction.apply(telemetry).join(timeout, unit);
               return join.isSuccess();
             });
     return result == ReadableResult.SUCCEEDED;
+  }
+
+  private void log(String msg) {
+    if (debugEnabled) {
+      logger.log(Level.INFO, msg);
+    }
   }
 
   @Override

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
@@ -24,8 +24,20 @@ public final class ToDiskExporterBuilder<T> {
 
   private Function<Collection<T>, CompletableResultCode> exportFunction =
       x -> CompletableResultCode.ofFailure();
+  private boolean debugEnabled = false;
 
   ToDiskExporterBuilder() {}
+
+  @CanIgnoreReturnValue
+  public ToDiskExporterBuilder<T> enableDebug() {
+    return setDebugEnabled(true);
+  }
+
+  @CanIgnoreReturnValue
+  public ToDiskExporterBuilder<T> setDebugEnabled(boolean debugEnabled) {
+    this.debugEnabled = debugEnabled;
+    return this;
+  }
 
   @CanIgnoreReturnValue
   public ToDiskExporterBuilder<T> setFolderName(String folderName) {
@@ -61,7 +73,7 @@ public final class ToDiskExporterBuilder<T> {
 
   public ToDiskExporter<T> build() throws IOException {
     Storage storage = storageBuilder.build();
-    return new ToDiskExporter<>(serializer, exportFunction, storage);
+    return new ToDiskExporter<>(serializer, exportFunction, storage, debugEnabled);
   }
 
   private static void validateConfiguration(StorageConfiguration configuration) {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.ProtoLogsDataMapper;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.proto.logs.v1.LogsData;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.io.IOException;
@@ -31,6 +32,6 @@ public final class LogRecordDataDeserializer implements SignalDeserializer<LogRe
 
   @Override
   public String signalType() {
-    return "logs";
+    return SignalTypes.logs.name();
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
@@ -28,4 +28,9 @@ public final class LogRecordDataDeserializer implements SignalDeserializer<LogRe
       throw new IllegalArgumentException(e);
     }
   }
+
+  @Override
+  public String signalType() {
+    return "logs";
+  }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.metrics.ProtoMetricsDataMapper;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
@@ -31,6 +32,6 @@ public final class MetricDataDeserializer implements SignalDeserializer<MetricDa
 
   @Override
   public String signalType() {
-    return "metrics";
+    return SignalTypes.metrics.name();
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
@@ -28,4 +28,9 @@ public final class MetricDataDeserializer implements SignalDeserializer<MetricDa
       throw new IllegalArgumentException(e);
     }
   }
+
+  @Override
+  public String signalType() {
+    return "metrics";
+  }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
@@ -24,5 +24,11 @@ public interface SignalDeserializer<SDK_ITEM> {
     return LogRecordDataDeserializer.getInstance();
   }
 
+  /** Deserializes the given byte array into a list of telemetry items. */
   List<SDK_ITEM> deserialize(byte[] source);
+
+  /** Returns the name of the type of signal -- one of "metrics", "traces", or "logs". */
+  default String signalType() {
+    return "unknown";
+  }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
@@ -27,7 +27,7 @@ public interface SignalDeserializer<SDK_ITEM> {
   /** Deserializes the given byte array into a list of telemetry items. */
   List<SDK_ITEM> deserialize(byte[] source);
 
-  /** Returns the name of the type of signal -- one of "metrics", "traces", or "logs". */
+  /** Returns the name of the stored type of signal -- one of "metrics", "spans", or "logs". */
   default String signalType() {
     return "unknown";
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.ProtoSpansDataMapper;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.proto.trace.v1.TracesData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
@@ -31,6 +32,6 @@ public final class SpanDataDeserializer implements SignalDeserializer<SpanData> 
 
   @Override
   public String signalType() {
-    return "spans";
+    return SignalTypes.spans.name();
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
@@ -28,4 +28,9 @@ public final class SpanDataDeserializer implements SignalDeserializer<SpanData> 
       throw new IllegalArgumentException(e);
     }
   }
+
+  @Override
+  public String signalType() {
+    return "spans";
+  }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public final class FolderManager {
   private final File folder;
@@ -42,6 +43,7 @@ public final class FolderManager {
     return null;
   }
 
+  @NotNull
   public synchronized WritableFile createWritableFile() throws IOException {
     long systemCurrentTimeMillis = nowMillis(clock);
     File[] existingFiles = folder.listFiles();

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageBuilder.java
@@ -10,8 +10,12 @@ import io.opentelemetry.contrib.disk.buffering.StorageConfiguration;
 import io.opentelemetry.sdk.common.Clock;
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class StorageBuilder {
+
+  private static final Logger logger = Logger.getLogger(StorageBuilder.class.getName());
 
   private String folderName = "data";
   private StorageConfiguration configuration = StorageConfiguration.getDefault(new File("."));
@@ -40,7 +44,10 @@ public class StorageBuilder {
   public Storage build() throws IOException {
     File folder = ensureSubdir(configuration.getRootDir(), folderName);
     FolderManager folderManager = new FolderManager(folder, configuration, clock);
-    return new Storage(folderManager);
+    if (configuration.isDebugEnabled()) {
+      logger.log(Level.INFO, "Building storage with configuration => " + configuration);
+    }
+    return new Storage(folderManager, configuration.isDebugEnabled());
   }
 
   private static File ensureSubdir(File rootDir, String child) throws IOException {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFile.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFile.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Reads from a file and updates it in parallel in order to avoid re-reading the same items later.
@@ -34,7 +35,7 @@ import javax.annotation.Nullable;
  * <p>More information on the overall storage process in the CONTRIBUTING.md file.
  */
 public final class ReadableFile implements FileOperations {
-  private final File file;
+  @NotNull private final File file;
   private final int originalFileSize;
   private final StreamReader reader;
   private final FileTransferUtil fileTransferUtil;
@@ -140,6 +141,7 @@ public final class ReadableFile implements FileOperations {
     return isClosed.get();
   }
 
+  @NotNull
   @Override
   public File getFile() {
     return file;
@@ -169,5 +171,10 @@ public final class ReadableFile implements FileOperations {
         out.write(buffer, 0, lengthRead);
       }
     }
+  }
+
+  @Override
+  public String toString() {
+    return "ReadableFile{" + "file=" + file + '}';
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/WritableFile.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/WritableFile.java
@@ -89,4 +89,9 @@ public final class WritableFile implements FileOperations {
       out.close();
     }
   }
+
+  @Override
+  public String toString() {
+    return "WritableFile{" + "file=" + file + '}';
+  }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/DebugLogger.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/DebugLogger.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.utils;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DebugLogger {
+  private final Logger logger;
+  private final boolean debugEnabled;
+
+  private DebugLogger(Logger logger, boolean debugEnabled) {
+    this.logger = logger;
+    this.debugEnabled = debugEnabled;
+  }
+
+  public static DebugLogger wrap(Logger logger, boolean debugEnabled) {
+    return new DebugLogger(logger, debugEnabled);
+  }
+
+  public void log(String msg) {
+    log(msg, Level.INFO);
+  }
+
+  public void log(String msg, Level level) {
+    if (debugEnabled) {
+      logger.log(level, msg);
+    }
+  }
+
+  public void log(String msg, Level level, Throwable e) {
+    if (debugEnabled) {
+      logger.log(level, msg, e);
+    }
+  }
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/SignalTypes.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/SignalTypes.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.utils;
+
+public enum SignalTypes {
+  metrics,
+  spans,
+  logs
+}

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporte
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.ToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -103,7 +104,7 @@ public class IntegrationTest {
       SignalSerializer<T> serializer, Function<Collection<T>, CompletableResultCode> exporter)
       throws IOException {
     return ToDiskExporter.<T>builder()
-        .setFolderName("spans")
+        .setFolderName(SignalTypes.spans.name())
         .setStorageConfiguration(storageConfig)
         .setSerializer(serializer)
         .setExportFunction(exporter)
@@ -119,7 +120,7 @@ public class IntegrationTest {
       throws IOException {
     return builder
         .setExportFunction(exportFunction)
-        .setFolderName("spans")
+        .setFolderName(SignalTypes.spans.name())
         .setStorageConfiguration(storageConfig)
         .setDeserializer(deserializer)
         .setStorageClock(clock)

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporterTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporterTest.java
@@ -23,6 +23,7 @@ import io.opentelemetry.contrib.disk.buffering.internal.files.DefaultTemporaryFi
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
+import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.resources.Resource;
@@ -84,11 +85,14 @@ class SpanFromDiskExporterTest {
     List<SpanData> spans = Arrays.asList(span1, span2);
 
     SignalSerializer<SpanData> serializer = SignalSerializer.ofSpans();
-    File subdir = new File(config.getRootDir(), "spans");
+    File subdir = new File(config.getRootDir(), SignalTypes.spans.name());
     assertTrue(subdir.mkdir());
 
     Storage storage =
-        Storage.builder().setStorageConfiguration(config).setFolderName("spans").build();
+        Storage.builder()
+            .setStorageConfiguration(config)
+            .setFolderName(SignalTypes.spans.name())
+            .build();
     storage.write(serializer.serialize(spans));
     storage.close();
     return spans;

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterTest.java
@@ -49,7 +49,7 @@ class ToDiskExporterTest {
           exportedFnSeen = x;
           return exportFnResultToReturn.get();
         };
-    toDiskExporter = new ToDiskExporter<>(serializer, exportFn, storage);
+    toDiskExporter = new ToDiskExporter<>(serializer, exportFn, storage, true);
     when(serializer.serialize(records)).thenReturn(serialized);
   }
 

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
@@ -39,7 +39,7 @@ class StorageTest {
     writableFile = createWritableFile();
     processing = mock();
     when(readableFile.readAndProcess(processing)).thenReturn(ReadableResult.SUCCEEDED);
-    storage = new Storage(folderManager);
+    storage = new Storage(folderManager, true);
   }
 
   @Test


### PR DESCRIPTION
Previously, the disk buffering code would ALWAYS log when it attempted to read from disk and when it was exporting data from disk. This gets a bit chatty and may not be what users want to see, so we need a way to silence it.

This PR introduces "debug mode" which is effectively verbose logging for troubleshooting purposes. It adds additional logging statements and logs the storage configuration in `StorageBuilder.build()`.
