### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/aws-xray/src/awsTest/resources/otel-collector.yml
+++ b/aws-xray/src/awsTest/resources/otel-collector.yml
@@ -5,11 +5,11 @@ extensions:
   health_check:
 
 exporters:
-  logging:
+  debug:
 
 service:
   extensions: [health_check]
   pipelines:
     traces:
       receivers: [awsxray]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037
