### PR TITLE
Ensure all XRay Sampler functionality is under ParentBased logic

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -56,6 +56,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
   @Nullable private volatile ScheduledFuture<?> pollFuture;
   @Nullable private volatile ScheduledFuture<?> fetchTargetsFuture;
   @Nullable private volatile GetSamplingRulesResponse previousRulesResponse;
+  @Nullable private volatile XrayRulesSampler internalXrayRulesSampler;
   private volatile Sampler sampler;
 
   /**
@@ -125,7 +126,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
       GetSamplingRulesResponse response =
           client.getSamplingRules(GetSamplingRulesRequest.create(null));
       if (!response.equals(previousRulesResponse)) {
-        sampler =
+        updateInternalSamplers(
             new XrayRulesSampler(
                 clientId,
                 resource,
@@ -133,7 +134,8 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
                 initialSampler,
                 response.getSamplingRules().stream()
                     .map(SamplingRuleRecord::getRule)
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toList())));
+
         previousRulesResponse = response;
         ScheduledFuture<?> existingFetchTargetsFuture = fetchTargetsFuture;
         if (existingFetchTargetsFuture != null) {
@@ -170,11 +172,11 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
   }
 
   private void fetchTargets() {
-    if (!(sampler instanceof XrayRulesSampler)) {
+    if (this.internalXrayRulesSampler == null) {
       throw new IllegalStateException("Programming bug.");
     }
 
-    XrayRulesSampler xrayRulesSampler = (XrayRulesSampler) sampler;
+    XrayRulesSampler xrayRulesSampler = this.internalXrayRulesSampler;
     try {
       Date now = Date.from(Instant.ofEpochSecond(0, clock.now()));
       List<SamplingStatisticsDocument> statistics = xrayRulesSampler.snapshot(now);
@@ -188,8 +190,7 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
       Map<String, SamplingTargetDocument> targets =
           response.getDocuments().stream()
               .collect(Collectors.toMap(SamplingTargetDocument::getRuleName, Function.identity()));
-      sampler =
-          xrayRulesSampler = xrayRulesSampler.withTargets(targets, requestedTargetRuleNames, now);
+      updateInternalSamplers(xrayRulesSampler.withTargets(targets, requestedTargetRuleNames, now));
     } catch (Throwable t) {
       // Might be a transient API failure, try again after a default interval.
       fetchTargetsFuture =
@@ -223,6 +224,11 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
       clientIdChars[i] = hex[rand.nextInt(hex.length)];
     }
     return new String(clientIdChars);
+  }
+
+  private void updateInternalSamplers(XrayRulesSampler xrayRulesSampler) {
+    this.internalXrayRulesSampler = xrayRulesSampler;
+    this.sampler = Sampler.parentBased(internalXrayRulesSampler);
   }
 
   // Visible for testing

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/SamplingRuleApplier.java
@@ -464,11 +464,11 @@ final class SamplingRuleApplier {
   }
 
   private Sampler createRateLimited(int numPerSecond) {
-    return Sampler.parentBased(new RateLimitingSampler(numPerSecond, clock));
+    return new RateLimitingSampler(numPerSecond, clock);
   }
 
   private static Sampler createFixedRate(double rate) {
-    return Sampler.parentBased(Sampler.traceIdRatioBased(rate));
+    return Sampler.traceIdRatioBased(rate);
   }
 
   // We keep track of sampling requests and decisions to report to X-Ray to allow it to allocate

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
@@ -168,6 +168,18 @@ class AwsXrayRemoteSamplerTest {
     }
   }
 
+  @Test
+  void parentBasedXraySamplerAfterDefaultSampler() {
+    try (AwsXrayRemoteSampler sampler = AwsXrayRemoteSampler.newBuilder(Resource.empty()).build()) {
+      await()
+          .untilAsserted(
+              () -> {
+                assertThat(sampler.getDescription())
+                    .startsWith("AwsXrayRemoteSampler{ParentBased{root:XrayRulesSampler{[");
+              });
+    }
+  }
+
   // https://github.com/open-telemetry/opentelemetry-java-contrib/issues/376
   @Test
   void testJitterTruncation() {

--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
@@ -170,8 +170,15 @@ class AwsXrayRemoteSamplerTest {
 
   @Test
   void parentBasedXraySamplerAfterDefaultSampler() {
-    try (AwsXrayRemoteSampler sampler = AwsXrayRemoteSampler.newBuilder(Resource.empty()).build()) {
+    rulesResponse.set(RULE_RESPONSE_1);
+    try (AwsXrayRemoteSampler samplerWithLongerPollingInterval =
+        AwsXrayRemoteSampler.newBuilder(Resource.empty())
+            .setInitialSampler(Sampler.alwaysOn())
+            .setEndpoint(server.httpUri().toString())
+            .setPollingInterval(Duration.ofMillis(5))
+            .build()) {
       await()
+          .pollDelay(Duration.ofMillis(10))
           .untilAsserted(
               () -> {
                 assertThat(sampler.getDescription())


### PR DESCRIPTION
**Description:**

This fixes the bug where:
- While the subcomponents of XRay Sampler uses ParentBased logic to short-circuit the Parent's Sampling Decision, the XRay Sampling Statistics recording logic is not skipped when a Parent's Sampling Decision is found. This causes XRay Sampler to produce Sampling Statistics based on number of Spans (regardless of Parent's Sampling Decision), while XRay Sampler should produce Sampling Statistics based on number of Traces (aka the number of root Spans that makes the Sampling Decision)

The changes introduced in this PR are as follows:
- Wrap entire internal `XrayRulesSampler` of `AwsXrayRemoteSampler` under a single ParentBased Sampler
- Remove use of redundant ParentBased Sampler logic for internal subcomponents for XRay Sampler.

**Existing Issue(s):**
Related
- https://github.com/aws-observability/aws-otel-js-instrumentation/issues/79
- https://github.com/aws-observability/aws-otel-js-instrumentation/pull/80

**Testing:**

- Tested Sampler functionality with XRay Sampler test bed - https://github.com/aws-observability/aws-otel-community/tree/master/centralized-sampling-tests
- Added unit test to verify ParentBased sampler is wrapped around XRayRulesSampler.


**Documentation:**


**Outstanding items:**


