### PR TITLE
Reimplemented renovate fixes and change testcontainers image

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -16,7 +16,7 @@ val DEPENDENCY_BOMS = listOf(
   "org.junit:junit-bom:5.11.3",
   "io.grpc:grpc-bom:1.68.1",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}",
-  "org.testcontainers:testcontainers-bom:1.20.1"
+  "org.testcontainers:testcontainers-bom:1.20.2"
 )
 
 val autoServiceVersion = "1.1.1"
@@ -64,7 +64,7 @@ val DEPENDENCIES = listOf(
   "org.junit-pioneer:junit-pioneer:1.9.1",
   "org.skyscreamer:jsonassert:1.5.3",
   "org.apache.kafka:kafka-clients:3.8.1",
-  "org.testcontainers:kafka:1.20.1",
+  "org.testcontainers:kafka:1.20.2",
   "com.lmax:disruptor:3.4.4",
   "org.jctools:jctools-core:4.0.5",
   "tools.profiler:async-profiler:3.0",

--- a/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterIntegrationTest.java
+++ b/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterIntegrationTest.java
@@ -38,8 +38,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.rnorth.ducttape.unreliables.Unreliables;
-import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers(disabledWithoutDocker = true)

--- a/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterIntegrationTest.java
+++ b/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterIntegrationTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.rnorth.ducttape.unreliables.Unreliables;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
@@ -46,7 +46,7 @@ import org.testcontainers.utility.DockerImageName;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KafkaSpanExporterIntegrationTest {
   private static final DockerImageName KAFKA_TEST_IMAGE =
-      DockerImageName.parse("confluentinc/cp-kafka:6.2.1");
+      DockerImageName.parse("apache/kafka:3.8.1");
   private static final String TOPIC = "span_topic";
   private KafkaContainer kafka;
   private KafkaConsumer<String, ExportTraceServiceRequest> consumer;


### PR DESCRIPTION
Reimplemented renovate fixes and change testcontainers image to `apache/kafka`

**Description:**

Change proposed renovate dependency update, use `apache/kafka` image instead of `confluentinc/cp-kafka`.
This change is in line with implementations elsewhere in the product.

**Existing Issue(s):**

[Renovate PR](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1482)



**Testing:**

Validated with existing tests.

**Documentation:**

None needed

**Outstanding items:**

None