### PR TITLE
Revert "fix(deps): update dependency com.linecorp.armeria:armeria-bom to v1.31.0 (#1542)"

### DIFF
--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/SimpleHttpClientTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/SimpleHttpClientTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.TlsKeyPair;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -69,7 +68,7 @@ class SimpleHttpClientTest {
         new ServerExtension() {
           @Override
           protected void configure(ServerBuilder sb) {
-            sb.tls(TlsKeyPair.of(certificate.privateKeyFile(), certificate.certificateFile()));
+            sb.tls(certificate.certificateFile(), certificate.privateKeyFile());
 
             sb.service("/", (ctx, req) -> HttpResponse.of("Thanks for trusting me"));
           }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -12,7 +12,7 @@ val otelInstrumentationVersion = "2.9.0-alpha"
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.18.1",
   "com.google.guava:guava-bom:33.3.1-jre",
-  "com.linecorp.armeria:armeria-bom:1.31.0",
+  "com.linecorp.armeria:armeria-bom:1.30.1",
   "org.junit:junit-bom:5.11.3",
   "io.grpc:grpc-bom:1.68.1",
   "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}",


### PR DESCRIPTION
#1542 was merged even though there was a failing test, this PR reverts that change until we can figure out what the underlying issue is (renovate should dutifully re-open the update).

#1545 fixes CI to prevent merging in the future when there is a failing test.