### PR TITLE
[jmx-scraper] keep old servlet API and java8 compatibility

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,7 +87,7 @@
     },
     {
       // pinned version for compatibility
-      "matchFileNames": ["jmx-scraper/test-webapp/**"],
+      "matchFileNames": ["jmx-scraper/test-webapp/build.gradle.kts"],
       "matchPackagePrefixes": ["jakarta.servlet:"],
       "matchCurrentVersion": "5.0.0",
       "enabled": false

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,6 +84,13 @@
       "matchPackagePrefixes": ["org.openjdk.jmc"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      // pinned version for compatibility
+      "matchFileNames": ["jmx-scraper/test-webapp/**"],
+      "matchPackagePrefixes": ["jakarta.servlet:"],
+      "matchCurrentVersion": "5.0.0",
+      "enabled": false
     }
   ]
 }

--- a/jmx-scraper/test-app/build.gradle.kts
+++ b/jmx-scraper/test-app/build.gradle.kts
@@ -5,9 +5,8 @@ plugins {
 description = "JMX metrics scraper - test application"
 
 java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks {

--- a/jmx-scraper/test-webapp/build.gradle.kts
+++ b/jmx-scraper/test-webapp/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(8)
-  }
+  // keeping java 8 compatibility to allow running this sample app in most containers
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }


### PR DESCRIPTION
- Pin servlet version to 5.0.0 to prevent update PRs like #1543 
- use java source and target code level instead of toolchain contraints, given there isn't any java 8 compatible toolchain available for aarch64, we can replace it with any other compatible version that can compile to Java 8 (and let gradle find a suitable one).
