### PR TITLE
Update proto alpha versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,12 +8,13 @@
       "matchPackageNames": [
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
         "io.opentelemetry.semconv:opentelemetry-semconv",
-        "io.opentelemetry.semconv:opentelemetry-semconv-incubating"
+        "io.opentelemetry.semconv:opentelemetry-semconv-incubating",
+        "io.opentelemetry.proto:opentelemetry-proto"
       ],
       // Renovate's default behavior is only to update from unstable -> unstable if it's for the
       // major.minor.patch, under the assumption that you would want to update to the stable version
       // of that release instead of the unstable version for a future release
-      // (but there's never any stable version of these artifacts so this logic doesn't apply)
+      // (TODO remove once the artifacts above release stable versions)
       "ignoreUnstable": false
     },
     {


### PR DESCRIPTION
This repo is stuck on an old proto version:

https://github.com/open-telemetry/opentelemetry-java-contrib/blob/857e4ae8c55d881db277b79330dfc7b65c0a909f/jmx-metrics/build.gradle.kts#L60