### PR TITLE
[jmx-scraper] pin servlet 5.x version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,6 +85,13 @@
       "matchPackagePrefixes": ["org.openjdk.jmc"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      // pinned version for compatibility
+      "matchFileNames": ["jmx-scraper/test-webapp/build.gradle.kts"],
+      "matchPackagePrefixes": ["jakarta.servlet:"],
+      "matchCurrentVersion": "5.0.0",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Pin the servlet version to avoid renovate PR bot to attempt breaking compatibility with PRs like #1543 .