### PR TITLE
Deserialization validation

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/FromDiskExporterImpl.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.exporter;
 
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.DeserializationException;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.Storage;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.ProcessResult;
@@ -71,7 +72,7 @@ public final class FromDiskExporterImpl<EXPORT_DATA> implements FromDiskExporter
                     "Now exporting batch of " + telemetry.size() + " " + deserializer.signalType());
                 CompletableResultCode join = exportFunction.apply(telemetry).join(timeout, unit);
                 return join.isSuccess() ? ProcessResult.SUCCEEDED : ProcessResult.TRY_LATER;
-              } catch (IllegalArgumentException e) {
+              } catch (DeserializationException e) {
                 return ProcessResult.CONTENT_INVALID;
               }
             });

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/DeserializationException.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/DeserializationException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
 import java.io.IOException;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/DeserializationException.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/DeserializationException.java
@@ -1,0 +1,10 @@
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
+
+import java.io.IOException;
+
+@SuppressWarnings("serial")
+public class DeserializationException extends IOException {
+  public DeserializationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
@@ -22,11 +22,11 @@ public final class LogRecordDataDeserializer implements SignalDeserializer<LogRe
   }
 
   @Override
-  public List<LogRecordData> deserialize(byte[] source) {
+  public List<LogRecordData> deserialize(byte[] source) throws DeserializationException {
     try {
       return ProtoLogsDataMapper.getInstance().fromProto(LogsData.ADAPTER.decode(source));
     } catch (IOException e) {
-      throw new IllegalArgumentException(e);
+      throw new DeserializationException(e);
     }
   }
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
@@ -22,11 +22,11 @@ public final class MetricDataDeserializer implements SignalDeserializer<MetricDa
   }
 
   @Override
-  public List<MetricData> deserialize(byte[] source) {
+  public List<MetricData> deserialize(byte[] source) throws DeserializationException {
     try {
       return ProtoMetricsDataMapper.getInstance().fromProto(MetricsData.ADAPTER.decode(source));
     } catch (IOException e) {
-      throw new IllegalArgumentException(e);
+      throw new DeserializationException(e);
     }
   }
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SignalDeserializer.java
@@ -25,7 +25,7 @@ public interface SignalDeserializer<SDK_ITEM> {
   }
 
   /** Deserializes the given byte array into a list of telemetry items. */
-  List<SDK_ITEM> deserialize(byte[] source);
+  List<SDK_ITEM> deserialize(byte[] source) throws DeserializationException;
 
   /** Returns the name of the stored type of signal -- one of "metrics", "spans", or "logs". */
   default String signalType() {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
@@ -22,11 +22,11 @@ public final class SpanDataDeserializer implements SignalDeserializer<SpanData> 
   }
 
   @Override
-  public List<SpanData> deserialize(byte[] source) {
+  public List<SpanData> deserialize(byte[] source) throws DeserializationException {
     try {
       return ProtoSpansDataMapper.getInstance().fromProto(TracesData.ADAPTER.decode(source));
     } catch (IOException e) {
-      throw new IllegalArgumentException(e);
+      throw new DeserializationException(e);
     }
   }
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
@@ -10,6 +10,7 @@ import static java.util.logging.Level.WARNING;
 import io.opentelemetry.contrib.disk.buffering.internal.exporter.FromDiskExporterImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.ReadableFile;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.WritableFile;
+import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.ProcessResult;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.WritableResult;
 import io.opentelemetry.contrib.disk.buffering.internal.utils.DebugLogger;
@@ -77,11 +78,11 @@ public final class Storage implements Closeable {
    * @param processing Is passed over to {@link ReadableFile#readAndProcess(Function)}.
    * @throws IOException If an unexpected error happens.
    */
-  public ReadableResult readAndProcess(Function<byte[], Boolean> processing) throws IOException {
+  public ReadableResult readAndProcess(Function<byte[], ProcessResult> processing) throws IOException {
     return readAndProcess(processing, 1);
   }
 
-  private ReadableResult readAndProcess(Function<byte[], Boolean> processing, int attemptNumber)
+  private ReadableResult readAndProcess(Function<byte[], ProcessResult> processing, int attemptNumber)
       throws IOException {
     if (isClosed.get()) {
       logger.log("Refusing to read from storage after being closed.");

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
@@ -104,7 +104,7 @@ public final class Storage implements Closeable {
     ReadableResult result = readableFile.readAndProcess(processing);
     switch (result) {
       case SUCCEEDED:
-      case PROCESSING_FAILED:
+      case TRY_LATER:
         return result;
       default:
         // Retry with new file

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/Storage.java
@@ -78,12 +78,13 @@ public final class Storage implements Closeable {
    * @param processing Is passed over to {@link ReadableFile#readAndProcess(Function)}.
    * @throws IOException If an unexpected error happens.
    */
-  public ReadableResult readAndProcess(Function<byte[], ProcessResult> processing) throws IOException {
+  public ReadableResult readAndProcess(Function<byte[], ProcessResult> processing)
+      throws IOException {
     return readAndProcess(processing, 1);
   }
 
-  private ReadableResult readAndProcess(Function<byte[], ProcessResult> processing, int attemptNumber)
-      throws IOException {
+  private ReadableResult readAndProcess(
+      Function<byte[], ProcessResult> processing, int attemptNumber) throws IOException {
     if (isClosed.get()) {
       logger.log("Refusing to read from storage after being closed.");
       return ReadableResult.FAILED;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFile.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFile.java
@@ -111,10 +111,10 @@ public final class ReadableFile implements FileOperations {
         return ReadableResult.SUCCEEDED;
       case TRY_LATER:
         unconsumedResult = read;
-        return ReadableResult.PROCESSING_FAILED;
+        return ReadableResult.TRY_LATER;
       case CONTENT_INVALID:
         cleanUp();
-        return ReadableResult.PROCESSING_FAILED;
+        return ReadableResult.FAILED;
     }
     return ReadableResult.FAILED;
   }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/reader/ProcessResult.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/reader/ProcessResult.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader;
 
 /** Result of processing the contents of a file. */

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/reader/ProcessResult.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/reader/ProcessResult.java
@@ -1,0 +1,8 @@
+package io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader;
+
+/** Result of processing the contents of a file. */
+public enum ProcessResult {
+  SUCCEEDED,
+  TRY_LATER,
+  CONTENT_INVALID
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/responses/ReadableResult.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/responses/ReadableResult.java
@@ -8,5 +8,5 @@ package io.opentelemetry.contrib.disk.buffering.internal.storage.responses;
 public enum ReadableResult {
   SUCCEEDED,
   FAILED,
-  PROCESSING_FAILED
+  TRY_LATER
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/FromDiskExporterImplTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -91,11 +92,7 @@ class FromDiskExporterImplTest {
 
   @Test
   void whenDeserializationFails_returnFalse() throws IOException {
-    when(deserializer.deserialize(any()))
-        .thenAnswer(
-            invocation -> {
-              throw new DeserializationException(new IOException("Some exception"));
-            });
+    doThrow(DeserializationException.class).when(deserializer).deserialize(any());
 
     assertThat(exporter.exportStoredBatch(1, TimeUnit.SECONDS)).isFalse();
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.storage;
 
-import static io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult.PROCESSING_FAILED;
+import static io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult.TRY_LATER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,11 +53,11 @@ class StorageTest {
   }
 
   @Test
-  void whenReadableFileProcessingFails_returnFailed() throws IOException {
+  void whenReadableFileProcessingFails_returnTryLater() throws IOException {
     when(folderManager.getReadableFile()).thenReturn(readableFile);
-    when(readableFile.readAndProcess(processing)).thenReturn(PROCESSING_FAILED);
+    when(readableFile.readAndProcess(processing)).thenReturn(TRY_LATER);
 
-    assertEquals(PROCESSING_FAILED, storage.readAndProcess(processing));
+    assertEquals(TRY_LATER, storage.readAndProcess(processing));
 
     verify(readableFile).readAndProcess(processing);
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.ReadableFile;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.WritableFile;
+import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.ProcessResult;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.responses.WritableResult;
 import java.io.IOException;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class StorageTest {
   private FolderManager folderManager;
   private Storage storage;
-  private Function<byte[], Boolean> processing;
+  private Function<byte[], ProcessResult> processing;
   private ReadableFile readableFile;
   private WritableFile writableFile;
 

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.contrib.disk.buffering.internal.files.TemporaryFileProvider;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.DeserializationException;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers.SignalDeserializer;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.models.LogRecordDataImpl;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
@@ -140,8 +141,7 @@ class ReadableFileTest {
   @Test
   void whenProcessingFails_returnTryLaterStatus() throws IOException {
     assertEquals(
-        ReadableResult.TRY_LATER,
-        readableFile.readAndProcess(bytes -> ProcessResult.TRY_LATER));
+        ReadableResult.TRY_LATER, readableFile.readAndProcess(bytes -> ProcessResult.TRY_LATER));
   }
 
   @Test
@@ -250,6 +250,10 @@ class ReadableFileTest {
   }
 
   private static LogRecordData deserialize(byte[] data) {
-    return DESERIALIZER.deserialize(data).get(0);
+    try {
+      return DESERIALIZER.deserialize(data).get(0);
+    } catch (DeserializationException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
@@ -138,9 +138,9 @@ class ReadableFileTest {
   }
 
   @Test
-  void whenProcessingFails_returnProcessFailedStatus() throws IOException {
+  void whenProcessingFails_returnTryLaterStatus() throws IOException {
     assertEquals(
-        ReadableResult.PROCESSING_FAILED,
+        ReadableResult.TRY_LATER,
         readableFile.readAndProcess(bytes -> ProcessResult.TRY_LATER));
   }
 
@@ -175,6 +175,15 @@ class ReadableFileTest {
   @Test
   void whenReadingLastLine_deleteOriginalFile_and_close() throws IOException {
     getRemainingDataAndClose(readableFile);
+
+    assertFalse(source.exists());
+    assertTrue(readableFile.isClosed());
+  }
+
+  @Test
+  void whenTheFileContentIsInvalid_deleteOriginalFile_and_close() throws IOException {
+    assertEquals(
+        ReadableResult.FAILED, readableFile.readAndProcess(bytes -> ProcessResult.CONTENT_INVALID));
 
     assertFalse(source.exists());
     assertTrue(readableFile.isClosed());


### PR DESCRIPTION
**Description:**

Adding validations for cases when trying to deserialize contents from a corrupted file. These changes aim to remove the corrupted file in those cases while avoiding throwing any exceptions to the caller.

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-android/issues/457 

**Testing:**

Unit tests

**Documentation:**

**Outstanding items:**

