### PR TITLE
Added jmx-scraper component to GH issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,7 @@ body:
         - jfr-connection
         - jfr-events
         - jmx-metrics
+        - jmx-scraper
         - maven-extension
         - micrometer-meter-provider
         - noop-api

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,6 +17,7 @@ body:
         - jfr-connection
         - jfr-events
         - jmx-metrics
+        - jmx-scraper
         - maven-extension
         - micrometer-meter-provider
         - noop-api


### PR DESCRIPTION
Enable creating issues for JMX Scraper component.
'jmx-scraper' is added to 'Component(s)' dropdown on 'New issue' page.