### PR TITLE
publish jmx scraper artifact

### DIFF
--- a/jmx-scraper/build.gradle.kts
+++ b/jmx-scraper/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
 
   id("otel.java-conventions")
 
-  // TODO publishing disabled until component is ready to be used
-  // id("otel.publish-conventions")
+  id("otel.publish-conventions")
 }
 
 description = "JMX metrics scraper"


### PR DESCRIPTION
**Description:**

Part of #1362 

This PR enables publishing the `jmx-scarper` artifact for consumption.

Publishing the artifact for the next release cycle unblocks integration in the [`jmxreceiver` collector extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/README.md) that relies on released artifacts.

Tested locally with `gradle publishToMavenLocal`.
