### PR TITLE
[jmx-scraper] wildfly refactor assertions

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
@@ -51,22 +51,6 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .isUpDownCounter()
-                    .hasDescription("The number of region servers.")
-                    .hasUnit("{server}")
-                    .hasDataPointsWithoutAttributes())
-        .add(
-            "hbase.master.regions_in_transition.count",
-            metric ->
-                metric
-                    .isUpDownCounter()
-                    .hasDescription("The number of regions that are in transition.")
-                    .hasUnit("{region}")
-                    .hasDataPointsWithoutAttributes())
-        .add(
-            "hbase.master.regions_in_transition.count",
-            metric ->
-                metric
-                    .isUpDownCounter()
                     .hasDescription("The number of regions that are in transition.")
                     .hasUnit("{region}")
                     .hasDataPointsWithoutAttributes())

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/MetricsVerifier.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/MetricsVerifier.java
@@ -63,6 +63,9 @@ public class MetricsVerifier {
    */
   @CanIgnoreReturnValue
   public MetricsVerifier add(String metricName, Consumer<MetricAssert> assertion) {
+    if (assertions.containsKey(metricName)) {
+      throw new IllegalArgumentException("Duplicate assertion for metric " + metricName);
+    }
     assertions.put(
         metricName,
         metric -> {

--- a/jmx-scraper/src/main/resources/wildfly.yaml
+++ b/jmx-scraper/src/main/resources/wildfly.yaml
@@ -59,22 +59,24 @@ rules:
   - bean: jboss.as:subsystem=datasources,data-source=*,statistics=pool
     metricAttribute:
       data_source: param(data-source)
-    type: counter
     prefix: wildfly.jdbc.
     mapping:
       ActiveCount:
         metric: &metric connection.open
+        type: updowncounter
         unit: &unit "{connection}"
         desc: &desc The number of open jdbc connections.
         metricAttribute:
           state: const(active)
       IdleCount:
         metric: *metric
+        type: updowncounter
         unit: *unit
         desc: *desc
         metricAttribute:
           state: const(idle)
       WaitCount:
+        type: counter
         metric: request.wait
         unit: "{request}"
         desc: The number of jdbc connections that had to wait before opening.


### PR DESCRIPTION
**Description:**

Migrates Wildfly integration test to use the new assertion framework.

Bonus: fixes a few bugs in the yaml definition and hbase tests that were not covered previously :tada: 

Part of #1573

- **prevent adding duplicate metric assertions**
- **fix wildfly datasource metrics**
- **migrate wildfly assertions**

