### PR TITLE
[jmx-scraper] Update Cassandra units to match semconv

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/CassandraIntegrationTest.java
@@ -86,39 +86,39 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
                 metric,
                 "cassandra.compaction.tasks.completed",
                 "Number of completed compactions since server [re]start",
-                "1"),
+                "{task}"),
         metric ->
             assertGauge(
                 metric,
                 "cassandra.compaction.tasks.pending",
                 "Estimated number of compactions remaining to perform",
-                "1"),
+                "{task}"),
         metric ->
             assertSum(
                 metric,
                 "cassandra.storage.load.count",
                 "Size of the on disk data size this node manages",
-                "by",
+                "By",
                 /* isMonotonic= */ false),
         metric ->
             assertSum(
                 metric,
                 "cassandra.storage.total_hints.count",
                 "Number of hint messages written to this node since [re]start",
-                "1"),
+                "{hint}"),
         metric ->
             assertSum(
                 metric,
                 "cassandra.storage.total_hints.in_progress.count",
                 "Number of hints attempting to be sent currently",
-                "1",
+                "{hint}",
                 /* isMonotonic= */ false),
         metric ->
             assertSumWithAttributes(
                 metric,
                 "cassandra.client.request.count",
                 "Number of requests by operation",
-                "1",
+                "{request}",
                 attrs -> attrs.containsOnly(entry("operation", "RangeSlice")),
                 attrs -> attrs.containsOnly(entry("operation", "Read")),
                 attrs -> attrs.containsOnly(entry("operation", "Write"))),
@@ -127,7 +127,7 @@ class CassandraIntegrationTest extends AbstractIntegrationTest {
                 metric,
                 "cassandra.client.request.error.count",
                 "Number of request errors by operation",
-                "1",
+                "{error}",
                 getRequestErrorCountAttributes()));
   }
 

--- a/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/cassandra.groovy
@@ -72,19 +72,19 @@ def storage = "${cassandraMetrics}:type=Storage"
 def storageLoad = otel.mbean("${storage},name=Load")
 otel.instrument(storageLoad,
         "cassandra.storage.load.count",
-        "Size of the on disk data size this node manages", "by", "Count",
+        "Size of the on disk data size this node manages", "By", "Count",
         otel.&longUpDownCounterCallback)
 
 def storageTotalHints = otel.mbean("${storage},name=TotalHints")
 otel.instrument(storageTotalHints,
         "cassandra.storage.total_hints.count",
-        "Number of hint messages written to this node since [re]start", "1", "Count",
+        "Number of hint messages written to this node since [re]start", "{hint}", "Count",
         otel.&longCounterCallback)
 
 def storageTotalHintsInProgress = otel.mbean("${storage},name=TotalHintsInProgress")
 otel.instrument(storageTotalHintsInProgress,
         "cassandra.storage.total_hints.in_progress.count",
-        "Number of hints attempting to be sent currently", "1", "Count",
+        "Number of hints attempting to be sent currently", "{hint}", "Count",
         otel.&longUpDownCounterCallback)
 
 
@@ -92,13 +92,13 @@ def compaction = "${cassandraMetrics}:type=Compaction"
 def compactionPendingTasks = otel.mbean("${compaction},name=PendingTasks")
 otel.instrument(compactionPendingTasks,
         "cassandra.compaction.tasks.pending",
-        "Estimated number of compactions remaining to perform", "1", "Value",
+        "Estimated number of compactions remaining to perform", "{task}", "Value",
         otel.&longValueCallback)
 
 def compactionCompletedTasks = otel.mbean("${compaction},name=CompletedTasks")
 otel.instrument(compactionCompletedTasks,
         "cassandra.compaction.tasks.completed",
-        "Number of completed compactions since server [re]start", "1", "Value",
+        "Number of completed compactions since server [re]start", "{task}", "Value",
         otel.&longCounterCallback)
 
 
@@ -111,7 +111,7 @@ def clientRequests = otel.mbeans([
 otel.instrument(clientRequests,
   "cassandra.client.request.count",
   "Number of requests by operation",
-  "1",
+  "{request}",
   [
     "operation" : { mbean -> mbean.name().getKeyProperty("scope") },
   ],
@@ -132,7 +132,7 @@ def clientRequestErrors = otel.mbeans([
 otel.instrument(clientRequestErrors,
   "cassandra.client.request.error.count",
   "Number of request errors by operation",
-  "1",
+  "{error}",
   [
     "operation" : { mbean -> mbean.name().getKeyProperty("scope") },
     "status" : {

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CassandraIntegrationTest.java
@@ -118,7 +118,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Number of completed compactions since server [re]start")
-                    .hasUnit("1")
+                    .hasUnit("{task}")
                     .isCounter()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -126,7 +126,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Estimated number of compactions remaining to perform")
-                    .hasUnit("1")
+                    .hasUnit("{task}")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -134,7 +134,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Size of the on disk data size this node manages")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isUpDownCounter()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -142,7 +142,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Number of hint messages written to this node since [re]start")
-                    .hasUnit("1")
+                    .hasUnit("{hint}")
                     .isCounter()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -150,7 +150,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Number of hints attempting to be sent currently")
-                    .hasUnit("1")
+                    .hasUnit("{hint}")
                     .isUpDownCounter()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -158,7 +158,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Number of requests by operation")
-                    .hasUnit("1")
+                    .hasUnit("{request}")
                     .isCounter()
                     .hasDataPointsWithAttributes(
                         attributeGroup(attribute("operation", "RangeSlice")),
@@ -169,7 +169,7 @@ public class CassandraIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("Number of request errors by operation")
-                    .hasUnit("1")
+                    .hasUnit("{error}")
                     .isCounter()
                     .hasDataPointsWithAttributes(
                         errorCountAttributes("RangeSlice", "Timeout"),

--- a/jmx-scraper/src/main/resources/cassandra.yaml
+++ b/jmx-scraper/src/main/resources/cassandra.yaml
@@ -6,7 +6,7 @@ rules:
       Value:
         metric: cassandra.compaction.tasks.completed
         type: counter
-        unit: "1"
+        unit: "{task}"
         desc: Number of completed compactions since server [re]start
 
   - bean: org.apache.cassandra.metrics:type=Compaction,name=PendingTasks
@@ -14,7 +14,7 @@ rules:
       Value:
         metric: cassandra.compaction.tasks.pending
         type: gauge
-        unit: "1"
+        unit: "{task}"
         desc: Estimated number of compactions remaining to perform
 
   # Storage
@@ -23,7 +23,7 @@ rules:
       Count:
         metric: cassandra.storage.load.count
         type: updowncounter
-        unit: by
+        unit: By
         desc: Size of the on disk data size this node manages
 
   - bean: org.apache.cassandra.metrics:type=Storage,name=TotalHints
@@ -31,7 +31,7 @@ rules:
       Count:
         metric: cassandra.storage.total_hints.count
         type: counter
-        unit: "1"
+        unit: "{hint}"
         desc: Number of hint messages written to this node since [re]start
 
   - bean: org.apache.cassandra.metrics:type=Storage,name=TotalHintsInProgress
@@ -39,7 +39,7 @@ rules:
       Count:
         metric: cassandra.storage.total_hints.in_progress.count
         type: updowncounter
-        unit: "1"
+        unit: "{hint}"
         desc: Number of hints attempting to be sent currently
 
   # Client latency
@@ -99,7 +99,7 @@ rules:
       Count:
         metric: cassandra.client.request.count
         type: counter
-        unit: "1"
+        unit: "{request}"
         desc: Number of requests by operation
 
   # Client error count
@@ -114,7 +114,7 @@ rules:
       Count:
         metric: cassandra.client.request.error.count
         type: counter
-        unit: "1"
+        unit: "{error}"
         desc: Number of request errors by operation
 
   - beans:
@@ -128,7 +128,7 @@ rules:
       Count:
         metric: cassandra.client.request.error.count
         type: counter
-        unit: "1"
+        unit: "{error}"
         desc: Number of request errors by operation
 
   - beans:
@@ -142,5 +142,5 @@ rules:
       Count:
         metric: cassandra.client.request.error.count
         type: counter
-        unit: "1"
+        unit: "{error}"
         desc: Number of request errors by operation


### PR DESCRIPTION
**Description:**

Change metric unit definitions for Cassandra to match semconv.

In scope:

1. Units updated for JMX Scraper.
2. Units updated for JMX Metrics Gatherer for consistency.

Part of https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1362