### PR TITLE
[jmx-scraper] fix JVM units + simplify tests

### DIFF
--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/JvmTargetSystemIntegrationTest.java
@@ -31,13 +31,13 @@ class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
             "Metaspace",
             "Par Survivor Space");
     waitAndAssertMetrics(
-        metric -> assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "1"),
+        metric -> assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "{class}"),
         metric ->
             assertTypedSum(
                 metric,
                 "jvm.gc.collections.count",
                 "total number of collections that have occurred",
-                "1",
+                "{collection}",
                 Arrays.asList("ConcurrentMarkSweep", "ParNew")),
         metric ->
             assertTypedSum(
@@ -46,27 +46,27 @@ class JvmTargetSystemIntegrationTest extends AbstractIntegrationTest {
                 "the approximate accumulated collection elapsed time in milliseconds",
                 "ms",
                 Arrays.asList("ConcurrentMarkSweep", "ParNew")),
-        metric -> assertGauge(metric, "jvm.memory.heap.committed", "current heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.heap.init", "current heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.heap.max", "current heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.heap.used", "current heap usage", "by"),
+        metric -> assertGauge(metric, "jvm.memory.heap.committed", "current heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.heap.init", "current heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.heap.max", "current heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.heap.used", "current heap usage", "By"),
         metric ->
-            assertGauge(metric, "jvm.memory.nonheap.committed", "current non-heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.nonheap.init", "current non-heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.nonheap.max", "current non-heap usage", "by"),
-        metric -> assertGauge(metric, "jvm.memory.nonheap.used", "current non-heap usage", "by"),
-        metric ->
-            assertTypedGauge(
-                metric, "jvm.memory.pool.committed", "current memory pool usage", "by", gcLabels),
+            assertGauge(metric, "jvm.memory.nonheap.committed", "current non-heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.nonheap.init", "current non-heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.nonheap.max", "current non-heap usage", "By"),
+        metric -> assertGauge(metric, "jvm.memory.nonheap.used", "current non-heap usage", "By"),
         metric ->
             assertTypedGauge(
-                metric, "jvm.memory.pool.init", "current memory pool usage", "by", gcLabels),
+                metric, "jvm.memory.pool.committed", "current memory pool usage", "By", gcLabels),
         metric ->
             assertTypedGauge(
-                metric, "jvm.memory.pool.max", "current memory pool usage", "by", gcLabels),
+                metric, "jvm.memory.pool.init", "current memory pool usage", "By", gcLabels),
         metric ->
             assertTypedGauge(
-                metric, "jvm.memory.pool.used", "current memory pool usage", "by", gcLabels),
-        metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "1"));
+                metric, "jvm.memory.pool.max", "current memory pool usage", "By", gcLabels),
+        metric ->
+            assertTypedGauge(
+                metric, "jvm.memory.pool.used", "current memory pool usage", "By", gcLabels),
+        metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "{thread}"));
   }
 }

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
@@ -380,13 +380,14 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
       List<Consumer<Metric>> assertions = new ArrayList<>(kafkaBrokerAssertions());
       assertions.addAll(
           Arrays.asList(
-              metric -> assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "1"),
+              metric ->
+                  assertGauge(metric, "jvm.classes.loaded", "number of loaded classes", "{class}"),
               metric ->
                   assertTypedSum(
                       metric,
                       "jvm.gc.collections.count",
                       "total number of collections that have occurred",
-                      "1",
+                      "{collection}",
                       Arrays.asList("G1 Young Generation", "G1 Old Generation")),
               metric ->
                   assertTypedSum(
@@ -396,36 +397,36 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
                       "ms",
                       Arrays.asList("G1 Young Generation", "G1 Old Generation")),
               metric ->
-                  assertGauge(metric, "jvm.memory.heap.committed", "current heap usage", "by"),
-              metric -> assertGauge(metric, "jvm.memory.heap.init", "current heap usage", "by"),
-              metric -> assertGauge(metric, "jvm.memory.heap.max", "current heap usage", "by"),
-              metric -> assertGauge(metric, "jvm.memory.heap.used", "current heap usage", "by"),
+                  assertGauge(metric, "jvm.memory.heap.committed", "current heap usage", "By"),
+              metric -> assertGauge(metric, "jvm.memory.heap.init", "current heap usage", "By"),
+              metric -> assertGauge(metric, "jvm.memory.heap.max", "current heap usage", "By"),
+              metric -> assertGauge(metric, "jvm.memory.heap.used", "current heap usage", "By"),
               metric ->
                   assertGauge(
-                      metric, "jvm.memory.nonheap.committed", "current non-heap usage", "by"),
+                      metric, "jvm.memory.nonheap.committed", "current non-heap usage", "By"),
               metric ->
-                  assertGauge(metric, "jvm.memory.nonheap.init", "current non-heap usage", "by"),
+                  assertGauge(metric, "jvm.memory.nonheap.init", "current non-heap usage", "By"),
               metric ->
-                  assertGauge(metric, "jvm.memory.nonheap.max", "current non-heap usage", "by"),
+                  assertGauge(metric, "jvm.memory.nonheap.max", "current non-heap usage", "By"),
               metric ->
-                  assertGauge(metric, "jvm.memory.nonheap.used", "current non-heap usage", "by"),
+                  assertGauge(metric, "jvm.memory.nonheap.used", "current non-heap usage", "By"),
               metric ->
                   assertTypedGauge(
                       metric,
                       "jvm.memory.pool.committed",
                       "current memory pool usage",
-                      "by",
+                      "By",
                       gcLabels),
               metric ->
                   assertTypedGauge(
-                      metric, "jvm.memory.pool.init", "current memory pool usage", "by", gcLabels),
+                      metric, "jvm.memory.pool.init", "current memory pool usage", "By", gcLabels),
               metric ->
                   assertTypedGauge(
-                      metric, "jvm.memory.pool.max", "current memory pool usage", "by", gcLabels),
+                      metric, "jvm.memory.pool.max", "current memory pool usage", "By", gcLabels),
               metric ->
                   assertTypedGauge(
-                      metric, "jvm.memory.pool.used", "current memory pool usage", "by", gcLabels),
-              metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "1")));
+                      metric, "jvm.memory.pool.used", "current memory pool usage", "By", gcLabels),
+              metric -> assertGauge(metric, "jvm.threads.count", "number of threads", "{thread}")));
 
       waitAndAssertMetrics(assertions);
     }

--- a/jmx-metrics/src/main/resources/target-systems/jvm.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/jvm.groovy
@@ -16,11 +16,11 @@
 
 def classLoading = otel.mbean("java.lang:type=ClassLoading")
 otel.instrument(classLoading, "jvm.classes.loaded", "number of loaded classes",
-        "1", "LoadedClassCount", otel.&longValueCallback)
+        "{class}", "LoadedClassCount", otel.&longValueCallback)
 
 def garbageCollector = otel.mbeans("java.lang:type=GarbageCollector,*")
 otel.instrument(garbageCollector, "jvm.gc.collections.count", "total number of collections that have occurred",
-        "1", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
+        "{collection}", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
         "CollectionCount", otel.&longCounterCallback)
 otel.instrument(garbageCollector, "jvm.gc.collections.elapsed",
         "the approximate accumulated collection elapsed time in milliseconds", "ms",
@@ -29,15 +29,15 @@ otel.instrument(garbageCollector, "jvm.gc.collections.elapsed",
 
 def memory = otel.mbean("java.lang:type=Memory")
 otel.instrument(memory, "jvm.memory.heap", "current heap usage",
-        "by", "HeapMemoryUsage", otel.&longValueCallback)
+        "By", "HeapMemoryUsage", otel.&longValueCallback)
 otel.instrument(memory, "jvm.memory.nonheap", "current non-heap usage",
-        "by", "NonHeapMemoryUsage", otel.&longValueCallback)
+        "By", "NonHeapMemoryUsage", otel.&longValueCallback)
 
 def memoryPool = otel.mbeans("java.lang:type=MemoryPool,*")
 otel.instrument(memoryPool, "jvm.memory.pool", "current memory pool usage",
-        "by", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
+        "By", ["name" : { mbean -> mbean.name().getKeyProperty("name") }],
         "Usage", otel.&longValueCallback)
 
 def threading = otel.mbean("java.lang:type=Threading")
 otel.instrument(threading, "jvm.threads.count", "number of threads",
-        "1", "ThreadCount", otel.&longValueCallback)
+        "{thread}", "ThreadCount", otel.&longValueCallback)

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -12,11 +12,8 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
@@ -197,31 +194,6 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
         "data point attributes", /* expectedCheckStatus= */ false, dataPointAttributesChecked);
     dataPointAttributesChecked = true;
     return this;
-  }
-
-  // TODO: To be removed and calls will be replaced with hasDataPointsWithAttributes()
-  @CanIgnoreReturnValue
-  public MetricAssert hasTypedDataPoints(Collection<String> types) {
-    return checkDataPoints(
-        dataPoints -> {
-          dataPointsCommonCheck(dataPoints);
-
-          Set<String> foundValues = new HashSet<>();
-          for (NumberDataPoint dataPoint : dataPoints) {
-            List<KeyValue> attributes = dataPoint.getAttributesList();
-
-            info.description(
-                "expected exactly one 'name' attribute for typed data point in metric '%s'",
-                actual.getName());
-            iterables.assertHasSize(info, attributes, 1);
-
-            objects.assertEqual(info, attributes.get(0).getKey(), "name");
-            foundValues.add(attributes.get(0).getValue().getStringValue());
-          }
-          info.description(
-              "missing or unexpected type attribute for metric '%s'", actual.getName());
-          iterables.assertContainsExactlyInAnyOrder(info, foundValues, types.toArray());
-        });
   }
 
   private void dataPointsCommonCheck(List<NumberDataPoint> dataPoints) {

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
@@ -78,7 +78,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -86,7 +86,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -94,7 +94,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -102,7 +102,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -110,7 +110,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current non-heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -118,7 +118,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current non-heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -126,7 +126,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current non-heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -134,7 +134,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current non-heap usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -142,7 +142,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current memory pool usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(memoryAttributes))
         .add(
@@ -150,7 +150,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current memory pool usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(memoryAttributes))
         .add(
@@ -158,7 +158,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current memory pool usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(memoryAttributes))
         .add(
@@ -166,7 +166,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("current memory pool usage")
-                    .hasUnit("by")
+                    .hasUnit("By")
                     .isGauge()
                     .hasDataPointsWithAttributes(memoryAttributes))
         .add(

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
@@ -53,7 +53,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("number of loaded classes")
-                    .hasUnit("1")
+                    .hasUnit("{class}")
                     .isGauge()
                     .hasDataPointsWithoutAttributes())
         .add(
@@ -61,7 +61,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("total number of collections that have occurred")
-                    .hasUnit("1")
+                    .hasUnit("{collection}")
                     .isCounter()
                     .hasDataPointsWithAttributes(gcAlgorithmAttributes))
         .add(
@@ -174,7 +174,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
             metric ->
                 metric
                     .hasDescription("number of threads")
-                    .hasUnit("1")
+                    .hasUnit("{thread}")
                     .isGauge()
                     .hasDataPointsWithoutAttributes());
   }

--- a/jmx-scraper/src/main/resources/jvm.yaml
+++ b/jmx-scraper/src/main/resources/jvm.yaml
@@ -28,7 +28,7 @@ rules:
           name: param(name)
 
   - bean: java.lang:type=Memory
-    unit: by
+    unit: By
     prefix: jvm.memory.
     mapping:
       HeapMemoryUsage.committed:
@@ -66,7 +66,7 @@ rules:
 
   - bean: java.lang:type=MemoryPool,name=*
     type: gauge
-    unit: by
+    unit: By
     metricAttribute:
       name: param(name)
     mapping:

--- a/jmx-scraper/src/main/resources/jvm.yaml
+++ b/jmx-scraper/src/main/resources/jvm.yaml
@@ -7,7 +7,7 @@ rules:
       LoadedClassCount:
         metric: jvm.classes.loaded
         type: gauge
-        unit: '1'
+        unit: '{class}'
         desc: number of loaded classes
 
   - bean: java.lang:type=GarbageCollector,name=*
@@ -15,7 +15,7 @@ rules:
       CollectionCount:
         metric: jvm.gc.collections.count
         type: counter
-        unit: '1'
+        unit: '{collection}'
         desc: total number of collections that have occurred
         metricAttribute:
           name: param(name)
@@ -87,5 +87,5 @@ rules:
     mapping:
       ThreadCount:
         metric: jvm.threads.count
-        unit: '1'
+        unit: '{thread}'
         desc: number of threads


### PR DESCRIPTION
**Description:**

- removed 'typed' attributes from tests
- fix 'bytes' unit by using 'By'
- fix other units
- update jmx gatherer JVM metrics for consistency

Part of #1573

Changing units is not considered a "breaking change" as they are often only stored as meta-data. Aligning those units with semconv would have to be done at some point and there is no point in keeping those inconsistencies.