### PR TITLE
Revert "Change to release after SDK and before Instrumentation (#1581)"

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,9 +12,9 @@ as the last step, which publishes a snapshot build to
 
 ## Release cadence
 
-This repository roughly targets monthly minor releases from the `main` branch on the Tuesday after
+This repository roughly targets monthly minor releases from the `main` branch on the Friday after
 the second Monday of the month (roughly a couple of days after the monthly minor release of
-[opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)).
+[opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)).
 
 ## Preparing a new major or minor release
 

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -7,13 +7,15 @@ data class DependencySet(val group: String, val version: String, val modules: Li
 val dependencyVersions = hashMapOf<String, String>()
 rootProject.extra["versions"] = dependencyVersions
 
+val otelInstrumentationVersion = "2.10.0-alpha"
+
 val DEPENDENCY_BOMS = listOf(
   "com.fasterxml.jackson:jackson-bom:2.18.2",
   "com.google.guava:guava-bom:33.3.1-jre",
   "com.linecorp.armeria:armeria-bom:1.31.3",
   "org.junit:junit-bom:5.11.3",
   "io.grpc:grpc-bom:1.69.0",
-  "io.opentelemetry:opentelemetry-bom-alpha:1.45.0-alpha",
+  "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${otelInstrumentationVersion}",
   "org.testcontainers:testcontainers-bom:1.20.4"
 )
 

--- a/jmx-scraper/build.gradle.kts
+++ b/jmx-scraper/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
   runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
   runtimeOnly("io.opentelemetry:opentelemetry-exporter-logging")
 
-  implementation("io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:2.10.0-alpha")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-jmx-metrics")
 
   testImplementation("org.junit-pioneer:junit-pioneer")
   testImplementation("io.opentelemetry:opentelemetry-sdk-testing")

--- a/resource-providers/build.gradle.kts
+++ b/resource-providers/build.gradle.kts
@@ -15,11 +15,7 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
   testImplementation("com.google.auto.service:auto-service")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
-    exclude("io.opentelemetry.javaagent", "opentelemetry-javaagent-tooling-java9")
-  }
 }

--- a/resource-providers/build.gradle.kts
+++ b/resource-providers/build.gradle.kts
@@ -15,7 +15,11 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
   testImplementation("com.google.auto.service:auto-service")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling") {
+    exclude("io.opentelemetry.javaagent", "opentelemetry-javaagent-tooling-java9")
+  }
 }

--- a/runtime-attach/runtime-attach/build.gradle.kts
+++ b/runtime-attach/runtime-attach/build.gradle.kts
@@ -11,19 +11,15 @@ val agent: Configuration by configurations.creating {
   isCanBeConsumed = false
 }
 
-// can't use bom since that will cause conflicts when updating to the latest SDK version
-// and before updating to the latest instrumentation version
-val otelInstrumentationVersion = "2.10.0"
-
 dependencies {
   implementation(project(":runtime-attach:runtime-attach-core"))
-  agent("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion")
+  agent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 
   // Used by byte-buddy but not brought in as a transitive dependency.
   compileOnly("com.google.code.findbugs:annotations")
 
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent:$otelInstrumentationVersion")
-  testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:$otelInstrumentationVersion")
+  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent")
+  testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
   testImplementation("org.assertj:assertj-core")
 }

--- a/static-instrumenter/agent-extension/build.gradle.kts
+++ b/static-instrumenter/agent-extension/build.gradle.kts
@@ -8,20 +8,15 @@ otelJava {
   minJavaVersionSupported.set(JavaVersion.VERSION_11)
 }
 
-// can't use bom since that will cause conflicts when updating to the latest SDK version
-// and before updating to the latest instrumentation version
-val otelInstrumentationVersion = "2.10.0"
-val otelInstrumentationAlphaVersion = "2.10.0-alpha"
-
 dependencies {
   annotationProcessor("com.google.auto.service:auto-service")
   compileOnly("com.google.auto.service:auto-service")
 
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$otelInstrumentationAlphaVersion")
-  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:$otelInstrumentationVersion")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:$otelInstrumentationAlphaVersion")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-muzzle:$otelInstrumentationAlphaVersion")
+  compileOnly("io.opentelemetry.javaagent:opentelemetry-muzzle")
 
   compileOnly(project(":static-instrumenter:bootstrap"))
 }

--- a/static-instrumenter/agent-instrumenter/build.gradle.kts
+++ b/static-instrumenter/agent-instrumenter/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api")
   runtimeOnly("org.slf4j:slf4j-simple")
 
-  javaagent("io.opentelemetry.javaagent:opentelemetry-javaagent:2.10.0")
+  javaagent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 
   bootstrapLibs(project(":static-instrumenter:bootstrap"))
   javaagentLibs(project(":static-instrumenter:agent-extension"))


### PR DESCRIPTION
(it also broke the release process)

but more importantly, I think the more general dependency direction we want to promote is having contrib components using `opentelemetry-instrumentation-api` and `opentelemetry-javaagent-extension-api`

I'd prefer to explore moving contrib components into the instrumentation repo if we are including them in the java agent distribution

cc @jackshirazi 