### PR TITLE
Log the hbase attributes for one failing data point

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
@@ -120,6 +120,7 @@ public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
             "hbase.region_server.queue.length",
             metric ->
                 metric
+                    .logAttributes()
                     .isUpDownCounter()
                     .hasDescription("The number of RPC handlers actively servicing requests.")
                     .hasUnit("{handler}")


### PR DESCRIPTION
Relates to #1605

Because we're having intermittent test failures, I thought it might be nice to see the attributes for the given data point(s) that are failing. The output looks something like this:

```
Dec 16, 2024 3:25:34 PM io.opentelemetry.contrib.jmxscraper.assertions.MetricAssert lambda$logAttributes$4
INFO: hbase.region_server.queue.length -> attrs = [{region_server=> string_value: "1fdbc6238e8a"},{state=> string_value: "flush"}]
Dec 16, 2024 3:25:34 PM io.opentelemetry.contrib.jmxscraper.assertions.MetricAssert lambda$logAttributes$4
INFO: hbase.region_server.queue.length -> attrs = [{region_server=> string_value: "1fdbc6238e8a"},{state=> string_value: "compaction"}]
```

and the idea then is that you can turn this on for a while until we can figure out what aspect of the test is failing. Also open to other ideas on how to narrow it down.