### PR TITLE
Improve containers startup and increase max duration of test

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -111,13 +111,13 @@ public abstract class TargetSystemIntegrationTest {
             .withLogConsumer(new Slf4jLogConsumer(targetSystemLogger))
             .withNetwork(network)
             .withNetworkAliases(TARGET_SYSTEM_NETWORK_ALIAS);
-    target.start();
 
     scraper =
         new JmxScraperContainer(otlpEndpoint, scraperBaseImage())
             .withLogConsumer(new Slf4jLogConsumer(jmxScraperLogger))
             .withNetwork(network)
-            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT);
+            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT)
+            .dependsOn(target);
 
     scraper = customizeScraperContainer(scraper, target, tmpDir);
     scraper.start();
@@ -167,7 +167,7 @@ public abstract class TargetSystemIntegrationTest {
   protected void verifyMetrics() {
     MetricsVerifier metricsVerifier = createMetricsVerifier();
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(60))
         .untilAsserted(
             () -> {
               List<ExportMetricsServiceRequest> receivedMetrics = otlpServer.getMetrics();

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -111,13 +111,13 @@ public abstract class TargetSystemIntegrationTest {
             .withLogConsumer(new Slf4jLogConsumer(targetSystemLogger))
             .withNetwork(network)
             .withNetworkAliases(TARGET_SYSTEM_NETWORK_ALIAS);
+    target.start();
 
     scraper =
         new JmxScraperContainer(otlpEndpoint, scraperBaseImage())
             .withLogConsumer(new Slf4jLogConsumer(jmxScraperLogger))
             .withNetwork(network)
-            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT)
-            .dependsOn(target);
+            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT);
 
     scraper = customizeScraperContainer(scraper, target, tmpDir);
     scraper.start();


### PR DESCRIPTION
**Description:**

This is not the full fix for flaky integration tests but it should improve their stability. More PRs will come.
Part of fix for https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1605

Because some of the metrics may require some more time to be reported. Maximum metrics assertion timeout has been increased to support this scenario. This timeout increase does not impact successful tests duration because such tests end as soon as all assertions are fulfilled.
