### PR TITLE
Fix HBase test flakiness

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/assertions/MetricAssert.java
@@ -249,8 +249,8 @@ public class MetricAssert extends AbstractAssert<MetricAssert, Metric> {
             }
 
             info.description(
-                "data point attributes '%s' for metric '%s' must match exactly one of the attribute sets '%s'",
-                dataPointAttributes, actual.getName(), Arrays.asList(matcherGroups));
+                "data point attributes '%s' for metric '%s' must match exactly one of the attribute sets '%s'.\nActual data points: %s",
+                dataPointAttributes, actual.getName(), Arrays.asList(matcherGroups), dataPoints);
             integers.assertEqual(info, matchCount, 1);
           }
 

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/HBaseIntegrationTest.java
@@ -16,15 +16,16 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 public class HBaseIntegrationTest extends TargetSystemIntegrationTest {
-  private static final int DEFAULT_MASTER_SERVICE_PORT = 16000;
-
   @Override
   protected GenericContainer<?> createTargetContainer(int jmxPort) {
     return new GenericContainer<>("dajobe/hbase")
         .withEnv("HBASE_MASTER_OPTS", genericJmxJvmArguments(jmxPort))
         .withStartupTimeout(Duration.ofMinutes(2))
-        .withExposedPorts(jmxPort, DEFAULT_MASTER_SERVICE_PORT)
-        .waitingFor(Wait.forListeningPorts(jmxPort, DEFAULT_MASTER_SERVICE_PORT));
+        .withExposedPorts(jmxPort)
+        // HBase initialization process is finished a long time after all the ports are opened.
+        // Because of this it is necessary to wait for log message confirming that startup process
+        // is complete.
+        .waitingFor(Wait.forLogMessage(".+Master has completed initialization.+", 1));
   }
 
   @Override

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/MetricsVerifier.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/MetricsVerifier.java
@@ -114,7 +114,11 @@ public class MetricsVerifier {
 
     assertionNames.removeAll(receivedMetricNames);
     if (!assertionNames.isEmpty()) {
-      fail("Metrics expected but not received: " + assertionNames);
+      fail(
+          "Metrics expected but not received: "
+              + assertionNames
+              + "\nReceived only: "
+              + receivedMetricNames);
     }
   }
 }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -111,13 +111,13 @@ public abstract class TargetSystemIntegrationTest {
             .withLogConsumer(new Slf4jLogConsumer(targetSystemLogger))
             .withNetwork(network)
             .withNetworkAliases(TARGET_SYSTEM_NETWORK_ALIAS);
-    target.start();
 
     scraper =
         new JmxScraperContainer(otlpEndpoint, scraperBaseImage())
             .withLogConsumer(new Slf4jLogConsumer(jmxScraperLogger))
             .withNetwork(network)
-            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT);
+            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT)
+            .dependsOn(target);
 
     scraper = customizeScraperContainer(scraper, target, tmpDir);
     scraper.start();
@@ -167,7 +167,7 @@ public abstract class TargetSystemIntegrationTest {
   protected void verifyMetrics() {
     MetricsVerifier metricsVerifier = createMetricsVerifier();
     await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(60))
         .untilAsserted(
             () -> {
               List<ExportMetricsServiceRequest> receivedMetrics = otlpServer.getMetrics();

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -111,13 +111,13 @@ public abstract class TargetSystemIntegrationTest {
             .withLogConsumer(new Slf4jLogConsumer(targetSystemLogger))
             .withNetwork(network)
             .withNetworkAliases(TARGET_SYSTEM_NETWORK_ALIAS);
+    target.start();
 
     scraper =
         new JmxScraperContainer(otlpEndpoint, scraperBaseImage())
             .withLogConsumer(new Slf4jLogConsumer(jmxScraperLogger))
             .withNetwork(network)
-            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT)
-            .dependsOn(target);
+            .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT);
 
     scraper = customizeScraperContainer(scraper, target, tmpDir);
     scraper.start();

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -185,7 +185,7 @@ public abstract class TargetSystemIntegrationTest {
                       .collect(Collectors.toList());
 
               assertThat(metrics)
-                  .describedAs("metrics reported but none from JMX scraper")
+                  .describedAs("Metrics received but not suitable for JMX scraper")
                   .isNotEmpty();
 
               metricsVerifier.verify(metrics);


### PR DESCRIPTION
**Description:**

Part of fix for https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1605

HBase is doing a lot of things after all the ports are open and before it completes its initialization. Because of this the test may be flaky.

**Scope**

- Changed condition for detecting container start from checking ports to checking log. This may require us to update regexp when testing HBase in different version, but it improved stability a lot.
- Fine tuning some assertion messages, including dumping all data points with attributes when matching attributes fails
- Cleanup of TargetSystemIntegrationTest class