### PR TITLE
Fix flaky test

### DIFF
--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentReservoirSamplingSpanProcessorTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentReservoirSamplingSpanProcessorTest.java
@@ -243,9 +243,11 @@ class ConsistentReservoirSamplingSpanProcessorTest {
 
   @Test
   void ignoresNullSpans() {
+    SpanExporter mockSpanExporter = mock(SpanExporter.class);
+    when(mockSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
     SpanProcessor processor =
         ConsistentReservoirSamplingSpanProcessor.create(
-            mock(SpanExporter.class), RESERVOIR_SIZE, EXPORT_PERIOD_100_MILLIS_AS_NANOS);
+            mockSpanExporter, RESERVOIR_SIZE, EXPORT_PERIOD_100_MILLIS_AS_NANOS);
     assertThatCode(
             () -> {
               processor.onStart(null, null);


### PR DESCRIPTION
```
ConsistentReservoirSamplingSpanProcessorTest > ignoresNullSpans() FAILED
    java.lang.NullPointerException
        at io.opentelemetry.contrib.sampler.consistent.ConsistentReservoirSamplingSpanProcessor$Worker.lambda$shutdown$1(ConsistentReservoirSamplingSpanProcessor.java:522)
        at io.opentelemetry.sdk.common.CompletableResultCode.whenComplete(CompletableResultCode.java:189)
        at io.opentelemetry.contrib.sampler.consistent.ConsistentReservoirSamplingSpanProcessor$Worker.shutdown(ConsistentReservoirSamplingSpanProcessor.java:518)
        at io.opentelemetry.contrib.sampler.consistent.ConsistentReservoirSamplingSpanProcessor$Worker.access$900(ConsistentReservoirSamplingSpanProcessor.java:433)
        at io.opentelemetry.contrib.sampler.consistent.ConsistentReservoirSamplingSpanProcessor.shutdown(ConsistentReservoirSamplingSpanProcessor.java:420)
        at io.opentelemetry.contrib.sampler.consistent.ConsistentReservoirSamplingSpanProcessorTest.ignoresNullSpans(ConsistentReservoirSamplingSpanProcessorTest.java:256)
```