### PR TITLE
Improving inter-operation with legacy samplers

### DIFF
--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/Composable.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/Composable.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.trace.data.LinkData;
 import java.util.List;
 
 /** An interface for components to be used by composite consistent probability samplers. */
-public interface ComposableSampler {
+public interface Composable {
 
   /**
    * Returns the SamplingIntent that is used for the sampling decision. The SamplingIntent includes

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAlwaysOffSampler.java
@@ -33,7 +33,17 @@ final class ConsistentAlwaysOffSampler extends ConsistentSampler {
       Attributes attributes,
       List<LinkData> parentLinks) {
 
-    return () -> getInvalidThreshold();
+    return new SamplingIntent() {
+      @Override
+      public long getThreshold() {
+        return getInvalidThreshold();
+      }
+
+      @Override
+      public boolean isAdjustedCountReliable() {
+        return false;
+      }
+    };
   }
 
   @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSampler.java
@@ -122,7 +122,7 @@ final class ConsistentRateLimitingSampler extends ConsistentSampler {
   private final double targetSpansPerNanosecondLimit;
   private final double probabilitySmoothingFactor;
   private final AtomicReference<State> state;
-  private final ComposableSampler delegate;
+  private final Composable delegate;
 
   /**
    * Constructor.
@@ -133,7 +133,7 @@ final class ConsistentRateLimitingSampler extends ConsistentSampler {
    * @param nanoTimeSupplier a supplier for the current nano time
    */
   ConsistentRateLimitingSampler(
-      ComposableSampler delegate,
+      Composable delegate,
       double targetSpansPerSecondLimit,
       double adaptationTimeSeconds,
       LongSupplier nanoTimeSupplier) {
@@ -253,6 +253,11 @@ final class ConsistentRateLimitingSampler extends ConsistentSampler {
       @Override
       public long getThreshold() {
         return suggestedThreshold;
+      }
+
+      @Override
+      public boolean isAdjustedCountReliable() {
+        return delegateIntent.isAdjustedCountReliable();
       }
 
       @Override

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRuleBasedSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRuleBasedSampler.java
@@ -19,8 +19,8 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * A consistent sampler that uses Span categorization and uses a different delegate sampler for each
- * category. Categorization of Spans is aided by Predicates, which can be combined with
- * ComposableSamplers into PredicatedSamplers.
+ * category. Categorization of Spans is aided by Predicates, which can be combined with Composables
+ * into PredicatedSamplers.
  */
 @Immutable
 final class ConsistentRuleBasedSampler extends ConsistentSampler {

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/Predicate.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/Predicate.java
@@ -39,6 +39,17 @@ public interface Predicate {
   }
 
   /*
+   * Return a Predicate that will only match Spans with local parent
+   */
+  static Predicate hasLocalParent() {
+    return (parentContext, name, spanKind, attributes, parentLinks) -> {
+      Span parentSpan = Span.fromContext(parentContext);
+      SpanContext parentSpanContext = parentSpan.getSpanContext();
+      return !parentSpanContext.isValid() || !parentSpanContext.isRemote();
+    };
+  }
+
+  /*
    * Return a Predicate that matches all Spans
    */
   static Predicate anySpan() {

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/PredicatedSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/PredicatedSampler.java
@@ -7,17 +7,17 @@ package io.opentelemetry.contrib.sampler.consistent56;
 
 import static java.util.Objects.requireNonNull;
 
-/** A class for holding a pair (Predicate, ComposableSampler) */
+/** A class for holding a pair (Predicate, Composable) */
 public final class PredicatedSampler {
 
-  public static PredicatedSampler onMatch(Predicate predicate, ComposableSampler sampler) {
+  public static PredicatedSampler onMatch(Predicate predicate, Composable sampler) {
     return new PredicatedSampler(predicate, sampler);
   }
 
   private final Predicate predicate;
-  private final ComposableSampler sampler;
+  private final Composable sampler;
 
-  private PredicatedSampler(Predicate predicate, ComposableSampler sampler) {
+  private PredicatedSampler(Predicate predicate, Composable sampler) {
     this.predicate = requireNonNull(predicate);
     this.sampler = requireNonNull(sampler);
   }
@@ -26,7 +26,7 @@ public final class PredicatedSampler {
     return predicate;
   }
 
-  public ComposableSampler getSampler() {
+  public Composable getSampler() {
     return sampler;
   }
 }

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/SamplingIntent.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/SamplingIntent.java
@@ -20,6 +20,13 @@ public interface SamplingIntent {
    */
   long getThreshold();
 
+  /*
+   * Return true if the adjusted count (calculated as reciprocal of the sampling probability) can be faithfully used to estimate span metrics.
+   */
+  default boolean isAdjustedCountReliable() {
+    return true;
+  }
+
   /**
    * Returns a set of Attributes to be added to the Span in case of positive sampling decision.
    *

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/CoinFlipSampler.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/CoinFlipSampler.java
@@ -24,8 +24,8 @@ final class CoinFlipSampler extends ConsistentSampler {
 
   private static final SplittableRandom random = new SplittableRandom(0x160a50a2073e17e6L);
 
-  private final ComposableSampler samplerA;
-  private final ComposableSampler samplerB;
+  private final Composable samplerA;
+  private final Composable samplerB;
   private final double probability;
   private final String description;
 
@@ -36,7 +36,7 @@ final class CoinFlipSampler extends ConsistentSampler {
    * @param samplerA the first delegate sampler
    * @param samplerB the second delegate sampler
    */
-  CoinFlipSampler(ComposableSampler samplerA, ComposableSampler samplerB) {
+  CoinFlipSampler(Composable samplerA, Composable samplerB) {
     this(samplerA, samplerB, 0.5);
   }
 
@@ -48,7 +48,7 @@ final class CoinFlipSampler extends ConsistentSampler {
    * @param samplerA the first delegate sampler
    * @param samplerB the second delegate sampler
    */
-  CoinFlipSampler(ComposableSampler samplerA, ComposableSampler samplerB, double probability) {
+  CoinFlipSampler(Composable samplerA, Composable samplerB, double probability) {
     this.samplerA = requireNonNull(samplerA);
     this.samplerB = requireNonNull(samplerB);
     this.probability = probability;

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAnyOfTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentAnyOfTest.java
@@ -9,26 +9,89 @@ import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUt
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ConsistentAnyOfTest {
 
+  static class TestSampler implements Composable {
+    private final long threshold;
+    private final boolean isAdjustedCountCorrect;
+
+    public TestSampler(long threshold, boolean isAdjustedCountCorrect) {
+      this.threshold = threshold;
+      this.isAdjustedCountCorrect = isAdjustedCountCorrect;
+    }
+
+    @Override
+    public SamplingIntent getSamplingIntent(
+        Context parentContext,
+        String name,
+        SpanKind spanKind,
+        Attributes attributes,
+        List<LinkData> parentLinks) {
+
+      return new SamplingIntent() {
+        @Override
+        public long getThreshold() {
+          return threshold;
+        }
+
+        @Override
+        public boolean isAdjustedCountReliable() {
+          return isAdjustedCountCorrect;
+        }
+      };
+    }
+
+    @Override
+    public String getDescription() {
+      return "MockSampler for tests";
+    }
+  }
+
   @Test
-  void testMinimumThreshold() {
-    ComposableSampler delegate1 = new ConsistentFixedThresholdSampler(0x80000000000000L);
-    ComposableSampler delegate2 = new ConsistentFixedThresholdSampler(0x30000000000000L);
-    ComposableSampler delegate3 = new ConsistentFixedThresholdSampler(0xa0000000000000L);
-    ComposableSampler sampler = ConsistentSampler.anyOf(delegate1, delegate2, delegate3);
+  void testMinimumThresholdWithAdjustedCount() {
+    Composable delegate1 = new TestSampler(0x80000000000000L, /* isAdjustedCountCorrect= */ false);
+    Composable delegate2 = new TestSampler(0x30000000000000L, /* isAdjustedCountCorrect= */ true);
+    Composable delegate3 = new TestSampler(0xa0000000000000L, /* isAdjustedCountCorrect= */ false);
+    Composable delegate4 = new TestSampler(0x30000000000000L, /* isAdjustedCountCorrect= */ false);
+
+    Composable sampler = ConsistentSampler.anyOf(delegate1, delegate2, delegate3, delegate4);
     SamplingIntent intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
     assertThat(intent.getThreshold()).isEqualTo(0x30000000000000L);
+    assertThat(intent.isAdjustedCountReliable()).isTrue();
+
+    // Change the delegate order
+    sampler = ConsistentSampler.anyOf(delegate1, delegate4, delegate3, delegate2);
+    intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
+    assertThat(intent.getThreshold()).isEqualTo(0x30000000000000L);
+    assertThat(intent.isAdjustedCountReliable()).isTrue();
+  }
+
+  @Test
+  void testMinimumThresholdWithoutAdjustedCount() {
+    Composable delegate1 = new TestSampler(0x80000000000000L, /* isAdjustedCountCorrect= */ true);
+    Composable delegate2 = new TestSampler(0x30000000000000L, /* isAdjustedCountCorrect= */ false);
+    Composable delegate3 = new TestSampler(0xa0000000000000L, /* isAdjustedCountCorrect= */ true);
+
+    Composable sampler = ConsistentSampler.anyOf(delegate1, delegate2, delegate3);
+    SamplingIntent intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
+    assertThat(intent.getThreshold()).isEqualTo(0x30000000000000L);
+    assertThat(intent.isAdjustedCountReliable()).isFalse();
   }
 
   @Test
   void testAlwaysDrop() {
-    ComposableSampler delegate1 = ConsistentSampler.alwaysOff();
-    ComposableSampler sampler = ConsistentSampler.anyOf(delegate1);
+    Composable delegate1 = ConsistentSampler.alwaysOff();
+    Composable sampler = ConsistentSampler.anyOf(delegate1);
     SamplingIntent intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
     assertThat(intent.getThreshold()).isEqualTo(getInvalidThreshold());
+    assertThat(intent.isAdjustedCountReliable()).isFalse();
   }
 
   @Test
@@ -36,27 +99,28 @@ class ConsistentAnyOfTest {
     AttributeKey<String> key1 = AttributeKey.stringKey("tag1");
     AttributeKey<String> key2 = AttributeKey.stringKey("tag2");
     AttributeKey<String> key3 = AttributeKey.stringKey("tag3");
-    ComposableSampler delegate1 =
+    Composable delegate1 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x30000000000000L), key1, "a");
-    ComposableSampler delegate2 =
+    Composable delegate2 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x50000000000000L), key2, "b");
-    ComposableSampler delegate3 = new MarkingSampler(ConsistentSampler.alwaysOff(), key3, "c");
-    ComposableSampler sampler = ConsistentSampler.anyOf(delegate1, delegate2, delegate3);
+    Composable delegate3 = new MarkingSampler(ConsistentSampler.alwaysOff(), key3, "c");
+    Composable sampler = ConsistentSampler.anyOf(delegate1, delegate2, delegate3);
     SamplingIntent intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
     assertThat(intent.getAttributes().get(key1)).isEqualTo("a");
     assertThat(intent.getAttributes().get(key2)).isEqualTo("b");
     assertThat(intent.getAttributes().get(key3)).isEqualTo("c");
     assertThat(intent.getThreshold()).isEqualTo(0x30000000000000L);
+    assertThat(intent.isAdjustedCountReliable()).isTrue();
   }
 
   @Test
   void testSpanAttributeOverride() {
     AttributeKey<String> key1 = AttributeKey.stringKey("shared");
-    ComposableSampler delegate1 =
+    Composable delegate1 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x30000000000000L), key1, "a");
-    ComposableSampler delegate2 =
+    Composable delegate2 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x50000000000000L), key1, "b");
-    ComposableSampler sampler = ConsistentSampler.anyOf(delegate1, delegate2);
+    Composable sampler = ConsistentSampler.anyOf(delegate1, delegate2);
     SamplingIntent intent = sampler.getSamplingIntent(null, "span_name", null, null, null);
     assertThat(intent.getAttributes().get(key1)).isEqualTo("b");
   }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRateLimitingSamplerTest.java
@@ -64,7 +64,7 @@ class ConsistentRateLimitingSamplerTest {
     double targetSpansPerSecondLimit = 1000;
     double adaptationTimeSeconds = 5;
 
-    ComposableSampler delegate =
+    Composable delegate =
         new CoinFlipSampler(ConsistentSampler.alwaysOff(), ConsistentSampler.probabilityBased(0.8));
     ConsistentSampler sampler =
         ConsistentSampler.rateLimited(
@@ -105,7 +105,7 @@ class ConsistentRateLimitingSamplerTest {
     double targetSpansPerSecondLimit = 1000;
     double adaptationTimeSeconds = 5;
 
-    ComposableSampler delegate =
+    Composable delegate =
         new CoinFlipSampler(ConsistentSampler.alwaysOff(), ConsistentSampler.probabilityBased(0.8));
     ConsistentSampler sampler =
         ConsistentSampler.rateLimited(
@@ -305,7 +305,7 @@ class ConsistentRateLimitingSamplerTest {
     double adaptationTimeSeconds = 5;
     AttributeKey<String> key = AttributeKey.stringKey("category");
 
-    ComposableSampler delegate =
+    Composable delegate =
         new CoinFlipSampler(
             new MarkingSampler(ConsistentSampler.probabilityBased(0.6), key, "A"),
             new MarkingSampler(ConsistentSampler.probabilityBased(0.4), key, "B"));

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRuleBasedSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentRuleBasedSamplerTest.java
@@ -16,7 +16,7 @@ class ConsistentRuleBasedSamplerTest {
 
   @Test
   void testEmptySet() {
-    ComposableSampler sampler = ConsistentSampler.ruleBased(SpanKind.SERVER);
+    Composable sampler = ConsistentSampler.ruleBased(SpanKind.SERVER);
     SamplingIntent intent =
         sampler.getSamplingIntent(null, "span_name", SpanKind.SERVER, null, null);
     assertThat(intent.getThreshold()).isEqualTo(getInvalidThreshold());
@@ -36,14 +36,14 @@ class ConsistentRuleBasedSamplerTest {
     AttributeKey<String> key2 = AttributeKey.stringKey("tag2");
     AttributeKey<String> key3 = AttributeKey.stringKey("tag3");
 
-    ComposableSampler delegate1 =
+    Composable delegate1 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x80000000000000L), key1, "a");
-    ComposableSampler delegate2 =
+    Composable delegate2 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x50000000000000L), key2, "b");
-    ComposableSampler delegate3 =
+    Composable delegate3 =
         new MarkingSampler(new ConsistentFixedThresholdSampler(0x30000000000000L), key3, "c");
 
-    ComposableSampler sampler =
+    Composable sampler =
         ConsistentSampler.ruleBased(
             null,
             PredicatedSampler.onMatch(matchSpanName("A"), delegate1),
@@ -79,7 +79,7 @@ class ConsistentRuleBasedSamplerTest {
 
   @Test
   void testSpanKindMatch() {
-    ComposableSampler sampler =
+    Composable sampler =
         ConsistentSampler.ruleBased(
             SpanKind.CLIENT,
             PredicatedSampler.onMatch(Predicate.anySpan(), ConsistentSampler.alwaysOn()));

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSamplerTest.java
@@ -200,6 +200,42 @@ class ConsistentSamplerTest {
   }
 
   @Test
+  void testParentBasedInConsistentMode() {
+
+    long parentRandomValue = 0x7f99aa40c02744L;
+
+    Input input = new Input();
+    input.setParentRandomValue(parentRandomValue);
+    input.setParentThreshold(parentRandomValue);
+    input.setParentSampled(false); // should be ignored
+
+    ConsistentSampler sampler = ConsistentSampler.parentBased(ConsistentSampler.alwaysOn());
+
+    Output output = sample(input, sampler);
+
+    assertThat(output.samplingResult.getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
+    assertThat(output.getThreshold()).hasValue(parentRandomValue);
+    assertThat(output.getRandomValue()).hasValue(parentRandomValue);
+    assertThat(output.getSampledFlag()).isTrue();
+  }
+
+  @Test
+  void testParentBasedInLegacyMode() {
+
+    // No parent threshold present
+    Input input = new Input();
+
+    ConsistentSampler sampler = ConsistentSampler.parentBased(ConsistentSampler.alwaysOn());
+
+    Output output = sample(input, sampler);
+
+    assertThat(output.samplingResult.getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
+    assertThat(output.getThreshold()).isNotPresent();
+    assertThat(output.getRandomValue()).isNotPresent();
+    assertThat(output.getSampledFlag()).isTrue();
+  }
+
+  @Test
   void testHalfThresholdNotSampled() {
 
     Input input = new Input();

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/MarkingSampler.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/MarkingSampler.java
@@ -23,9 +23,9 @@ import javax.annotation.concurrent.Immutable;
  * could be also offered as a general utility.
  */
 @Immutable
-final class MarkingSampler implements ComposableSampler {
+final class MarkingSampler implements Composable {
 
-  private final ComposableSampler delegate;
+  private final Composable delegate;
   private final AttributeKey<String> attributeKey;
   private final String attributeValue;
 
@@ -38,8 +38,7 @@ final class MarkingSampler implements ComposableSampler {
    * @param attributeKey Span attribute key
    * @param attributeValue Span attribute value
    */
-  MarkingSampler(
-      ComposableSampler delegate, AttributeKey<String> attributeKey, String attributeValue) {
+  MarkingSampler(Composable delegate, AttributeKey<String> attributeKey, String attributeValue) {
     this.delegate = requireNonNull(delegate);
     this.attributeKey = requireNonNull(attributeKey);
     this.attributeValue = requireNonNull(attributeValue);

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/UseCaseTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/UseCaseTest.java
@@ -67,7 +67,7 @@ class UseCaseTest {
             (parentContext, name, spanKind, attributes, parentLinks) -> {
               return "/checkout".equals(attributes.get(httpTarget));
             });
-    ComposableSampler s1 =
+    Composable s1 =
         ConsistentSampler.parentBased(
             ConsistentSampler.ruleBased(
                 null,
@@ -79,8 +79,8 @@ class UseCaseTest {
           return "/foo".equals(attributes.get(httpUrl));
         };
 
-    ComposableSampler s2 = ConsistentSampler.ruleBased(SpanKind.CLIENT, onMatch(foo, alwaysOn()));
-    ComposableSampler s3 = ConsistentSampler.anyOf(s1, s2);
+    Composable s2 = ConsistentSampler.ruleBased(SpanKind.CLIENT, onMatch(foo, alwaysOn()));
+    Composable s3 = ConsistentSampler.anyOf(s1, s2);
     return ConsistentSampler.rateLimited(s3, 1000.0, 5, UseCaseTest::nanoTime);
   }
 


### PR DESCRIPTION
**Description:**

Extended `SamplingIntent` to support cases when the threshold can be used to arrive at the final sampling decision, but should not be used to calculate adjusted count.
This is done to handle situations when an upstream service is using legacy (not consistent probability) sampling.


**Documentation:**

See https://github.com/open-telemetry/opentelemetry-specification/pull/4321 for detailed description.