### PR TITLE
GCP Auth extension - allow users to specify quota project ID

### DIFF
--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -39,7 +39,7 @@ Here is a list of configurable options for the extension:
   - This is a required option, the agent configuration will fail if this option is not set.
 - `GOOGLE_CLOUD_QUOTA_PROJECT`: Environment variable that represents the Google Cloud Quota Project ID which will be charged for the GCP API usage. To learn more about a *quota project*, see [here](https://cloud.google.com/docs/quotas/quota-project).
   - Can also be configured using `google.cloud.quota.project` system property.
-  - If this option is not configured, the extension would infer GCP Quota Project ID from the application default credentials. For more information on application default credentials, see [here](https://cloud.google.com/docs/authentication/application-default-credentials).
+  - If this option is not configured, the extension will use the Quota Project ID found in the Application Default Credentials (ADC), if available. For more information on application default credentials, see [here](https://cloud.google.com/docs/authentication/application-default-credentials).
 
 ## Usage
 

--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -36,7 +36,7 @@ Here is a list of configurable options for the extension:
 
 - `GOOGLE_CLOUD_PROJECT`: Environment variable that represents the Google Cloud Project ID to which the telemetry needs to be exported.
   - Can also be configured using `google.cloud.project` system property.
-  - This is a required option, the telemetry export to GCP will fail.
+  - This is a required option, the agent configuration will fail if this option is not set.
 - `GOOGLE_CLOUD_QUOTA_PROJECT`: Environment variable that represents the Google Cloud Quota Project ID which will be charged for the GCP API usage. To learn more about a *quota project*, see [here](https://cloud.google.com/docs/quotas/quota-project).
   - Can also be configured using `google.cloud.quota.project` system property.
   - If this option is not configured, the extension would infer GCP Quota Project ID from the application default credentials. For more information on application default credentials, see [here](https://cloud.google.com/docs/authentication/application-default-credentials).

--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -36,7 +36,10 @@ Here is a list of configurable options for the extension:
 
 - `GOOGLE_CLOUD_PROJECT`: Environment variable that represents the Google Cloud Project ID to which the telemetry needs to be exported.
   - Can also be configured using `google.cloud.project` system property.
-  - If this option is not configured, the extension would infer GCP Project ID from the application default credentials. For more information on application default credentials, see [here](https://cloud.google.com/docs/authentication/application-default-credentials).
+  - This is a required option, the telemetry export to GCP will fail.
+- `GOOGLE_CLOUD_QUOTA_PROJECT`: Environment variable that represents the Google Cloud Quota Project ID which will be charged for the GCP API usage. To learn more about a *quota project*, see [here](https://cloud.google.com/docs/quotas/quota-project).
+  - Can also be configured using `google.cloud.quota.project` system property.
+  - If this option is not configured, the extension would infer GCP Quota Project ID from the application default credentials. For more information on application default credentials, see [here](https://cloud.google.com/docs/authentication/application-default-credentials).
 
 ## Usage
 

--- a/gcp-auth-extension/build.gradle.kts
+++ b/gcp-auth-extension/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   testCompileOnly("com.google.auto.service:auto-service-annotations")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
   testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testCompileOnly("org.junit.jupiter:junit-jupiter-params")
 
   testImplementation("io.opentelemetry:opentelemetry-api")
   testImplementation("io.opentelemetry:opentelemetry-exporter-otlp")
@@ -44,6 +45,9 @@ dependencies {
   testImplementation("org.springframework.boot:spring-boot-starter-web:2.7.18")
   testImplementation("org.springframework.boot:spring-boot-starter:2.7.18")
   testImplementation("org.springframework.boot:spring-boot-starter-test:2.7.18")
+
+  testAnnotationProcessor("com.google.auto.value:auto-value")
+  testCompileOnly("com.google.auto.value:auto-value-annotations")
 
   agent("io.opentelemetry.javaagent:opentelemetry-javaagent")
 }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -18,7 +18,18 @@ public enum ConfigurableOption {
    * Represents the Google Cloud Project ID option. Can be configured using the environment variable
    * `GOOGLE_CLOUD_PROJECT` or the system property `google.cloud.project`.
    */
-  GOOGLE_CLOUD_PROJECT("Google Cloud Project ID");
+  GOOGLE_CLOUD_PROJECT("Google Cloud Project ID"),
+
+  /**
+   * Represents the Google Cloud Quota Project ID option. Can be configured using the environment
+   * variable `GOOGLE_CLOUD_QUOTA_PROJECT` or the system property `google.cloud.quota.project`. The
+   * quota project is the project that is used for quota management and billing for the API usage.
+   *
+   * <p>The environment variable name is selected to be consistent with the <a
+   * href="https://cloud.google.com/docs/quotas/set-quota-project">official GCP client
+   * libraries</a>.
+   */
+  GOOGLE_CLOUD_QUOTA_PROJECT("Google Cloud Quota Project ID");
 
   private final String userReadableName;
   private final String environmentVariableName;

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -201,9 +201,16 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   @Test
   public void testCustomizerFailWithMissingResourceProject() {
     OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-    assertThrows(
-        ConfigurationException.class,
-        () -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter));
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockedGoogleCredentials);
+
+      assertThrows(
+          ConfigurationException.class,
+          () -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter));
+    }
   }
 
   @SuppressWarnings("CannotMockMethod")


### PR DESCRIPTION
**Description:**

This PR provides an optional argument that lets the users specify a quota project ID.

**Existing Issue(s):**

Fixes #1645 

**Testing:**
 - Unit tests verifying `google.cloud.project` as required field added.
 - Manually tested the extension JAR with test applications.

**Documentation:**

Updates to the README reflecting the user facing changes added.

**Outstanding items:**

Add parameterized unit tests to ensure behavior around null or empty values for the project IDs.
