### PR TITLE
add xray-lambda configurable propagator to autoconfigure spi

### DIFF
--- a/aws-xray-propagator/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
+++ b/aws-xray-propagator/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.contrib.awsxray.propagator.internal.AwsConfigurablePropagator
+io.opentelemetry.contrib.awsxray.propagator.internal.AwsXrayLambdaConfigurablePropagator


### PR DESCRIPTION
**Description:**
Bug fix - The xray-lambda spi wasnt added

**Existing Issue(s):**

[AWS Xray Propagator missing SPI file for xray-lambda propagation](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1668)

**Testing:**
No testing was performed

**Documentation:**
N/A

**Outstanding items:**

I am still investigating how to get xray-lambda to work with the java wrapper layer in this issue: https://github.com/open-telemetry/opentelemetry-lambda/issues/1669
