### PR TITLE
JMX Scraper: Kafka server, producer and consumer YAMLs and integration tests added

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaConsumerIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaConsumerIntegrationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.target_systems.kafka;
+
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeWithAnyValue;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaConsumerContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaProducerContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createZookeeperContainer;
+
+import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
+import io.opentelemetry.contrib.jmxscraper.target_systems.MetricsVerifier;
+import io.opentelemetry.contrib.jmxscraper.target_systems.TargetSystemIntegrationTest;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class KafkaConsumerIntegrationTest extends TargetSystemIntegrationTest {
+
+  @Override
+  protected Collection<GenericContainer<?>> createPrerequisiteContainers() {
+    GenericContainer<?> zookeeper =
+        createZookeeperContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("zookeeper")))
+            .withNetworkAliases("zookeeper");
+
+    GenericContainer<?> kafka =
+        createKafkaContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka")))
+            .withNetworkAliases("kafka")
+            .dependsOn(zookeeper);
+
+    GenericContainer<?> kafkaProducer =
+        createKafkaProducerContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka-producer")))
+            .withNetworkAliases("kafka-producer")
+            .dependsOn(kafka);
+
+    return Arrays.asList(zookeeper, kafka, kafkaProducer);
+  }
+
+  @Override
+  protected GenericContainer<?> createTargetContainer(int jmxPort) {
+    return createKafkaConsumerContainer()
+        .withEnv("JMX_PORT", Integer.toString(jmxPort))
+        .withExposedPorts(jmxPort)
+        .waitingFor(Wait.forListeningPorts(jmxPort));
+  }
+
+  @Override
+  protected JmxScraperContainer customizeScraperContainer(
+      JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
+    return scraper.withTargetSystem("kafka-consumer");
+  }
+
+  @Override
+  protected MetricsVerifier createMetricsVerifier() {
+    return MetricsVerifier.create()
+        .add(
+            "kafka.consumer.fetch-rate",
+            metric ->
+                metric
+                    .hasDescription("The number of fetch requests for all topics per second")
+                    .hasUnit("{request}")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(
+                        attributeWithAnyValue("client.id"))) // changed to follow semconv
+        .add(
+            "kafka.consumer.records-lag-max",
+            metric ->
+                metric
+                    .hasDescription("Number of messages the consumer lags behind the producer")
+                    .hasUnit("{message}")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.consumer.total.bytes-consumed-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average number of bytes consumed for all topics per second")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.consumer.total.fetch-size-avg",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average number of bytes fetched per request for all topics")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.consumer.total.records-consumed-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average number of records consumed for all topics per second")
+                    .hasUnit("{record}")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.consumer.bytes-consumed-rate",
+            metric ->
+                metric
+                    .hasDescription("The average number of bytes consumed per second")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"),
+                            attribute("topic", "test-topic-1"))))
+        .add(
+            "kafka.consumer.fetch-size-avg",
+            metric ->
+                metric
+                    .hasDescription("The average number of bytes fetched per request")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"),
+                            attribute("topic", "test-topic-1"))))
+        .add(
+            "kafka.consumer.records-consumed-rate",
+            metric ->
+                metric
+                    .hasDescription("The average number of records consumed per second")
+                    .hasUnit("{record}")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"),
+                            attribute("topic", "test-topic-1"))));
+  }
+}

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaContainerFactory.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaContainerFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.target_systems.kafka;
+
+import java.time.Duration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class KafkaContainerFactory {
+  private static final int KAFKA_PORT = 9092;
+  private static final String KAFKA_BROKER = "kafka:" + KAFKA_PORT;
+  private static final String KAFKA_DOCKER_IMAGE = "bitnami/kafka:2.8.1";
+
+  private KafkaContainerFactory() {}
+
+  public static GenericContainer<?> createZookeeperContainer() {
+    return new GenericContainer<>("zookeeper:3.5")
+        .withStartupTimeout(Duration.ofMinutes(2))
+        .waitingFor(Wait.forListeningPort());
+  }
+
+  public static GenericContainer<?> createKafkaContainer() {
+    return new GenericContainer<>(KAFKA_DOCKER_IMAGE)
+        .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
+        .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes") // Removed in 3.5.1
+        .withStartupTimeout(Duration.ofMinutes(2))
+        .withExposedPorts(KAFKA_PORT)
+        //        .waitingFor(Wait.forListeningPorts(KAFKA_PORT));
+        .waitingFor(
+            Wait.forLogMessage(".*KafkaServer.*started \\(kafka.server.KafkaServer\\).*", 1));
+  }
+
+  public static GenericContainer<?> createKafkaProducerContainer() {
+    return new GenericContainer<>(KAFKA_DOCKER_IMAGE)
+        //        .withCopyFileToContainer(
+        //            MountableFile.forClasspathResource("kafka-producer.sh"),
+        //            "/usr/bin/kafka-producer.sh")
+        //        .withCommand("/usr/bin/kafka-producer.sh")
+        .withCommand(
+            "sh",
+            "-c",
+            "echo 'Sending messages to test-topic-1'; "
+                + "i=1; while true; do echo \"Message $i\"; sleep .25; i=$((i+1)); done | /opt/bitnami/kafka/bin/kafka-console-producer.sh --bootstrap-server "
+                + KAFKA_BROKER
+                + " --topic test-topic-1;")
+        .withStartupTimeout(Duration.ofMinutes(2))
+        .waitingFor(Wait.forLogMessage(".*Welcome to the Bitnami kafka container.*", 1));
+  }
+
+  public static GenericContainer<?> createKafkaConsumerContainer() {
+    return new GenericContainer<>(KAFKA_DOCKER_IMAGE)
+        .withCommand(
+            "kafka-console-consumer.sh",
+            "--bootstrap-server",
+            KAFKA_BROKER,
+            "--whitelist",
+            "test-topic-.*",
+            "--max-messages",
+            "100")
+        .withStartupTimeout(Duration.ofMinutes(2))
+        .waitingFor(Wait.forListeningPort());
+  }
+}

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.target_systems.kafka;
+
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createZookeeperContainer;
+
+import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
+import io.opentelemetry.contrib.jmxscraper.assertions.AttributeMatcherGroup;
+import io.opentelemetry.contrib.jmxscraper.target_systems.MetricsVerifier;
+import io.opentelemetry.contrib.jmxscraper.target_systems.TargetSystemIntegrationTest;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+public class KafkaIntegrationTest extends TargetSystemIntegrationTest {
+  @Override
+  protected Collection<GenericContainer<?>> createPrerequisiteContainers() {
+    GenericContainer<?> zookeeper =
+        createZookeeperContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("zookeeper")))
+            .withNetworkAliases("zookeeper");
+
+    return Collections.singletonList(zookeeper);
+  }
+
+  @Override
+  protected GenericContainer<?> createTargetContainer(int jmxPort) {
+    return createKafkaContainer().withEnv("JMX_PORT", Integer.toString(jmxPort));
+  }
+
+  @Override
+  protected JmxScraperContainer customizeScraperContainer(
+      JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
+    return scraper.withTargetSystem("kafka");
+  }
+
+  @Override
+  protected MetricsVerifier createMetricsVerifier() {
+    AttributeMatcherGroup[] requestTypes = {
+      // attribute values are changed from lowercase to PascalCase
+      // because it is impossible to make them lowercase with YAML config
+      // TODO: What about const value attributes defined in YAML that are lowercase?
+      attributeGroup(attribute("type", "Produce")),
+      attributeGroup(attribute("type", "FetchFollower")),
+      attributeGroup(attribute("type", "FetchConsumer"))
+    };
+
+    return MetricsVerifier.create()
+        .add(
+            "kafka.message.count",
+            metric ->
+                metric
+                    .hasDescription("The number of messages received by the broker")
+                    .hasUnit("{message}")
+                    .isCounter()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.request.count",
+            metric ->
+                metric
+                    .hasDescription("The number of requests received by the broker")
+                    .hasUnit("{request}")
+                    .isCounter()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(attribute("type", "produce")),
+                        attributeGroup(attribute("type", "fetch"))))
+        .add(
+            "kafka.request.failed",
+            metric ->
+                metric
+                    .hasDescription("The number of requests to the broker resulting in a failure")
+                    .hasUnit("{request}")
+                    .isCounter()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(attribute("type", "produce")),
+                        attributeGroup(attribute("type", "fetch"))))
+        .add(
+            "kafka.network.io",
+            metric ->
+                metric
+                    .hasDescription("The bytes received or sent by the broker")
+                    .hasUnit("By")
+                    .isCounter()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(attribute("direction", "in")),
+                        attributeGroup(attribute("direction", "out"))))
+        .add(
+            "kafka.purgatory.size",
+            metric ->
+                metric
+                    .hasDescription("The number of requests waiting in purgatory")
+                    .hasUnit("{request}")
+                    .isUpDownCounter()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(attribute("type", "Produce")),
+                        attributeGroup(attribute("type", "Fetch"))))
+        .add(
+            "kafka.request.time.total",
+            metric ->
+                metric
+                    .hasDescription("The total time the broker has taken to service requests")
+                    .hasUnit("ms")
+                    .isCounter()
+                    .hasDataPointsWithAttributes(requestTypes))
+        .add(
+            "kafka.request.time.50p",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The 50th percentile time the broker has taken to service requests")
+                    .hasUnit("ms")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(requestTypes))
+        .add(
+            "kafka.request.time.99p",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The 99th percentile time the broker has taken to service requests")
+                    .hasUnit("ms")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(requestTypes))
+        .add(
+            "kafka.request.time.avg",
+            metric ->
+                metric
+                    .hasDescription("The average time the broker has taken to service requests")
+                    .hasUnit("ms")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(requestTypes))
+        .add(
+            "kafka.request.queue",
+            metric ->
+                metric
+                    .hasDescription("Size of the request queue")
+                    .hasUnit("{request}")
+                    .isUpDownCounter()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.partition.count",
+            metric ->
+                metric
+                    .hasDescription("The number of partitions on the broker")
+                    .hasUnit("{partition}")
+                    .isGauge()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.partition.offline",
+            metric ->
+                metric
+                    .hasDescription("The number of partitions offline")
+                    .hasUnit("{partition}")
+                    .isGauge()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.partition.under_replicated",
+            metric ->
+                metric
+                    .hasDescription("The number of under replicated partitions")
+                    .hasUnit("{partition}")
+                    .isGauge()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.isr.operation.count",
+            metric ->
+                metric
+                    .hasDescription("The number of in-sync replica shrink and expand operations")
+                    .hasUnit("{operation}")
+                    .isCounter()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(attribute("operation", "shrink")),
+                        attributeGroup(attribute("operation", "expand"))))
+        .add(
+            "kafka.controller.active.count",
+            metric ->
+                metric
+                    .hasDescription("The number of controllers active on the broker") // CHANGED
+                    .hasUnit("{controller}")
+                    .isUpDownCounter() // CHANGED
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.leader.election.count", // CHANGED from "kafka.leader.election.rate"
+            metric ->
+                metric
+                    .hasDescription("The leader election count")
+                    .hasUnit("{election}")
+                    .isCounter()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.leader.election.unclean.count", // CHANGED from "kafka.unclean.election.rate"
+            metric ->
+                metric
+                    .hasDescription(
+                        "Unclean leader election count - increasing indicates broker failures") // CHANGED
+                    .hasUnit("{election}")
+                    .isCounter()
+                    .hasDataPointsWithoutAttributes())
+        .add(
+            "kafka.lag.max", // CHANGED from "kafka.max.lag"
+            metric ->
+                metric
+                    .hasDescription(
+                        "The max lag in messages between follower and leader replicas") // CHANGED
+                    .hasUnit("{message}")
+                    .isGauge()
+                    .hasDataPointsWithoutAttributes())
+
+    // TODO: Find out how to force Kafka to generate these metrics
+    //        .add(
+    //            "kafka.logs.flush.count",
+    //            metric ->
+    //                metric
+    //                    .hasDescription("Log flush count")
+    //                    .hasUnit("{flush}")
+    //                    .isCounter()
+    //                    .hasDataPointsWithoutAttributes())
+    //        .add(
+    //            "kafka.logs.flush.time.median",
+    //            metric ->
+    //                metric
+    //                    .hasDescription("Log flush time - 50th percentile")
+    //                    .hasUnit("ms")
+    //                    .isGauge()
+    //                    .hasDataPointsWithoutAttributes())
+    //        .add(
+    //            "kafka.logs.flush.time.99p",
+    //            metric ->
+    //                metric
+    //                    .hasDescription("Log flush time - 99th percentile")
+    //                    .hasUnit("ms")
+    //                    .isGauge()
+    //                    .hasDataPointsWithoutAttributes())
+    ;
+  }
+}

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaProducerIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/kafka/KafkaProducerIntegrationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.target_systems.kafka;
+
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attribute;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeGroup;
+import static io.opentelemetry.contrib.jmxscraper.assertions.DataPointAttributes.attributeWithAnyValue;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createKafkaProducerContainer;
+import static io.opentelemetry.contrib.jmxscraper.target_systems.kafka.KafkaContainerFactory.createZookeeperContainer;
+
+import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
+import io.opentelemetry.contrib.jmxscraper.target_systems.MetricsVerifier;
+import io.opentelemetry.contrib.jmxscraper.target_systems.TargetSystemIntegrationTest;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class KafkaProducerIntegrationTest extends TargetSystemIntegrationTest {
+
+  @Override
+  protected Collection<GenericContainer<?>> createPrerequisiteContainers() {
+    GenericContainer<?> zookeeper =
+        createZookeeperContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("zookeeper")))
+            .withNetworkAliases("zookeeper");
+
+    GenericContainer<?> kafka =
+        createKafkaContainer()
+            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("kafka")))
+            .withNetworkAliases("kafka")
+            .dependsOn(zookeeper);
+
+    return Arrays.asList(zookeeper, kafka);
+  }
+
+  @Override
+  protected GenericContainer<?> createTargetContainer(int jmxPort) {
+    return createKafkaProducerContainer()
+        .withEnv("JMX_PORT", Integer.toString(jmxPort))
+        .withExposedPorts(jmxPort)
+        .waitingFor(Wait.forListeningPorts(jmxPort));
+    //        .waitingFor(Wait.forLogMessage(".*Sending messages to test-topic-1.*", 1));
+    // Container is started and ready for serve JMX metrics once it begins sending messages.
+  }
+
+  @Override
+  protected JmxScraperContainer customizeScraperContainer(
+      JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
+    return scraper.withTargetSystem("kafka-producer");
+  }
+
+  @Override
+  protected MetricsVerifier createMetricsVerifier() {
+    String topic = "test-topic-1";
+
+    return MetricsVerifier.create()
+        .add(
+            "kafka.producer.io-wait-time-ns-avg",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average length of time the I/O thread spent waiting for a socket ready for reads or writes")
+                    .hasUnit("ns")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.producer.outgoing-byte-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average number of outgoing bytes sent per second to all servers")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.producer.request-latency-avg",
+            metric ->
+                metric
+                    .hasDescription("The average request latency")
+                    .hasUnit("ms")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.producer.request-rate",
+            metric ->
+                metric
+                    .hasDescription("The average number of requests sent per second")
+                    .hasUnit("{request}")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+        .add(
+            "kafka.producer.response-rate",
+            metric ->
+                metric
+                    .hasDescription("Responses received per second")
+                    .hasUnit("{response}")
+                    .isGauge()
+                    .hasDataPointsWithOneAttribute(attributeWithAnyValue("client.id")))
+
+        // Per topic metrics
+        .add(
+            "kafka.producer.byte-rate",
+            metric ->
+                metric
+                    .hasDescription("The average number of bytes sent per second for a topic")
+                    .hasUnit("By")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"), attribute("topic", topic))))
+        .add(
+            "kafka.producer.compression-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average compression rate of record batches for a topic, defined as the average ratio of the compressed batch size divided by the uncompressed size")
+                    .hasUnit("{ratio}")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"), attribute("topic", topic))))
+        .add(
+            "kafka.producer.record-error-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average per-second number of record sends that resulted in errors for a topic")
+                    .hasUnit("{record}")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"), attribute("topic", topic))))
+        .add(
+            "kafka.producer.record-retry-rate",
+            metric ->
+                metric
+                    .hasDescription(
+                        "The average per-second number of retried record sends for a topic")
+                    .hasUnit("{record}")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"), attribute("topic", topic))))
+        .add(
+            "kafka.producer.record-send-rate",
+            metric ->
+                metric
+                    .hasDescription("The average number of records sent per second for a topic")
+                    .hasUnit("{record}")
+                    .isGauge()
+                    .hasDataPointsWithAttributes(
+                        attributeGroup(
+                            attributeWithAnyValue("client.id"), attribute("topic", topic))));
+  }
+}

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
@@ -185,7 +185,7 @@ public class JmxScraper {
         RuleParser parserInstance = RuleParser.get();
         parserInstance.addMetricDefsTo(conf, inputStream, system);
       } else {
-        throw new IllegalArgumentException("No support for system" + system);
+        throw new IllegalArgumentException("No support for system " + system);
       }
     } catch (Exception e) {
       throw new IllegalStateException("Error while loading rules for system " + system, e);

--- a/jmx-scraper/src/main/resources/kafka-consumer.yaml
+++ b/jmx-scraper/src/main/resources/kafka-consumer.yaml
@@ -1,0 +1,44 @@
+---
+# Kafka Consumer metrics
+rules:
+
+  - bean: kafka.consumer:client-id=*,type=consumer-fetch-manager-metrics
+    metricAttribute:
+      client.id: param(client-id)
+    prefix: kafka.consumer.
+    type: gauge
+    mapping:
+      fetch-rate:
+        desc: The number of fetch requests for all topics per second
+        unit: '{request}'
+      records-lag-max:
+        desc: Number of messages the consumer lags behind the producer
+        unit: '{message}'
+      bytes-consumed-rate:
+        metric: total.bytes-consumed-rate
+        desc: The average number of bytes consumed for all topics per second
+        unit: 'By'
+      fetch-size-avg:
+        metric: total.fetch-size-avg
+        desc: The average number of bytes fetched per request for all topics
+        unit: 'By'
+      records-consumed-rate:
+        metric: total.records-consumed-rate
+        desc: The average number of records consumed for all topics per second
+        unit: '{record}'
+
+  - bean: kafka.consumer:client-id=*,topic=*,type=consumer-fetch-manager-metrics
+    metricAttribute:
+      client.id: param(client-id)
+      topic: param(topic)
+    prefix: kafka.consumer.
+    unit: By
+    type: gauge
+    mapping:
+      bytes-consumed-rate:
+        desc: The average number of bytes consumed per second
+      fetch-size-avg:
+        desc: The average number of bytes fetched per request
+      records-consumed-rate:
+        desc: The average number of records consumed per second
+        unit: '{record}'

--- a/jmx-scraper/src/main/resources/kafka-producer.yaml
+++ b/jmx-scraper/src/main/resources/kafka-producer.yaml
@@ -1,0 +1,46 @@
+---
+# Kafka Producer metrics
+rules:
+  - bean: kafka.producer:client-id=*,type=producer-metrics
+    metricAttribute:
+      client.id: param(client-id)
+    prefix: kafka.producer.
+    type: gauge
+    mapping:
+      io-wait-time-ns-avg:
+        desc: The average length of time the I/O thread spent waiting for a socket ready for reads or writes
+        unit: ns
+      outgoing-byte-rate:
+        desc: The average number of outgoing bytes sent per second to all servers
+        unit: By
+      request-latency-avg:
+        desc: The average request latency
+        unit: ms
+      request-rate:
+        desc: The average number of requests sent per second
+        unit: '{request}'
+      response-rate:
+        desc: Responses received per second
+        unit: '{response}'
+
+  # per topic metrics
+  - bean: kafka.producer:client-id=*,topic=*,type=producer-topic-metrics
+    metricAttribute:
+      client.id: param(client-id)
+      topic: param(topic)
+    prefix: kafka.producer.
+    unit: '{record}'
+    type: gauge
+    mapping:
+      byte-rate:
+        desc: The average number of bytes sent per second for a topic
+        unit: By
+      compression-rate:
+        desc: The average compression rate of record batches for a topic, defined as the average ratio of the compressed batch size divided by the uncompressed size
+        unit: '{ratio}'
+      record-error-rate:
+        desc: The average per-second number of record sends that resulted in errors for a topic
+      record-retry-rate:
+        desc: The average per-second number of retried record sends for a topic
+      record-send-rate:
+        desc: The average number of records sent per second for a topic

--- a/jmx-scraper/src/main/resources/kafka.yaml
+++ b/jmx-scraper/src/main/resources/kafka.yaml
@@ -1,0 +1,215 @@
+---
+rules:
+  # Broker metrics
+
+  - bean: kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec
+    mapping:
+      Count:
+        metric: kafka.message.count
+        type: counter
+        desc: The number of messages received by the broker
+        unit: "{message}"
+
+  # TODO: optimize kafka.request.count - use refs
+  - bean: kafka.server:type=BrokerTopicMetrics,name=TotalFetchRequestsPerSec
+    metricAttribute:
+      # TODO: Should we convert all constant values to be PascalCase for consistency with values from bean params?
+      type: const(fetch)
+    mapping:
+      Count:
+        metric: kafka.request.count
+        type: counter
+        desc: The number of requests received by the broker
+        unit: "{request}"
+
+  - bean: kafka.server:type=BrokerTopicMetrics,name=TotalProduceRequestsPerSec
+    metricAttribute:
+      type: const(produce)
+    mapping:
+      Count:
+        metric: kafka.request.count
+        type: counter
+        desc: The number of requests received by the broker
+        unit: "{request}"
+
+  # TODO: optimize kafka.request.failed - use refs
+  - bean: kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec
+    metricAttribute:
+      type: const(fetch)
+    mapping:
+      Count:
+        metric: kafka.request.failed
+        type: counter
+        desc: The number of requests to the broker resulting in a failure
+        unit: "{request}"
+
+  - bean: kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec
+    metricAttribute:
+      type: const(produce)
+    mapping:
+      Count:
+        metric: kafka.request.failed
+        type: counter
+        desc: The number of requests to the broker resulting in a failure
+        unit: "{request}"
+
+  - beans:
+      - kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce
+      - kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchConsumer
+      - kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchFollower
+    metricAttribute:
+      type: param(request)
+    unit: ms
+    mapping:
+      Count:
+        metric: kafka.request.time.total
+        type: counter
+        desc: The total time the broker has taken to service requests
+      50thPercentile:
+        metric: kafka.request.time.50p
+        type: gauge
+        desc: The 50th percentile time the broker has taken to service requests
+      99thPercentile:
+        metric: kafka.request.time.99p
+        type: gauge
+        desc: The 99th percentile time the broker has taken to service requests
+      # Added
+      Mean:
+        metric: kafka.request.time.avg
+        type: gauge
+        desc: The average time the broker has taken to service requests
+
+  - bean: kafka.network:type=RequestChannel,name=RequestQueueSize
+    mapping:
+      Value:
+        metric: kafka.request.queue
+        type: updowncounter
+        desc: Size of the request queue
+        unit: "{request}"
+
+  # TODO: optimize kafka.network.io - use refs
+  - bean: kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec
+    metricAttribute:
+      direction: const(in)
+    mapping:
+      Count:
+        metric: kafka.network.io
+        type: counter
+        desc: The bytes received or sent by the broker
+        unit: By
+
+  - bean: kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec
+    metricAttribute:
+      direction: const(out)
+    mapping:
+      Count:
+        metric: kafka.network.io
+        type: counter
+        desc: The bytes received or sent by the broker
+        unit: By
+
+  - beans:
+      - kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Produce
+      - kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Fetch
+    metricAttribute:
+      type: param(delayedOperation)
+    mapping:
+      Value:
+        metric: kafka.purgatory.size
+        type: updowncounter
+        desc: The number of requests waiting in purgatory
+        unit: "{request}"
+
+  - bean: kafka.server:type=ReplicaManager,name=PartitionCount
+    mapping:
+      Value:
+        metric: kafka.partition.count
+        type: gauge
+        desc: The number of partitions on the broker
+        unit: "{partition}"
+
+  - bean: kafka.controller:type=KafkaController,name=OfflinePartitionsCount
+    mapping:
+      Value:
+        metric: kafka.partition.offline
+        type: gauge
+        desc: The number of partitions offline
+        unit: "{partition}"
+
+  - bean: kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions
+    mapping:
+      Value:
+        metric: kafka.partition.under_replicated
+        type: gauge
+        desc: The number of under replicated partitions
+        unit: "{partition}"
+
+  - bean: kafka.server:type=ReplicaManager,name=IsrShrinksPerSec
+    metricAttribute:
+      operation: const(shrink)
+    mapping:
+      Count:
+        metric: kafka.isr.operation.count
+        type: counter
+        desc: The number of in-sync replica shrink and expand operations
+        unit: "{operation}"
+
+  - bean: kafka.server:type=ReplicaManager,name=IsrExpandsPerSec
+    metricAttribute:
+      operation: const(expand)
+    mapping:
+      Count:
+        metric: kafka.isr.operation.count
+        type: counter
+        desc: The number of in-sync replica shrink and expand operations
+        unit: "{operation}"
+
+  - bean: kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica
+    mapping:
+      Value:
+        metric: kafka.lag.max
+        desc: The max lag in messages between follower and leader replicas
+        unit: "{message}"
+
+  - bean: kafka.controller:type=KafkaController,name=ActiveControllerCount
+    mapping:
+      Value:
+        metric: kafka.controller.active.count
+        type: updowncounter
+        desc: The number of controllers active on the broker
+        unit: "{controller}"
+
+  - bean: kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs
+    mapping:
+      Count:
+        metric: kafka.leader.election.count
+        type: counter
+        desc: The leader election count
+        unit: "{election}"
+
+  - bean: kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec
+    mapping:
+      Count:
+        metric: kafka.leader.election.unclean.count
+        type: counter
+        desc: Unclean leader election count - increasing indicates broker failures
+        unit: "{election}"
+
+  # Log metrics
+
+  - bean: kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs
+    unit: ms
+    type: gauge
+    prefix: kafka.logs.flush.
+    mapping:
+      Count:
+        metric: count
+        unit: '{flush}'
+        type: counter
+        desc: Log flush count
+      50thPercentile:
+        metric: time.50p
+        desc: Log flush time - 50th percentile
+      99thPercentile:
+        metric: time.99p
+        desc: Log flush time - 99th percentile


### PR DESCRIPTION
Three target systems connected to Kafka have been added:

1. Server
2. Producer
3. Consumer

To fully test Kafka metrics there is a need to spin multiple containers, so these three components can correctly interact and metrics can be correctly generated.
Base integration test class `TargetSystemIntegrationTest` was modified to support initialization of multiple containers.

There are still some TODOs left that will be fixed in subsequent PRs