### PR TITLE
[disk-buffering] Simplify MetricToDiskExporter creation

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
@@ -12,10 +12,10 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.function.Function;
 
 /**
  * This class implements a {@link MetricExporter} that delegates to an instance of {@code
@@ -24,22 +24,17 @@ import java.util.function.Function;
 public class MetricToDiskExporter implements MetricExporter {
 
   private final ToDiskExporter<MetricData> delegate;
-  private final Function<InstrumentType, AggregationTemporality> typeToTemporality;
+  private final AggregationTemporalitySelector aggregationTemporalitySelector;
 
   /**
    * Creates a new MetricToDiskExporter that will buffer Metric telemetry on disk storage.
    *
    * @param delegate - The MetricExporter to delegate to if disk writing fails.
    * @param config - The StorageConfiguration that specifies how storage is managed.
-   * @param typeToTemporality - The function that maps an InstrumentType into an
-   *     AggregationTemporality.
    * @return A new MetricToDiskExporter instance.
    * @throws IOException if the delegate ToDiskExporter could not be created.
    */
-  public static MetricToDiskExporter create(
-      MetricExporter delegate,
-      StorageConfiguration config,
-      Function<InstrumentType, AggregationTemporality> typeToTemporality)
+  public static MetricToDiskExporter create(MetricExporter delegate, StorageConfiguration config)
       throws IOException {
     ToDiskExporter<MetricData> toDisk =
         ToDiskExporter.<MetricData>builder()
@@ -48,15 +43,14 @@ public class MetricToDiskExporter implements MetricExporter {
             .setSerializer(SignalSerializer.ofMetrics())
             .setExportFunction(delegate::export)
             .build();
-    return new MetricToDiskExporter(toDisk, typeToTemporality);
+    return new MetricToDiskExporter(toDisk, delegate);
   }
 
   // VisibleForTesting
   MetricToDiskExporter(
-      ToDiskExporter<MetricData> delegate,
-      Function<InstrumentType, AggregationTemporality> typeToTemporality) {
+      ToDiskExporter<MetricData> delegate, AggregationTemporalitySelector selector) {
     this.delegate = delegate;
-    this.typeToTemporality = typeToTemporality;
+    this.aggregationTemporalitySelector = selector;
   }
 
   @Override
@@ -81,6 +75,6 @@ public class MetricToDiskExporter implements MetricExporter {
 
   @Override
   public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
-    return typeToTemporality.apply(instrumentType);
+    return aggregationTemporalitySelector.getAggregationTemporality(instrumentType);
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
@@ -85,9 +85,7 @@ public class IntegrationTest {
     memoryMetricExporter = InMemoryMetricExporter.create();
     ToDiskExporter<MetricData> toDiskMetricExporter =
         buildToDiskExporter(SignalSerializer.ofMetrics(), memoryMetricExporter::export);
-    metricToDiskExporter =
-        new MetricToDiskExporter(
-            toDiskMetricExporter, memoryMetricExporter::getAggregationTemporality);
+    metricToDiskExporter = new MetricToDiskExporter(toDiskMetricExporter, memoryMetricExporter);
     meterProvider = createMeterProvider(metricToDiskExporter);
     meter = meterProvider.get("MetricInstrumentationScope");
 


### PR DESCRIPTION
This makes the MetricToDiskExporter more consistent with the other exporters, and removes the requirement to have an additional mapping for temporality. Instead, we can just delegate to the MetricExporter that we are passed, because `MetricExporter` implements `AggregationTemporalitySelector`.  Furthermore, it eliminates the confusing and incorrect possibility where the to-disk exporter could have returned a temporality different than its delegate. Doh!