### PR TITLE
Maven 4.0 compatibility. Stop using `o.a.m.rtinfo.internal.DefaultRuntimeInformation`

### DIFF
--- a/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
+++ b/maven-extension/src/main/java/io/opentelemetry/maven/resources/MavenResourceProvider.java
@@ -10,19 +10,22 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ServiceAttributes;
-import org.apache.maven.rtinfo.RuntimeInformation;
-import org.apache.maven.rtinfo.internal.DefaultRuntimeInformation;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.apache.maven.Maven;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MavenResourceProvider implements ResourceProvider {
 
+  private static final Logger logger = LoggerFactory.getLogger(MavenResourceProvider.class);
+
   @Override
   public Resource createResource(ConfigProperties config) {
-    // TODO verify if there is solution to retrieve the RuntimeInformation instance loaded by the
-    //  Maven Plexus Launcher
-    RuntimeInformation runtimeInformation = new DefaultRuntimeInformation();
     return Resource.builder()
         .put(ServiceAttributes.SERVICE_NAME, MavenOtelSemanticAttributes.SERVICE_NAME_VALUE)
-        .put(ServiceAttributes.SERVICE_VERSION, runtimeInformation.getMavenVersion())
+        .put(ServiceAttributes.SERVICE_VERSION, getMavenRuntimeVersion())
         .put(
             MavenOtelSemanticAttributes.TELEMETRY_DISTRO_NAME,
             MavenOtelSemanticAttributes.TELEMETRY_DISTRO_NAME_VALUE)
@@ -30,5 +33,41 @@ public class MavenResourceProvider implements ResourceProvider {
             MavenOtelSemanticAttributes.TELEMETRY_DISTRO_VERSION,
             MavenOtelSemanticAttributes.TELEMETRY_DISTRO_VERSION_VALUE)
         .build();
+  }
+
+  /**
+   * Recopy of <a
+   * href="https://github.com/apache/maven/blob/maven-4.0.0-rc-2/compat/maven-compat/src/main/java/org/apache/maven/execution/DefaultRuntimeInformation.java">
+   * <code>org.apache.maven.rtinfo.internal.DefaultRuntimeInformation#getMavenVersion()</code></a>
+   * that is not available in Maven 4.0+
+   */
+  static String getMavenRuntimeVersion() {
+    String mavenVersion;
+    Properties props = new Properties();
+    String resource = "META-INF/maven/org.apache.maven/maven-core/pom.properties";
+
+    try (InputStream is = Maven.class.getResourceAsStream("/" + resource)) {
+      if (is != null) {
+        props.load(is);
+      } else {
+        logger.warn(
+            "Could not locate {} on classpath, Maven runtime information not available", resource);
+      }
+    } catch (IOException e) {
+      String msg = "Could not parse " + resource + ", Maven runtime information not available";
+      if (logger.isDebugEnabled()) {
+        logger.warn(msg, e);
+      } else {
+        logger.warn(msg);
+      }
+    }
+
+    String version = props.getProperty("version", "").trim();
+    if (!version.startsWith("${")) {
+      mavenVersion = version;
+    } else {
+      mavenVersion = "";
+    }
+    return mavenVersion;
   }
 }

--- a/maven-extension/src/test/java/io/opentelemetry/maven/resources/MavenResourceProviderTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/resources/MavenResourceProviderTest.java
@@ -1,0 +1,14 @@
+package io.opentelemetry.maven.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MavenResourceProviderTest {
+
+  @Test
+  void testGetMavenVersion() {
+    String mavenVersion = MavenResourceProvider.getMavenRuntimeVersion();
+    assertThat(mavenVersion).isEqualTo("3.5.0");
+  }
+}

--- a/maven-extension/src/test/java/io/opentelemetry/maven/resources/MavenResourceProviderTest.java
+++ b/maven-extension/src/test/java/io/opentelemetry/maven/resources/MavenResourceProviderTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.maven.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
**Description:**

Maven 4.0 compatibility. Stop using `org.apache.maven.rtinfo.internal.DefaultRuntimeInformation`

**Existing Issue(s):**

* https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1583

**Testing:**

Unit test added

**Documentation:**

None

**Outstanding items:**

None
