### PR TITLE
[baggage-processor] Change description to fit purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ feature or via instrumentation, this project is hopefully for you.
 ## Provided Libraries
 
 | Status* | Library                                                           |
-| ------- | ----------------------------------------------------------------- |
+| ------- |-------------------------------------------------------------------|
 | beta    | [AWS Resources](./aws-resources/README.md)                        |
 | stable  | [AWS X-Ray SDK Support](./aws-xray/README.md)                     |
 | alpha   | [AWS X-Ray Propagator](./aws-xray-propagator/README.md)           |
-| alpha   | [Baggage Span Processor](./baggage-processor/README.md)           |
+| alpha   | [Baggage to Attributes Processor](./baggage-processor/README.md) |
 | alpha   | [zstd Compressor](./compressors/compressor-zstd/README.md)        |
 | alpha   | [Consistent Sampling](./consistent-sampling/README.md)            |
 | alpha   | [Disk Buffering](./disk-buffering/README.md)                      |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ feature or via instrumentation, this project is hopefully for you.
 | beta    | [AWS Resources](./aws-resources/README.md)                        |
 | stable  | [AWS X-Ray SDK Support](./aws-xray/README.md)                     |
 | alpha   | [AWS X-Ray Propagator](./aws-xray-propagator/README.md)           |
-| alpha   | [Baggage to Attributes Processor](./baggage-processor/README.md) |
+| alpha   | [Baggage Processors](./baggage-processor/README.md) |
 | alpha   | [zstd Compressor](./compressors/compressor-zstd/README.md)        |
 | alpha   | [Consistent Sampling](./consistent-sampling/README.md)            |
 | alpha   | [Disk Buffering](./disk-buffering/README.md)                      |


### PR DESCRIPTION
The description of the `baggage-processor` module suggested that it was for spans. It contains the ability to add attributes to both spans and logs, so let's change the description to make it more fitting.