### PR TITLE
Update publishing for GCP Auth Extension

### DIFF
--- a/gcp-auth-extension/build.gradle.kts
+++ b/gcp-auth-extension/build.gradle.kts
@@ -60,12 +60,19 @@ tasks {
   }
 
   shadowJar {
-    archiveClassifier.set("")
+    archiveClassifier.set("shadow")
   }
 
   jar {
-    // Disable standard jar
-    enabled = false
+    /**
+     * We need to publish both - shaded and unshaded variants of the dependency
+     * Shaded dependency is required for use with the Java agent.
+     * Unshaded dependency can be used with OTel Autoconfigure module.
+     *
+     * Not overriding the classifier to empty results in an implicit classifier 'plain' being
+     * used with the standard JAR.
+     */
+    archiveClassifier.set("")
   }
 
   assemble {


### PR DESCRIPTION
**Description:**

Adds explicit classifier for shaded variant of the dependency. This allows both - shaded and unshaded variant of the dependency.

**Testing:**

Ran `./gradlew publishToMavenLocal` task locally to examine the generated `.pom` and `.module` files. 

**Documentation:**

Should be updated after the next release.
