### PR TITLE
Change maven dependencies to compileOnly

### DIFF
--- a/static-instrumenter/maven-plugin/build.gradle.kts
+++ b/static-instrumenter/maven-plugin/build.gradle.kts
@@ -15,8 +15,8 @@ otelJava {
 }
 
 dependencies {
-  implementation("org.apache.maven:maven-plugin-api:3.5.0") // do not auto-update this version
-  implementation("org.apache.maven:maven-project:2.2.1")
+  compileOnly("org.apache.maven:maven-plugin-api:3.5.0") // do not auto-update this version
+  compileOnly("org.apache.maven:maven-project:2.2.1")
   compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:3.15.1")
   compileOnly("org.apache.maven:maven-core:3.5.0") // do not auto-update this version
   compileOnly("org.slf4j:slf4j-api")


### PR DESCRIPTION
We compile against older version to ensure compatibility, so his is needed to resolve one of the OWASP failures.