### PR TITLE
Update test dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     "docker:pinDigests",
     "helpers:pinGitHubActionDigests"
   ],
+  "ignorePresets": [":ignoreModulesAndTests"], // needed to keep maven-extension test pom files up-to-date
   "packageRules": [
     {
       // this is to reduce the number of renovate PRs by consolidating them into a weekly batch

--- a/maven-extension/src/test/resources/projects/springboot_1/pom.xml
+++ b/maven-extension/src/test/resources/projects/springboot_1/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.1</version>
+    <version>3.4.1</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>io.opentelemetry.contrib.maven.test</groupId>
@@ -15,7 +15,7 @@
   <name>springboot-test</name>
   <description>Demo project for Spring Boot</description>
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
   </properties>
   <dependencies>
     <dependency>

--- a/maven-extension/src/test/resources/projects/springboot_2/pom.xml
+++ b/maven-extension/src/test/resources/projects/springboot_2/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.1</version>
+    <version>3.4.1</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>io.opentelemetry.contrib.maven.test</groupId>
@@ -15,7 +15,7 @@
   <name>springboot-test</name>
   <description>Demo project for Spring Boot</description>
   <properties>
-    <java.version>11</java.version>
+    <java.version>17</java.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
OSSF scorecard is dinging us for vulnerabilities in the old spring version (it appears to only look at pom file dependencies)