### PR TITLE
Artifact Hub exemption

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,3 @@
+exemptions:
+  - check: artifacthub_badge
+    reason: "Artifact Hub doesn't support Java packages"


### PR DESCRIPTION
To avoid our CLOMonitor score getting dinged for this

(will send to other Java repos after merging and confirming I got this right)