### PR TITLE
Configure workflows to support merge queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - main
       - release/*
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,12 @@
 name: CodeQL
 
 on:
-  pull_request:
-    branches:
-      - main
-      - release/*
   push:
     branches:
       - main
       - release/*
+  pull_request:
+  merge_group:
   schedule:
     - cron: "29 13 * * 2"  # weekly at 13:29 UTC on Tuesday
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -2,7 +2,11 @@ name: Gradle wrapper validation
 
 on:
   push:
+    branches:
+      - main
+      - release/*
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
"Require branch to be up to date before merging" is an OSSF best practice.