### PR TITLE
Fix `jvm.thread.count` semconv.

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
@@ -170,7 +170,7 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
                     .isGauge()
                     .hasDataPointsWithAttributes(memoryAttributes))
         .add(
-            "jvm.threads.count",
+            "jvm.thread.count",
             metric ->
                 metric
                     .hasDescription("number of threads")

--- a/jmx-scraper/src/main/resources/jvm.yaml
+++ b/jmx-scraper/src/main/resources/jvm.yaml
@@ -86,6 +86,6 @@ rules:
   - bean: java.lang:type=Threading
     mapping:
       ThreadCount:
-        metric: jvm.threads.count
+        metric: jvm.thread.count
         unit: "{thread}"
         desc: number of threads


### PR DESCRIPTION
The new scraper code is reporting the wrong name for `jvm.thread.count` ([semconv here](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/runtime/jvm-metrics.md#metric-jvmthreadcount)).

Even if this was done to keep parity with the old module, this new name is wrong and will have a negative impact on systems that rely on the correct name.