### PR TITLE
Change deprecated method name for spotless

### DIFF
--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -70,7 +70,7 @@ spotless {
       "*.sh",
       "src/**/*.properties",
     )
-    indentWithSpaces()
+    leadingTabsToSpaces()
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
fixes a build warning