### PR TITLE
jmx-scraper add missing custom yaml support

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/JmxScraperContainer.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/JmxScraperContainer.java
@@ -100,6 +100,12 @@ public class JmxScraperContainer extends GenericContainer<JmxScraperContainer> {
     return this;
   }
 
+  /**
+   * Adds custom metrics yaml from classpath resource
+   *
+   * @param yamlPath path to resource in classpath
+   * @return this
+   */
   @CanIgnoreReturnValue
   public JmxScraperContainer withCustomYaml(String yamlPath) {
     this.customYamlFiles.add(yamlPath);

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CustomIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/CustomIntegrationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jmxscraper.target_systems;
+
+import io.opentelemetry.contrib.jmxscraper.JmxScraperContainer;
+import io.opentelemetry.contrib.jmxscraper.TestAppContainer;
+import java.nio.file.Path;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class CustomIntegrationTest extends TargetSystemIntegrationTest {
+
+  @Override
+  protected GenericContainer<?> createTargetContainer(int jmxPort) {
+    // reusing test application for custom yaml
+    //noinspection resource
+    return new TestAppContainer()
+        .withJmxPort(jmxPort)
+        .withExposedPorts(jmxPort)
+        .waitingFor(Wait.forListeningPorts(jmxPort));
+  }
+
+  @Override
+  protected JmxScraperContainer customizeScraperContainer(
+      JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
+    // only testing custom yaml
+    return scraper.withCustomYaml("custom-metrics.yaml");
+  }
+
+  @Override
+  protected MetricsVerifier createMetricsVerifier() {
+    return MetricsVerifier.create()
+        // custom metric in custom-metrics.yaml
+        .add(
+            "custom.jvm.uptime",
+            metric ->
+                metric
+                    .hasDescription("JVM uptime in milliseconds")
+                    .hasUnit("ms")
+                    .isCounter()
+                    .hasDataPointsWithoutAttributes());
+  }
+}

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
@@ -30,7 +30,10 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
   @Override
   protected JmxScraperContainer customizeScraperContainer(
       JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
-    return scraper.withTargetSystem("jvm");
+    return scraper
+        .withTargetSystem("jvm")
+        // also testing custom yaml
+        .withCustomYaml("custom-metrics.yaml");
   }
 
   @Override
@@ -48,6 +51,16 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
         nameAttributeMatchers("PS MarkSweep", "PS Scavenge");
 
     return MetricsVerifier.create()
+        // custom metric in custom-metrics.yaml
+        .add(
+            "custom.jvm.uptime",
+            metric ->
+                metric
+                    .hasDescription("JVM uptime in milliseconds")
+                    .hasUnit("ms")
+                    .isCounter()
+                    .hasDataPointsWithoutAttributes())
+        // metrics for 'jvm' target system
         .add(
             "jvm.classes.loaded",
             metric ->

--- a/jmx-scraper/src/integrationTest/resources/custom-metrics.yaml
+++ b/jmx-scraper/src/integrationTest/resources/custom-metrics.yaml
@@ -1,0 +1,11 @@
+---
+
+rules:
+
+  - bean: java.lang:type=Runtime
+    mapping:
+      Uptime:
+        metric: custom.jvm.uptime
+        type: counter
+        unit: ms
+        desc: JVM uptime in milliseconds


### PR DESCRIPTION
While working on #1710 I found that the `io.opentelemetry.contrib.jmxscraper.JmxScraperContainer#withCustomYaml` was not used, which means using custom yaml feature was not properly tested with integration tests.

It turns out that the feature was not only not tested but also not implemented, so this PR fixes both.

Testing extends the tests for the `jvm` target system to avoid creating duplication and also allows to test usage when combined with `otel.jmx.target.system`.