### PR TITLE
Tomcat metrics definitions updated in JMX Scraper

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
@@ -54,10 +54,10 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                 metric
                     .hasDescription("The number of active sessions")
                     .hasUnit("{session}")
-                    .isGauge()
+                    .isUpDownCounter()
                     .hasDataPointsWithOneAttribute(attributeWithAnyValue("context")))
         .add(
-            "tomcat.errors",
+            "tomcat.request.errors",
             metric ->
                 metric
                     .hasDescription("The number of errors encountered")
@@ -65,7 +65,7 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                     .isCounter()
                     .hasDataPointsWithOneAttribute(attribute("proto_handler", "\"http-nio-8080\"")))
         .add(
-            "tomcat.processing_time",
+            "tomcat.request.duration",
             metric ->
                 metric
                     .hasDescription("The total processing time")
@@ -73,7 +73,7 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                     .isCounter()
                     .hasDataPointsWithOneAttribute(attribute("proto_handler", "\"http-nio-8080\"")))
         .add(
-            "tomcat.traffic",
+            "tomcat.network.io",
             metric ->
                 metric
                     .hasDescription("The number of bytes transmitted and received")
@@ -101,7 +101,7 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                             attribute("state", "busy"),
                             attribute("proto_handler", "\"http-nio-8080\""))))
         .add(
-            "tomcat.max_time",
+            "tomcat.request.duration.max",
             metric ->
                 metric
                     .hasDescription("Maximum time to process a request")
@@ -109,7 +109,7 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                     .isGauge()
                     .hasDataPointsWithOneAttribute(attribute("proto_handler", "\"http-nio-8080\"")))
         .add(
-            "tomcat.request_count",
+            "tomcat.requests",
             metric ->
                 metric
                     .hasDescription("The total requests")

--- a/jmx-scraper/src/main/resources/tomcat.yaml
+++ b/jmx-scraper/src/main/resources/tomcat.yaml
@@ -14,7 +14,7 @@ rules:
     mapping:
       activeSessions:
         metric: tomcat.sessions
-        type: gauge
+        type: updowncounter
         unit: "{session}"
         desc: The number of active sessions
 
@@ -26,37 +26,37 @@ rules:
       proto_handler: param(name)
     mapping:
       errorCount:
-        metric: errors
+        metric: request.errors
         type: counter
         unit: "{error}"
         desc: The number of errors encountered
       requestCount:
-        metric: request_count
+        metric: requests
         type: counter
         unit: "{request}"
         desc: The total requests
       maxTime:
-        metric: max_time
+        metric: request.duration.max
         type: gauge
         unit: ms
         desc: Maximum time to process a request
       processingTime:
-        metric: processing_time
+        metric: request.duration
         type: counter
         unit: ms
         desc: The total processing time
       bytesSent:
-        metric: traffic
-        type: counter
-        unit: By
-        desc: The number of bytes transmitted and received
+        metric: &metric network.io
+        type: &type counter
+        unit: &unit By
+        desc: &desc The number of bytes transmitted and received
         metricAttribute:
           direction: const(sent)
       bytesReceived:
-        metric: traffic
-        type: counter
-        unit: By
-        desc: The number of bytes transmitted and received
+        metric: *metric
+        type: *type
+        unit: *unit
+        desc: *desc
         metricAttribute:
           direction: const(received)
 
@@ -68,16 +68,16 @@ rules:
       proto_handler: param(name)
     mapping:
       currentThreadCount:
-        metric: threads
-        desc: The number of threads
-        type: gauge
-        unit: "{thread}"
+        metric: &metric threads
+        desc: &desc The number of threads
+        type: &type gauge
+        unit: &unit "{thread}"
         metricAttribute:
           state: const(idle)
       currentThreadsBusy:
-        metric: threads
-        desc: The number of threads
-        type: gauge
-        unit: "{thread}"
+        metric: *metric
+        desc: *desc
+        type: *type
+        unit: *unit
         metricAttribute:
           state: const(busy)


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-java-contrib/issues/1748
This is the first part of Tomcat metrics definition to make them aligned with semconv. If these changes are accepted then tha same changes will be done in [JMX Metrics Gatherer](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/jmx-metrics) component.

OTel reference documentation I used:

- [https://opentelemetry.io/docs/specs/semconv/general/naming/](https://opentelemetry.io/docs/specs/semconv/general/naming/)
- [https://opentelemetry.io/docs/specs/semconv/http/http-metrics/](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/)
