### PR TITLE
processors: remove {} as #6891 follow-up

### DIFF
--- a/processors/README.md
+++ b/processors/README.md
@@ -25,8 +25,7 @@ tracer_provider: ...
 
 logger_provider:
   processors:
-      # TODO(jack-berg): remove "{}" after releasing [opentelemetry-java#6891](https://github.com/open-telemetry/opentelemetry-java/pull/6891/files)
-      - event_to_span_event_bridge: {}
+      - event_to_span_event_bridge:
 ```
 
 ## Component owners

--- a/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
@@ -21,9 +21,7 @@ class EventToSpanBridgeComponentProviderTest {
         "file_format: 0.3\n"
             + "logger_provider:\n"
             + "  processors:\n"
-            // TODO(jack-berg): remove "{}" after releasing
-            // https://github.com/open-telemetry/opentelemetry-java/pull/6891/files
-            + "    - event_to_span_event_bridge: {}\n";
+            + "    - event_to_span_event_bridge:";
 
     OpenTelemetrySdk openTelemetrySdk =
         FileConfiguration.parseAndCreate(


### PR DESCRIPTION
Remove un-necessary `{}` as https://github.com/open-telemetry/opentelemetry-java/pull/6891 has been merged and released. This removes one TODO item from @jack-berg.

