### PR TITLE
Fix compilation errors due to declarative config breaking changes

### DIFF
--- a/aws-xray-propagator/build.gradle.kts
+++ b/aws-xray-propagator/build.gradle.kts
@@ -8,12 +8,14 @@ description = "OpenTelemetry AWS X-Ray Propagator"
 otelJava.moduleName.set("io.opentelemetry.contrib.awsxray.propagator")
 
 dependencies {
-  api("io.opentelemetry:opentelemetry-api")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-trace")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+  // TODO: revert versions before merging
+  api("io.opentelemetry:opentelemetry-api:1.48.0-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-trace:1.48.0-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.48.0-SNAPSHOT")
 
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
   testImplementation("uk.org.webcompere:system-stubs-jupiter:2.0.3")
 }

--- a/aws-xray-propagator/build.gradle.kts
+++ b/aws-xray-propagator/build.gradle.kts
@@ -8,14 +8,13 @@ description = "OpenTelemetry AWS X-Ray Propagator"
 otelJava.moduleName.set("io.opentelemetry.contrib.awsxray.propagator")
 
 dependencies {
-  // TODO: revert versions before merging
-  api("io.opentelemetry:opentelemetry-api:1.48.0-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-trace:1.48.0-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.48.0-SNAPSHOT")
+  api("io.opentelemetry:opentelemetry-api")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-trace")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   testImplementation("uk.org.webcompere:system-stubs-jupiter:2.0.3")
 }

--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayComponentProvider.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayComponentProvider.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.contrib.awsxray.propagator.internal;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 
 public class AwsXrayComponentProvider implements ComponentProvider<TextMapPropagator> {
   @Override
@@ -22,7 +22,7 @@ public class AwsXrayComponentProvider implements ComponentProvider<TextMapPropag
   }
 
   @Override
-  public TextMapPropagator create(StructuredConfigProperties config) {
+  public TextMapPropagator create(DeclarativeConfigProperties config) {
     return AwsXrayPropagator.getInstance();
   }
 }

--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayLambdaComponentProvider.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayLambdaComponentProvider.java
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.contrib.awsxray.propagator.internal;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayLambdaPropagator;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 
 public class AwsXrayLambdaComponentProvider implements ComponentProvider<TextMapPropagator> {
   @Override
@@ -22,7 +22,7 @@ public class AwsXrayLambdaComponentProvider implements ComponentProvider<TextMap
   }
 
   @Override
-  public TextMapPropagator create(StructuredConfigProperties config) {
+  public TextMapPropagator create(DeclarativeConfigProperties config) {
     return AwsXrayLambdaPropagator.getInstance();
   }
 }

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
@@ -11,7 +11,7 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayLambdaPropagator;
 import io.opentelemetry.contrib.awsxray.propagator.AwsXrayPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ class AwsComponentProviderTest {
     String yaml = "file_format: 0.3\n" + "propagator:\n" + "  composite: [xray, xray-lambda]\n";
 
     OpenTelemetrySdk openTelemetrySdk =
-        FileConfiguration.parseAndCreate(
+        DeclarativeConfiguration.parseAndCreate(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
     TextMapPropagator expectedPropagator =
         TextMapPropagator.composite(

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   `java-platform`
 }
 
-val otelInstrumentationVersion = "2.13.3-alpha"
+val otelInstrumentationVersion = "2.14.0-alpha"
 val semconvVersion = "1.30.0"
 
 javaPlatform {

--- a/processors/build.gradle.kts
+++ b/processors/build.gradle.kts
@@ -12,15 +12,17 @@ java {
 }
 
 dependencies {
-  api("io.opentelemetry:opentelemetry-sdk")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  // TODO: revert versions before merging
+  api("io.opentelemetry:opentelemetry-sdk:1.48.0-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
 
   // For EventToSpanEventBridge
-  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common:1.48.0-SNAPSHOT")
   implementation("com.fasterxml.jackson.core:jackson-core")
 
-  testImplementation("io.opentelemetry:opentelemetry-api-incubator")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.48.0-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
 }

--- a/processors/build.gradle.kts
+++ b/processors/build.gradle.kts
@@ -12,17 +12,16 @@ java {
 }
 
 dependencies {
-  // TODO: revert versions before merging
-  api("io.opentelemetry:opentelemetry-sdk:1.48.0-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
+  api("io.opentelemetry:opentelemetry-sdk")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator")
 
   // For EventToSpanEventBridge
-  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common:1.48.0-SNAPSHOT")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
   implementation("com.fasterxml.jackson.core:jackson-core")
 
-  testImplementation("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-testing:1.48.0-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-api-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
 }

--- a/processors/src/main/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanEventBridgeComponentProvider.java
+++ b/processors/src/main/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanEventBridgeComponentProvider.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.contrib.eventbridge.internal;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.contrib.eventbridge.EventToSpanEventBridge;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 
 /**
@@ -30,7 +30,7 @@ public class EventToSpanEventBridgeComponentProvider
   }
 
   @Override
-  public LogRecordProcessor create(StructuredConfigProperties config) {
+  public LogRecordProcessor create(DeclarativeConfigProperties config) {
     return EventToSpanEventBridge.create();
   }
 }

--- a/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
@@ -8,7 +8,7 @@ package io.opentelemetry.contrib.eventbridge.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -21,12 +21,10 @@ class EventToSpanBridgeComponentProviderTest {
         "file_format: 0.3\n"
             + "logger_provider:\n"
             + "  processors:\n"
-            // TODO(jack-berg): remove "{}" after releasing
-            // https://github.com/open-telemetry/opentelemetry-java/pull/6891/files
-            + "    - event_to_span_event_bridge: {}\n";
+            + "    - event_to_span_event_bridge:\n";
 
     OpenTelemetrySdk openTelemetrySdk =
-        FileConfiguration.parseAndCreate(
+        DeclarativeConfiguration.parseAndCreate(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
 
     assertThat(openTelemetrySdk.getSdkLoggerProvider().toString())

--- a/samplers/build.gradle.kts
+++ b/samplers/build.gradle.kts
@@ -7,12 +7,14 @@ description = "Sampler which makes its decision based on semantic attributes val
 otelJava.moduleName.set("io.opentelemetry.contrib.sampler")
 
 dependencies {
-  api("io.opentelemetry:opentelemetry-sdk")
+  // TODO: revert versions before merging
+  api("io.opentelemetry:opentelemetry-sdk:1.48.0-SNAPSHOT")
 
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
 
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
 }

--- a/samplers/build.gradle.kts
+++ b/samplers/build.gradle.kts
@@ -7,14 +7,13 @@ description = "Sampler which makes its decision based on semantic attributes val
 otelJava.moduleName.set("io.opentelemetry.contrib.sampler")
 
 dependencies {
-  // TODO: revert versions before merging
-  api("io.opentelemetry:opentelemetry-sdk:1.48.0-SNAPSHOT")
+  api("io.opentelemetry:opentelemetry-sdk")
 
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.48.0-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-api-incubator:1.48.0-alpha-SNAPSHOT")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+  compileOnly("io.opentelemetry:opentelemetry-api-incubator")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
 
   testImplementation("io.opentelemetry.semconv:opentelemetry-semconv-incubating")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.48.0-SNAPSHOT")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator:1.48.0-alpha-SNAPSHOT")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
 }

--- a/samplers/src/test/java/internal/RuleBasedRoutingSamplerComponentProviderTest.java
+++ b/samplers/src/test/java/internal/RuleBasedRoutingSamplerComponentProviderTest.java
@@ -10,14 +10,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
 import io.opentelemetry.contrib.sampler.internal.RuleBasedRoutingSamplerComponentProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.StructuredConfigProperties;
-import io.opentelemetry.sdk.extension.incubator.fileconfig.FileConfiguration;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
 import io.opentelemetry.sdk.trace.IdGenerator;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
@@ -52,7 +52,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
             + "              pattern: /actuator.*\n"
             + "              action: DROP\n";
     OpenTelemetrySdk openTelemetrySdk =
-        FileConfiguration.parseAndCreate(
+        DeclarativeConfiguration.parseAndCreate(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
     Sampler sampler = openTelemetrySdk.getSdkTracerProvider().getSampler();
     assertThat(sampler.toString())
@@ -97,8 +97,8 @@ class RuleBasedRoutingSamplerComponentProviderTest {
   @ParameterizedTest
   @MethodSource("createValidArgs")
   void create_Valid(String yaml, RuleBasedRoutingSampler expectedSampler) {
-    StructuredConfigProperties configProperties =
-        FileConfiguration.toConfigProperties(
+    DeclarativeConfigProperties configProperties =
+        DeclarativeConfiguration.toConfigProperties(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
 
     Sampler sampler = PROVIDER.create(configProperties);
@@ -149,12 +149,12 @@ class RuleBasedRoutingSamplerComponentProviderTest {
   @ParameterizedTest
   @MethodSource("createInvalidArgs")
   void create_Invalid(String yaml, String expectedErrorMessage) {
-    StructuredConfigProperties configProperties =
-        FileConfiguration.toConfigProperties(
+    DeclarativeConfigProperties configProperties =
+        DeclarativeConfiguration.toConfigProperties(
             new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
 
     assertThatThrownBy(() -> PROVIDER.create(configProperties))
-        .isInstanceOf(ConfigurationException.class)
+        .isInstanceOf(DeclarativeConfigException.class)
         .hasMessage(expectedErrorMessage);
   }
 


### PR DESCRIPTION
Fix breaking changes from moving / renaming of certain declarative config classes in: https://github.com/open-telemetry/opentelemetry-java/pull/6549

**NOTE:** Depends on `opentelemetry-java` 1.48.0 release, scheduled for 3/6/25.