### PR TITLE
Fix jmx-metrics kafka test

### DIFF
--- a/jmx-metrics/build.gradle.kts
+++ b/jmx-metrics/build.gradle.kts
@@ -50,6 +50,7 @@ testing {
         implementation("com.linecorp.armeria:armeria-junit5")
         implementation("io.opentelemetry.proto:opentelemetry-proto:1.5.0-alpha")
         implementation("org.testcontainers:junit-jupiter")
+        implementation("org.slf4j:slf4j-simple")
       }
     }
   }

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/KafkaIntegrationTest.java
@@ -80,7 +80,7 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
       };
 
   protected GenericContainer<?> kafkaProducerContainer() {
-    return new GenericContainer<>("bitnami/kafka:latest")
+    return new GenericContainer<>("bitnami/kafka:2.8.1")
         .withNetwork(Network.SHARED)
         .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
         .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")
@@ -207,7 +207,7 @@ abstract class KafkaIntegrationTest extends AbstractIntegrationTest {
 
     @Container
     GenericContainer<?> consumer =
-        new GenericContainer<>("bitnami/kafka:latest")
+        new GenericContainer<>("bitnami/kafka:2.8.1")
             .withNetwork(Network.SHARED)
             .withEnv("KAFKA_CFG_ZOOKEEPER_CONNECT", "zookeeper:2181")
             .withEnv("ALLOW_PLAINTEXT_LISTENER", "yes")


### PR DESCRIPTION
Changes to `bitnami/kafka:latest` break the test. Since this build uses gradle cache this failure isn't yet observed in daily build, but does happen in https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1817 This PR includes some addition changes that should help with debugging test failures.