### PR TITLE
fix: Image parsing

### DIFF
--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
@@ -314,7 +314,7 @@ public final class EcsResource {
 
     private static final Pattern imagePattern =
         Pattern.compile(
-            "^(?<repository>([^/\\s]+/)?([^:\\s]+))(:(?<tag>[^@\\s]+))?(@sha256:(?<sha256>\\d+))?$");
+            "^(?<repository>([^/\\s]+/)?([^:\\s]+))(:(?<tag>[^@\\s]+))?(@sha256:(?<sha256>[\\da-fA-F]+))?$");
 
     final String repository;
     final String tag;

--- a/aws-resources/src/test/resources/ecs-container-metadata-v3.json
+++ b/aws-resources/src/test/resources/ecs-container-metadata-v3.json
@@ -2,7 +2,7 @@
   "DockerId": "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
   "Name": "nginx-curl",
   "DockerName": "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
-  "Image": "nrdlngr/nginx-curl",
+  "Image": "nrdlngr/nginx-curl:latest@sha256:8dc35e9386b5d280d285ae7a78d271a5d4a82106cb254fbed5fde4923faa8deb",
   "ImageID": "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
   "Labels": {
     "com.amazonaws.ecs.cluster": "default",


### PR DESCRIPTION
**Description:**

Fix ECS image parsing; SHA256 is hex encoded, not just digits.

**Existing Issue(s):**

#1788

**Testing:**

Unit test input updated to show the bug

**Documentation:**

N/A

**Outstanding items:**

None
