### PR TITLE
Disable CodeQL on merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
   required-status-check:
-    if: github.event_name == 'pull_request' && always()
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && always()
     needs:
       - build
       - test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,12 @@ on:
       - main
       - release/*
   pull_request:
-  merge_group:
+  # TODO (trask) adding this to the merge queue causes the merge queue to fail
+  # see related issues
+  # - https://github.com/github/codeql-action/issues/1572
+  # - https://github.com/github/codeql-action/issues/1537
+  # - https://github.com/github/codeql-action/issues/2691
+  # merge_group:
   schedule:
     - cron: "29 13 * * 2"  # weekly at 13:29 UTC on Tuesday
 


### PR DESCRIPTION
Adding CodeQL to the merge queue causes the merge queue to fail, see related issues
- https://github.com/github/codeql-action/issues/1572
- https://github.com/github/codeql-action/issues/1537
- https://github.com/github/codeql-action/issues/2691