### PR TITLE
Upgrade async-profiler to 4.0 in inferred spans feature

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     api("org.testcontainers:kafka:1.21.0")
     api("com.lmax:disruptor:3.4.4")
     api("org.jctools:jctools-core:4.0.5")
-    api("tools.profiler:async-profiler:3.0")
+    api("tools.profiler:async-profiler:4.0")
     api("com.blogspot.mydailyjava:weak-lock-free:0.18")
     api("org.agrona:agrona:1.22.0")
   }

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -42,4 +42,8 @@ tasks {
       }
     }
   }
+
+  withType<Test>().configureEach {
+    jvmArgs("-Djava.util.logging.config.file=${project.projectDir.resolve("src/test/resources/logging.properties")}")
+  }
 }

--- a/inferred-spans/src/main/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfiler.java
+++ b/inferred-spans/src/main/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfiler.java
@@ -426,7 +426,7 @@ public class SamplingProfiler implements Runnable {
 
   String createStartCommand() {
     StringBuilder startCommand =
-        new StringBuilder("start,jfr,clock=m,event=wall,cstack=n,interval=")
+        new StringBuilder("start,jfr,clock=m,event=wall,nobatch,cstack=n,interval=")
             .append(config.getSamplingInterval().toMillis())
             .append("ms,filter,file=")
             .append(jfrFile)

--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
@@ -144,13 +144,13 @@ class SamplingProfilerTest {
     setupProfiler(false);
     assertThat(setup.profiler.createStartCommand())
         .isEqualTo(
-            "start,jfr,clock=m,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0");
+            "start,jfr,clock=m,event=wall,nobatch,cstack=n,interval=5ms,filter,file=null,safemode=0");
 
     setup.close();
     setupProfiler(config -> config.startScheduledProfiling(false).profilerLoggingEnabled(false));
     assertThat(setup.profiler.createStartCommand())
         .isEqualTo(
-            "start,jfr,clock=m,event=wall,cstack=n,interval=5ms,filter,file=null,safemode=0,loglevel=none");
+            "start,jfr,clock=m,event=wall,nobatch,cstack=n,interval=5ms,filter,file=null,safemode=0,loglevel=none");
 
     setup.close();
     setupProfiler(
@@ -162,7 +162,7 @@ class SamplingProfilerTest {
                 .asyncProfilerSafeMode(14));
     assertThat(setup.profiler.createStartCommand())
         .isEqualTo(
-            "start,jfr,clock=m,event=wall,cstack=n,interval=10ms,filter,file=null,safemode=14,loglevel=none");
+            "start,jfr,clock=m,event=wall,nobatch,cstack=n,interval=10ms,filter,file=null,safemode=14,loglevel=none");
   }
 
   @Test

--- a/inferred-spans/src/test/resources/logging.properties
+++ b/inferred-spans/src/test/resources/logging.properties
@@ -1,0 +1,4 @@
+handlers=java.util.logging.ConsoleHandler
+.level=ALL
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
**Description:**

Upgrades async-profiler used by the inferred-spans extension to 4.0. Supersedes #1840.
Async-profiler 4.0 introduced a new batching mode as the default for wall clock profiling ([PR](https://github.com/async-profiler/async-profiler/issues/1007)). This mode yields great efficiency improvements:

Previously, if a thread was blocked for e.g. a second, the profiler would periodically wake it up and collect the same stacktrace every time. With batching, the profiler got smarter: It still wakes the thread up, but then detects that the CPU-time of the thread hasn't changed, so it can omit fetching the same stacktrace again.

Unfortunately I don't think we can make use of this improvement yet, see https://github.com/async-profiler/async-profiler/issues/1277. However, eventually we'll definitely add it, as I'm expecting great efficiency improvements.
Based on the outcome of the discussion in the linked issue, I'll open a issue in this repo to make sure we don't forget about it.

This feature has also changed how the samples are stored in the JFR files, causing the inferred spans extension to not find them anymore. To fix this for now, I've disabled the batching functionality, causing async-profiler to operate in the "old" wall clock profiling mode.



**Testing:**

Quick manual test plus our unit test coverage is already decent.
