### PR TITLE
Lychee / markdown link check - set max concurrency

### DIFF
--- a/.github/workflows/reusable-markdown-link-check.yml
+++ b/.github/workflows/reusable-markdown-link-check.yml
@@ -19,4 +19,5 @@ jobs:
             --include-fragments
             --exclude "^https://github.com/open-telemetry/opentelemetry-java-contrib/(issues|pull)/\\d+$"
             --max-retries 6
+            --max-concurrency 1
             .


### PR DESCRIPTION
We have done this in other repos to fix the linkdown checker from failing every PR...so let's do it here too.