### PR TITLE
Update cassandra link

### DIFF
--- a/jmx-metrics/docs/target-systems/cassandra.md
+++ b/jmx-metrics/docs/target-systems/cassandra.md
@@ -1,7 +1,7 @@
 # Casandra Metrics
 
 The JMX Metric Gatherer provides built in Cassandra metric gathering capabilities.
-These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each node: https://cassandra.apache.org/doc/latest/operating/metrics.html.
+These metrics are sourced from Cassandra's exposed Dropwizard Metrics for each node: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/metrics.html.
 
 ## Metrics
 


### PR DESCRIPTION
Looks like this link changed and is causing our builds to fail

<img width="884" alt="image" src="https://github.com/user-attachments/assets/35ad6a80-4cb2-4e64-847f-6c8a997affc9" />
