### PR TITLE
Add metrics support to auth extension

### DIFF
--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -47,6 +47,10 @@ Here is a list of required and optional configuration available for the extensio
 
   - Can also be configured using `google.cloud.quota.project` system property.
 
+- `GOOGLE_OTEL_AUTH_TARGET_SIGNALS`: Environment variable that specifies a comma-separated list of OpenTelemetry signals for which this authentication extension should be active. Valid values contain - `metrics`, `traces` or `all`. If left unspecified, `all` is assumed meaning the extension will attempt to apply authentication to exports for all signals.
+
+  - Can also be configured using `google.otel.auth.target.signals` system property.
+
 ## Usage
 
 ### With OpenTelemetry Java agent

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -30,7 +30,27 @@ public enum ConfigurableOption {
    * href="https://cloud.google.com/docs/quotas/set-quota-project">official GCP client
    * libraries</a>.
    */
-  GOOGLE_CLOUD_QUOTA_PROJECT("Google Cloud Quota Project ID");
+  GOOGLE_CLOUD_QUOTA_PROJECT("Google Cloud Quota Project ID"),
+
+  /**
+   * Specifies a comma-separated list of OpenTelemetry signals for which this authentication
+   * extension should be active. The authentication mechanisms provided by this extension will only
+   * be applied to the listed signals. If not set, {@code all} is assumed to be set which means
+   * authentication is enabled for all supported signals.
+   *
+   * <p>Valid signal values are:
+   *
+   * <ul>
+   *   <li>{@code metrics} - Enables authentication for metric exports.
+   *   <li>{@code traces} - Enables authentication for trace exports.
+   *   <li>{@code all} - Enables authentication for all exports.
+   * </ul>
+   *
+   * <p>The values are case-sensitive. Whitespace around commas and values is ignored. Can be
+   * configured using the environment variable `GOOGLE_OTEL_AUTH_TARGET_SIGNALS` or the system
+   * property `google.otel.auth.target.signals`.
+   */
+  GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Auth Extension");
 
   private final String userReadableName;
   private final String environmentVariableName;

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -132,14 +132,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // This method evaluates if the endpoint provided by the user is a known GCP telemetry endpoint.
   private static boolean isKnownGcpTelemetryEndpoint(String endpoint) {
     String knownBaseEndpointRegex = "^https://telemetry\\.googleapis\\.com(?:[:/].*)?$";
-    String knownBaseSandboxEndpoint =
-        "^https://staging-telemetry\\.sandbox\\.googleapis\\.com(?:[:/].*)?$";
     String knownRegionalizedEndpointRegex =
         "^https://([a-z0-9]+(?:-[a-z0-9]+)*)\\.rep\\.googleapis\\.com(?:[:/].*)?$";
     // create a combined regex that matches any of the above.
     String knownGcpEndpointRegex =
-        String.join(
-            "|", knownBaseEndpointRegex, knownBaseSandboxEndpoint, knownRegionalizedEndpointRegex);
+        String.join("|", knownBaseEndpointRegex, knownRegionalizedEndpointRegex);
     Pattern knownGcpEndpointPattern = Pattern.compile(knownGcpEndpointRegex);
     Matcher gcpEndpointMatcher = knownGcpEndpointPattern.matcher(endpoint);
     return gcpEndpointMatcher.matches();

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -53,9 +53,9 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   static final String QUOTA_USER_PROJECT_HEADER = "x-goog-user-project";
   static final String GCP_USER_PROJECT_ID_KEY = "gcp.project_id";
 
-  private static final String SIGNAL_TYPE_TRACES = "traces";
-  private static final String SIGNAL_TYPE_METRICS = "metrics";
-  private static final String SIGNAL_TYPE_ALL = "all";
+  static final String SIGNAL_TYPE_TRACES = "traces";
+  static final String SIGNAL_TYPE_METRICS = "metrics";
+  static final String SIGNAL_TYPE_ALL = "all";
 
   /**
    * Customizes the provided {@link AutoConfigurationCustomizer} such that authenticated exports to
@@ -122,17 +122,15 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   // Checks if the auth extension is configured to target the passed signal for authentication.
-  private static boolean isSignalTargeted(String signal) {
-    String targetedSignals =
+  private static boolean isSignalTargeted(String checkSignal) {
+    String userSpecifiedTargetedSignals =
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getConfiguredValueWithFallback(
             () -> SIGNAL_TYPE_ALL);
-    return Arrays.stream(targetedSignals.split(","))
+    return Arrays.stream(userSpecifiedTargetedSignals.split(","))
         .map(String::trim)
-        .map(
+        .anyMatch(
             targetedSignal ->
-                targetedSignal.equals(signal) || targetedSignal.equals(SIGNAL_TYPE_ALL))
-        .findFirst()
-        .isPresent();
+                targetedSignal.equals(checkSignal) || targetedSignal.equals(SIGNAL_TYPE_ALL));
   }
 
   // Adds authorization headers to the calls made by the OtlpGrpcSpanExporter and

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -76,6 +76,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
   private static final ImmutableMap<String, String> otelProperties =
       ImmutableMap.of(
+          "otel.exporter.otlp.traces.endpoint",
+          "https://telemetry.googleapis.com/v1/traces",
           "otel.traces.exporter",
           "otlp",
           "otel.metrics.exporter",

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -249,7 +249,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
     System.setProperty(
         ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
     System.setProperty(
-        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_METRICS);
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(),
+        SIGNAL_TYPE_METRICS);
     // Prepare mocks
     prepareMockBehaviorForGoogleCredentials();
     OtlpHttpMetricExporter mockOtlpHttpMetricExporter = Mockito.mock(OtlpHttpMetricExporter.class);
@@ -309,7 +310,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
     System.setProperty(
         ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
     System.setProperty(
-        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_METRICS);
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(),
+        SIGNAL_TYPE_METRICS);
     // Prepare mocks
     prepareMockBehaviorForGoogleCredentials();
     OtlpGrpcMetricExporter mockOtlpGrpcMetricExporter = Mockito.mock(OtlpGrpcMetricExporter.class);


### PR DESCRIPTION
**Description:**

Feature addition - Adds metrics support for authenticated OTLP exports to GCP.
Also adds a new configuration `GOOGLE_OTEL_AUTH_TARGET_SIGNALS` to allow users to select signals to which authentication should be applied to. 

**Testing:**

 - Adds unit tests (focussed only on metrics).
 - Manually tested the extension with OTLP traces & metrics combined.

**Documentation:**

 - Updated the README. 

**Outstanding items:**

 - Update documentation.
 - Fix broken integration test.
