### PR TITLE
Implementing ExtendedLogRecordData

### DIFF
--- a/disk-buffering/build.gradle.kts
+++ b/disk-buffering/build.gradle.kts
@@ -22,6 +22,7 @@ val protos by configurations.creating
 
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
+  implementation("io.opentelemetry:opentelemetry-api-incubator")
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
   signature("com.toasttab.android:gummy-bears-api-21:0.6.1:coreLib@signature")

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/models/LogRecordDataImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/models/LogRecordDataImpl.java
@@ -9,15 +9,17 @@ import com.google.auto.value.AutoValue;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.Value;
+import io.opentelemetry.api.incubator.common.ExtendedAttributes;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
-import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.Nullable;
 
+@SuppressWarnings({"deprecation", "SuppressWarningsWithoutExplanation"})
 @AutoValue
-public abstract class LogRecordDataImpl implements LogRecordData {
+public abstract class LogRecordDataImpl implements ExtendedLogRecordData {
 
   public static Builder builder() {
     return new AutoValue_LogRecordDataImpl.Builder();
@@ -30,6 +32,14 @@ public abstract class LogRecordDataImpl implements LogRecordData {
         ? io.opentelemetry.sdk.logs.data.Body.empty()
         : io.opentelemetry.sdk.logs.data.Body.string(valueBody.asString());
   }
+
+  @Override
+  public ExtendedAttributes getExtendedAttributes() {
+    return ExtendedAttributes.builder().putAll(getAttributes()).build();
+  }
+
+  @Override
+  public abstract Attributes getAttributes();
 
   @Override
   @Nullable

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/models/LogRecordDataImpl.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/models/LogRecordDataImpl.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData;
 import io.opentelemetry.sdk.resources.Resource;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"deprecation", "SuppressWarningsWithoutExplanation"})
 @AutoValue
 public abstract class LogRecordDataImpl implements ExtendedLogRecordData {
 
@@ -38,6 +37,9 @@ public abstract class LogRecordDataImpl implements ExtendedLogRecordData {
     return ExtendedAttributes.builder().putAll(getAttributes()).build();
   }
 
+  // It's only deprecated in the incubating interface for extended attributes, which are not yet
+  // supported in this module.
+  @SuppressWarnings("deprecation")
   @Override
   public abstract Attributes getAttributes();
 


### PR DESCRIPTION
These changes are meant as a temporary workaround for [this issue](https://github.com/open-telemetry/opentelemetry-java/issues/7363).

We need to decide whether we are going to add support for extended attributes in disk buffering while they are incubating. However, in the meantime these changes will prevent the issue mentioned above where logs are completely broken due to the cast issue.