### PR TITLE
Simplify auto spotless workflow

### DIFF
--- a/.github/workflows/auto-spotless-apply.yml
+++ b/.github/workflows/auto-spotless-apply.yml
@@ -42,30 +42,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: steps.unzip-patch.outputs.exists == 'true'
         with:
+          repository: "${{ github.event.workflow_run.head_repository.full_name }}"
+          ref: "${{ github.event.workflow_run.head_branch }}"
           token: ${{ steps.otelbot-token.outputs.token }}
-
-      - id: get-pr
-        if: steps.unzip-patch.outputs.exists == 'true'
-        name: Get PR
-        env:
-          PR_BRANCH: |-
-            ${{
-              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
-                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
-                || github.event.workflow_run.head_branch
-            }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo gh pr view "${PR_BRANCH}" --json number --jq .number
-          number=$(gh pr view "${PR_BRANCH}" --json number --jq .number)
-          echo $number
-          echo "number=$number" >> $GITHUB_OUTPUT
-
-      - name: Check out PR branch
-        if: steps.unzip-patch.outputs.exists == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr checkout ${{ steps.get-pr.outputs.number }}
 
       - name: Use CLA approved github bot
         if: steps.unzip-patch.outputs.exists == 'true'
@@ -81,6 +60,21 @@ jobs:
           git apply "${{ runner.temp }}/patch"
           git commit -a -m "./gradlew spotlessApply"
           git push
+
+      - id: get-pr
+        if: steps.unzip-patch.outputs.exists == 'true'
+        name: Get PR
+        env:
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          number=$(gh pr view --repo "${{ github.event.workflow_run.repository.full_name }}" "${PR_BRANCH}" --json number --jq .number)
+          echo "number=$number" >> $GITHUB_OUTPUT
 
       - if: steps.unzip-patch.outputs.exists == 'true' && success()
         env:


### PR DESCRIPTION
Also should fix the edge case where PR is coming from `main` branch on fork: https://github.com/open-telemetry/opentelemetry-java-contrib/pull/1855#issuecomment-2916665955

The problem before was that there was already a `main` branch checked out locally, but now it checks out remote branch directly.