### PR TITLE
Setting up: A dummy PR to give otelbot-java-contrib one merged PR under its belt

### DIFF
--- a/.github/workflows/create-dummy-pr.yml
+++ b/.github/workflows/create-dummy-pr.yml
@@ -1,0 +1,42 @@
+name: Create a dummy PR
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  create:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Need to make some kind of change, and this workflow will no longer be needed after running it the one time, so...
+        run: git rm .github/workflows/create-dummy-pr.yml
+
+      - name: Use CLA approved bot
+        run: .github/scripts/use-cla-approved-bot.sh
+
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: otelbot-token
+        with:
+          app-id: 1296620
+          private-key: ${{ secrets.OTELBOT_JAVA_CONTRIB_PRIVATE_KEY }}
+
+      - name: Create pull request against the release branch
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+        run: |
+          message="A dummy PR to give otelbot-java-contrib one merged PR under its belt"
+          branch="otelbot/dummy-pr"
+
+          git checkout -b $branch
+          git commit -a -m "$message"
+          git push --set-upstream origin $branch
+          gh pr create --title "$message" \
+                       --body "$message." \
+                       --base main


### PR DESCRIPTION
I'm hoping by giving https://github.com/apps/otelbot-java-contrib one merged PR to its name, that GitHub will not consider it a "new contributor" and will stop flagging its commits as "needing maintainer approval" before CI will run.

(you can see this problem currently being exhibited in #1924)