### PR TITLE
OpAMP HTTP service

### DIFF
--- a/opamp-client/build.gradle.kts
+++ b/opamp-client/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp")
   annotationProcessor("com.google.auto.value:auto-value")
   compileOnly("com.google.auto.value:auto-value-annotations")
+  testImplementation("org.mockito:mockito-inline")
 }
 
 val opampReleaseInfo = tasks.register<Download>("opampLastReleaseInfo") {

--- a/opamp-client/build.gradle.kts
+++ b/opamp-client/build.gradle.kts
@@ -12,6 +12,7 @@ description = "Client implementation of the OpAMP spec."
 otelJava.moduleName.set("io.opentelemetry.contrib.opamp.client")
 
 dependencies {
+  implementation("com.squareup.okhttp3:okhttp")
   annotationProcessor("com.google.auto.value:auto-value")
   compileOnly("com.google.auto.value:auto-value-annotations")
 }

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpErrorException.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpErrorException.java
@@ -1,0 +1,36 @@
+package io.opentelemetry.opamp.client.internal.connectivity.http;
+
+import java.util.Objects;
+
+@SuppressWarnings("serial")
+public class HttpErrorException extends Exception {
+  public final int errorCode;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HttpErrorException)) {
+      return false;
+    }
+    HttpErrorException that = (HttpErrorException) o;
+    return errorCode == that.errorCode && Objects.equals(getMessage(), that.getMessage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorCode, getMessage());
+  }
+
+  /**
+   * Constructs an HTTP error related exception.
+   *
+   * @param errorCode The HTTP error code.
+   * @param message The HTTP error message associated with the code.
+   */
+  public HttpErrorException(int errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpErrorException.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpErrorException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.connectivity.http;
 
 import java.util.Objects;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpSender.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpSender.java
@@ -1,0 +1,22 @@
+package io.opentelemetry.opamp.client.internal.connectivity.http;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public interface HttpSender {
+
+  CompletableFuture<Response> send(Consumer<OutputStream> writer, int contentLength);
+
+  interface Response extends Closeable {
+    int statusCode();
+
+    String statusMessage();
+
+    InputStream bodyInputStream();
+
+    String getHeader(String name);
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpSender.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/HttpSender.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.connectivity.http;
 
 import java.io.Closeable;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
@@ -12,7 +12,7 @@ import okio.BufferedSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class OkHttpSender implements HttpSender {
+public final class OkHttpSender implements HttpSender {
   private final OkHttpClient client;
   private final String url;
 

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
@@ -1,0 +1,124 @@
+package io.opentelemetry.opamp.client.internal.connectivity.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class OkHttpSender implements HttpSender {
+  private final OkHttpClient client;
+  private final String url;
+
+  public static OkHttpSender create(String url) {
+    return create(url, new OkHttpClient());
+  }
+
+  public static OkHttpSender create(String url, OkHttpClient client) {
+    return new OkHttpSender(url, client);
+  }
+
+  private OkHttpSender(String url, OkHttpClient client) {
+    this.url = url;
+    this.client = client;
+  }
+
+  @Override
+  public CompletableFuture<Response> send(Consumer<OutputStream> writer, int contentLength) {
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    okhttp3.Request.Builder builder = new okhttp3.Request.Builder().url(url);
+    String contentType = "application/x-protobuf";
+    builder.addHeader("Content-Type", contentType);
+
+    RequestBody body = new RawRequestBody(writer, contentLength, MediaType.parse(contentType));
+    builder.post(body);
+
+    try {
+      okhttp3.Response response = client.newCall(builder.build()).execute();
+      if (response.isSuccessful()) {
+        if (response.body() != null) {
+          future.complete(new OkHttpResponse(response));
+        }
+      } else {
+        future.completeExceptionally(new HttpErrorException(response.code(), response.message()));
+      }
+    } catch (IOException e) {
+      future.completeExceptionally(e);
+    }
+
+    future.completeExceptionally(new IllegalStateException());
+
+    return future;
+  }
+
+  private static class OkHttpResponse implements Response {
+    private final okhttp3.Response response;
+
+    private OkHttpResponse(okhttp3.Response response) {
+      this.response = response;
+    }
+
+    @Override
+    public int statusCode() {
+      return response.code();
+    }
+
+    @Override
+    public String statusMessage() {
+      return response.message();
+    }
+
+    @Override
+    public InputStream bodyInputStream() {
+      if (response.body() != null) {
+        return response.body().byteStream();
+      }
+      throw new NullPointerException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+      return response.headers().get(name);
+    }
+
+    @Override
+    public void close() {
+      response.close();
+    }
+  }
+
+  private static class RawRequestBody extends RequestBody {
+    private final Consumer<OutputStream> writer;
+    private final int contentLength;
+    private final MediaType contentType;
+
+    private RawRequestBody(
+        Consumer<OutputStream> writer, int contentLength, MediaType contentType) {
+      this.writer = writer;
+      this.contentLength = contentLength;
+      this.contentType = contentType;
+    }
+
+    @Nullable
+    @Override
+    public MediaType contentType() {
+      return contentType;
+    }
+
+    @Override
+    public long contentLength() {
+      return contentLength;
+    }
+
+    @Override
+    public void writeTo(@NotNull BufferedSink bufferedSink) {
+      writer.accept(bufferedSink.outputStream());
+    }
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/OkHttpSender.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.connectivity.http;
 
 import java.io.IOException;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParser.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParser.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.connectivity.http;
 
 import io.opentelemetry.opamp.client.internal.tools.SystemTime;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParser.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParser.java
@@ -1,0 +1,44 @@
+package io.opentelemetry.opamp.client.internal.connectivity.http;
+
+import io.opentelemetry.opamp.client.internal.tools.SystemTime;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class RetryAfterParser {
+  private final SystemTime systemTime;
+  public static final Pattern SECONDS_PATTERN = Pattern.compile("\\d+");
+  public static final Pattern DATE_PATTERN =
+      Pattern.compile(
+          "^([A-Za-z]{3}, [0-3][0-9] [A-Za-z]{3} [0-9]{4} [0-2][0-9]:[0-5][0-9]:[0-5][0-9] GMT)$");
+  private static final SimpleDateFormat dateFormat =
+      new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+
+  public static RetryAfterParser getInstance() {
+    return new RetryAfterParser(SystemTime.getInstance());
+  }
+
+  RetryAfterParser(SystemTime systemTime) {
+    this.systemTime = systemTime;
+  }
+
+  public Duration parse(String value) {
+    if (SECONDS_PATTERN.matcher(value).matches()) {
+      return Duration.ofSeconds(Long.parseLong(value));
+    } else if (DATE_PATTERN.matcher(value).matches()) {
+      return Duration.ofMillis(toMilliseconds(value) - systemTime.getCurrentTimeMillis());
+    }
+    throw new IllegalArgumentException("Invalid Retry-After value: " + value);
+  }
+
+  @SuppressWarnings({"JavaUtilDate", "ThrowSpecificExceptions"})
+  private static long toMilliseconds(String value) {
+    try {
+      return dateFormat.parse(value).getTime();
+    } catch (ParseException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request;
 
 import com.google.auto.value.AutoValue;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
@@ -1,21 +1,3 @@
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *	http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package io.opentelemetry.opamp.client.internal.request;
 
 import com.google.auto.value.AutoValue;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/Request.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.opentelemetry.opamp.client.internal.request;
+
+import com.google.auto.value.AutoValue;
+import opamp.proto.AgentToServer;
+
+/** Wrapper class for "AgentToServer" request body. */
+@AutoValue
+public abstract class Request {
+  public abstract AgentToServer getAgentToServer();
+
+  public static Request create(AgentToServer agentToServer) {
+    return new AutoValue_Request(agentToServer);
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.opentelemetry.opamp.client.internal.request.delay;
+
+import java.time.Duration;
+
+/**
+ * A {@link PeriodicDelay} implementation that wants to accept delay time suggestions, as explained
+ * <a
+ * href="https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#throttling">here</a>,
+ * must implement this interface.
+ */
+public interface AcceptsDelaySuggestion {
+  void suggestDelay(Duration delay);
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
@@ -1,21 +1,3 @@
-/*
- * Licensed to Elasticsearch B.V. under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. Elasticsearch B.V. licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *	http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import java.time.Duration;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/AcceptsDelaySuggestion.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import java.time.Duration;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/FixedPeriodicDelay.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/FixedPeriodicDelay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import java.time.Duration;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/FixedPeriodicDelay.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/FixedPeriodicDelay.java
@@ -1,0 +1,19 @@
+package io.opentelemetry.opamp.client.internal.request.delay;
+
+import java.time.Duration;
+
+final class FixedPeriodicDelay implements PeriodicDelay {
+  private final Duration duration;
+
+  public FixedPeriodicDelay(Duration duration) {
+    this.duration = duration;
+  }
+
+  @Override
+  public Duration getNextDelay() {
+    return duration;
+  }
+
+  @Override
+  public void reset() {}
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicDelay.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicDelay.java
@@ -1,0 +1,13 @@
+package io.opentelemetry.opamp.client.internal.request.delay;
+
+import java.time.Duration;
+
+public interface PeriodicDelay {
+  static PeriodicDelay ofFixedDuration(Duration duration) {
+    return new FixedPeriodicDelay(duration);
+  }
+
+  Duration getNextDelay();
+
+  void reset();
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicDelay.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicDelay.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import java.time.Duration;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutor.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutor.java
@@ -1,0 +1,77 @@
+package io.opentelemetry.opamp.client.internal.request.delay;
+
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public final class PeriodicTaskExecutor {
+  private final ScheduledExecutorService executorService;
+  private final Lock delaySetLock = new ReentrantLock();
+  private final AtomicReference<Runnable> periodicTask = new AtomicReference<>();
+  private PeriodicDelay periodicDelay;
+  @Nullable private ScheduledFuture<?> scheduledFuture;
+
+  public static PeriodicTaskExecutor create(PeriodicDelay initialPeriodicDelay) {
+    return new PeriodicTaskExecutor(
+        Executors.newSingleThreadScheduledExecutor(), initialPeriodicDelay);
+  }
+
+  PeriodicTaskExecutor(
+      ScheduledExecutorService executorService, PeriodicDelay initialPeriodicDelay) {
+    this.executorService = executorService;
+    this.periodicDelay = initialPeriodicDelay;
+  }
+
+  public void start(@Nonnull Runnable periodicTask) {
+    this.periodicTask.set(periodicTask);
+    scheduleNext();
+  }
+
+  public void executeNow() {
+    executorService.execute(periodicTask.get());
+  }
+
+  public void setPeriodicDelay(PeriodicDelay periodicDelay) {
+    delaySetLock.lock();
+    try {
+      if (scheduledFuture != null) {
+        scheduledFuture.cancel(false);
+      }
+      this.periodicDelay = periodicDelay;
+      periodicDelay.reset();
+      scheduleNext();
+    } finally {
+      delaySetLock.unlock();
+    }
+  }
+
+  public void stop() {
+    executorService.shutdown();
+  }
+
+  private void scheduleNext() {
+    delaySetLock.lock();
+    try {
+      scheduledFuture =
+          executorService.schedule(
+              new PeriodicRunner(), periodicDelay.getNextDelay().toNanos(), TimeUnit.NANOSECONDS);
+    } finally {
+      delaySetLock.unlock();
+    }
+  }
+
+  private class PeriodicRunner implements Runnable {
+    @Override
+    public void run() {
+      Objects.requireNonNull(periodicTask.get()).run();
+      scheduleNext();
+    }
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutor.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import java.util.Objects;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.service;
 
 import io.opentelemetry.opamp.client.internal.connectivity.http.HttpErrorException;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -1,0 +1,222 @@
+package io.opentelemetry.opamp.client.internal.request.service;
+
+import io.opentelemetry.opamp.client.internal.connectivity.http.HttpErrorException;
+import io.opentelemetry.opamp.client.internal.connectivity.http.HttpSender;
+import io.opentelemetry.opamp.client.internal.request.Request;
+import io.opentelemetry.opamp.client.internal.request.delay.AcceptsDelaySuggestion;
+import io.opentelemetry.opamp.client.internal.request.delay.PeriodicDelay;
+import io.opentelemetry.opamp.client.internal.request.delay.PeriodicTaskExecutor;
+import io.opentelemetry.opamp.client.internal.response.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import opamp.proto.AgentToServer;
+import opamp.proto.ServerErrorResponse;
+import opamp.proto.ServerErrorResponseType;
+import opamp.proto.ServerToAgent;
+
+public final class HttpRequestService implements RequestService, Runnable {
+  private final HttpSender requestSender;
+  private final PeriodicTaskExecutor executor;
+  private final PeriodicDelay periodicRequestDelay;
+  private final PeriodicDelay periodicRetryDelay;
+  private final Object runningLock = new Object();
+  private final AtomicBoolean retryModeEnabled = new AtomicBoolean(false);
+  @Nullable private Callback callback;
+  @Nullable private Supplier<Request> requestSupplier;
+  private boolean isRunning = false;
+  private boolean isStopped = false;
+  public static final PeriodicDelay DEFAULT_DELAY_BETWEEN_REQUESTS =
+      PeriodicDelay.ofFixedDuration(Duration.ofSeconds(30));
+
+  /**
+   * Creates an {@link HttpRequestService}.
+   *
+   * @param requestSender The HTTP sender implementation.
+   */
+  public static HttpRequestService create(HttpSender requestSender) {
+    return create(requestSender, DEFAULT_DELAY_BETWEEN_REQUESTS, DEFAULT_DELAY_BETWEEN_REQUESTS);
+  }
+
+  /**
+   * Creates an {@link HttpRequestService}.
+   *
+   * @param requestSender The HTTP sender implementation.
+   * @param periodicRequestDelay The time to wait between requests in general.
+   * @param periodicRetryDelay The time to wait between retries.
+   */
+  public static HttpRequestService create(
+      HttpSender requestSender,
+      PeriodicDelay periodicRequestDelay,
+      PeriodicDelay periodicRetryDelay) {
+    return new HttpRequestService(
+        requestSender,
+        PeriodicTaskExecutor.create(periodicRequestDelay),
+        periodicRequestDelay,
+        periodicRetryDelay);
+  }
+
+  HttpRequestService(
+      HttpSender requestSender,
+      PeriodicTaskExecutor executor,
+      PeriodicDelay periodicRequestDelay,
+      PeriodicDelay periodicRetryDelay) {
+    this.requestSender = requestSender;
+    this.executor = executor;
+    this.periodicRequestDelay = periodicRequestDelay;
+    this.periodicRetryDelay = periodicRetryDelay;
+  }
+
+  @Override
+  public void start(Callback callback, Supplier<Request> requestSupplier) {
+    synchronized (runningLock) {
+      if (isStopped) {
+        throw new IllegalStateException("RequestDispatcher has been stopped");
+      }
+      if (isRunning) {
+        throw new IllegalStateException("RequestDispatcher is already running");
+      }
+      this.callback = callback;
+      this.requestSupplier = requestSupplier;
+      executor.start(this);
+      isRunning = true;
+    }
+  }
+
+  @Override
+  public void stop() {
+    synchronized (runningLock) {
+      if (!isRunning || isStopped) {
+        return;
+      }
+      isStopped = true;
+      executor.executeNow();
+      executor.stop();
+    }
+  }
+
+  private void enableRetryMode(@Nullable Duration suggestedDelay) {
+    if (retryModeEnabled.compareAndSet(false, true)) {
+      if (suggestedDelay != null && periodicRetryDelay instanceof AcceptsDelaySuggestion) {
+        ((AcceptsDelaySuggestion) periodicRetryDelay).suggestDelay(suggestedDelay);
+      }
+      executor.setPeriodicDelay(periodicRetryDelay);
+    }
+  }
+
+  private void disableRetryMode() {
+    if (retryModeEnabled.compareAndSet(true, false)) {
+      executor.setPeriodicDelay(periodicRequestDelay);
+    }
+  }
+
+  @Override
+  public void sendRequest() {
+    if (!retryModeEnabled.get()) {
+      executor.executeNow();
+    }
+  }
+
+  @Override
+  public void run() {
+    doSendRequest();
+  }
+
+  private void doSendRequest() {
+    try {
+      AgentToServer agentToServer =
+          Objects.requireNonNull(requestSupplier).get().getAgentToServer();
+
+      byte[] data = agentToServer.encodeByteString().toByteArray();
+      try (HttpSender.Response response =
+          requestSender.send(new ByteArrayWriter(data), data.length).get()) {
+        if (isSuccessful(response)) {
+          handleSuccessResponse(
+              Response.create(ServerToAgent.ADAPTER.decode(response.bodyInputStream())));
+        } else {
+          handleHttpError(response);
+        }
+      } catch (IOException e) {
+        getCallback().onRequestFailed(e);
+      }
+
+    } catch (InterruptedException e) {
+      getCallback().onRequestFailed(e);
+    } catch (ExecutionException e) {
+      if (e.getCause() != null) {
+        getCallback().onRequestFailed(e.getCause());
+      } else {
+        getCallback().onRequestFailed(e);
+      }
+    }
+  }
+
+  private void handleHttpError(HttpSender.Response response) {
+    int errorCode = response.statusCode();
+    getCallback().onRequestFailed(new HttpErrorException(errorCode, response.statusMessage()));
+
+    if (errorCode == 503 || errorCode == 429) {
+      String retryAfterHeader = response.getHeader("Retry-After");
+      Duration retryAfter = null;
+      if (retryAfterHeader != null) {
+        // retryAfter = TODO parse header to duration
+      }
+      enableRetryMode(retryAfter);
+    }
+  }
+
+  private static boolean isSuccessful(HttpSender.Response response) {
+    return response.statusCode() >= 200 && response.statusCode() < 300;
+  }
+
+  private void handleSuccessResponse(Response response) {
+    if (retryModeEnabled.get()) {
+      disableRetryMode();
+    }
+    ServerToAgent serverToAgent = response.getServerToAgent();
+
+    if (serverToAgent.error_response != null) {
+      handleErrorResponse(serverToAgent.error_response);
+    }
+
+    getCallback().onRequestSuccess(response);
+  }
+
+  private void handleErrorResponse(ServerErrorResponse errorResponse) {
+    if (errorResponse.type.equals(ServerErrorResponseType.ServerErrorResponseType_Unavailable)) {
+      Duration retryAfter = null;
+      if (errorResponse.retry_info != null) {
+        retryAfter = Duration.ofNanos(errorResponse.retry_info.retry_after_nanoseconds);
+      }
+      enableRetryMode(retryAfter);
+    }
+  }
+
+  private Callback getCallback() {
+    return Objects.requireNonNull(callback);
+  }
+
+  private static class ByteArrayWriter implements Consumer<OutputStream> {
+    private final byte[] data;
+
+    private ByteArrayWriter(byte[] data) {
+      this.data = data;
+    }
+
+    @SuppressWarnings("ThrowSpecificExceptions")
+    @Override
+    public void accept(OutputStream outputStream) {
+      try {
+        outputStream.write(data);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/RequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/RequestService.java
@@ -1,0 +1,70 @@
+package io.opentelemetry.opamp.client.internal.request.service;
+
+import io.opentelemetry.opamp.client.internal.OpampClient;
+import io.opentelemetry.opamp.client.internal.request.Request;
+import io.opentelemetry.opamp.client.internal.response.Response;
+import java.util.function.Supplier;
+
+/**
+ * Handles the network connectivity in general, its implementation can choose what protocol to use
+ * (HTTP or WebSocket) and should provide the necessary configurations options depending on the
+ * case. There are 2 implementations ready to use, {@link HttpRequestService}, for using HTTP, and
+ * {@link WebSocketRequestService} for using WebSocket. The {@link OpampClient} must not be aware of
+ * the specific implementation it uses as it can expect the same behavior from either.
+ */
+public interface RequestService {
+
+  /**
+   * Starts the service. The actions done in this method depend on the implementation. For HTTP
+   * there's nothing to do here, whereas for WebSocket this is where the connectivity is started.
+   *
+   * @param callback This is the only way that the service can communicate back to the {@link
+   *     OpampClient} implementation.
+   * @param requestSupplier This supplier must be queried every time a new request is about to be
+   *     sent.
+   */
+  void start(Callback callback, Supplier<Request> requestSupplier);
+
+  /** Triggers a new request send. */
+  void sendRequest();
+
+  /**
+   * Clears the service for good. No further calls to {@link #sendRequest()} can be made after this
+   * method is called.
+   */
+  void stop();
+
+  /** Allows the service to talk back to the {@link OpampClient} implementation. */
+  interface Callback {
+    /**
+     * For WebSocket implementations, this is called when the connection is established. For HTTP
+     * implementations, this is called on every HTTP request that ends successfully.
+     */
+    void onConnectionSuccess();
+
+    /**
+     * For WebSocket implementations, this is called when the connection cannot be made or is lost.
+     * For HTTP implementations, this is called on every HTTP request that fails.
+     *
+     * @param throwable The detailed error.
+     */
+    void onConnectionFailed(Throwable throwable);
+
+    /**
+     * For WebSocket implementations, this is called every time there's a new message from the
+     * server. For HTTP implementations, this is called when a successful HTTP request is finished
+     * with a valid server to agent response body.
+     *
+     * @param response The server to agent message.
+     */
+    void onRequestSuccess(Response response);
+
+    /**
+     * For both HTTP and WebSocket implementations, this is called when an attempt at sending a
+     * message fails.
+     *
+     * @param throwable The detailed error.
+     */
+    void onRequestFailed(Throwable throwable);
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/RequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/RequestService.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.service;
 
 import io.opentelemetry.opamp.client.internal.OpampClient;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/response/Response.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/response/Response.java
@@ -1,0 +1,13 @@
+package io.opentelemetry.opamp.client.internal.response;
+
+import com.google.auto.value.AutoValue;
+import opamp.proto.ServerToAgent;
+
+@AutoValue
+public abstract class Response {
+  public abstract ServerToAgent getServerToAgent();
+
+  public static Response create(ServerToAgent serverToAgent) {
+    return new AutoValue_Response(serverToAgent);
+  }
+}

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/response/Response.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/response/Response.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.response;
 
 import com.google.auto.value.AutoValue;

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/tools/SystemTime.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/tools/SystemTime.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.tools;
 
 /** Utility to be able to mock the current system time for testing purposes. */

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/tools/SystemTime.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/tools/SystemTime.java
@@ -1,0 +1,16 @@
+package io.opentelemetry.opamp.client.internal.tools;
+
+/** Utility to be able to mock the current system time for testing purposes. */
+public final class SystemTime {
+  private static final SystemTime INSTANCE = new SystemTime();
+
+  public static SystemTime getInstance() {
+    return INSTANCE;
+  }
+
+  private SystemTime() {}
+
+  public long getCurrentTimeMillis() {
+    return System.currentTimeMillis();
+  }
+}

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParserTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParserTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.connectivity.http;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParserTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/connectivity/http/RetryAfterParserTest.java
@@ -1,0 +1,24 @@
+package io.opentelemetry.opamp.client.internal.connectivity.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.opamp.client.internal.tools.SystemTime;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RetryAfterParserTest {
+
+  @Test
+  void verifyParsing() {
+    SystemTime systemTime = mock();
+    long currentTimeMillis = 1577836800000L;
+    when(systemTime.getCurrentTimeMillis()).thenReturn(currentTimeMillis);
+
+    RetryAfterParser parser = new RetryAfterParser(systemTime);
+
+    assertThat(parser.parse("123")).isEqualTo(Duration.ofSeconds(123));
+    assertThat(parser.parse("Wed, 01 Jan 2020 01:00:00 GMT")).isEqualTo(Duration.ofHours(1));
+  }
+}

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutorTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutorTest.java
@@ -1,0 +1,168 @@
+package io.opentelemetry.opamp.client.internal.request.delay;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+class PeriodicTaskExecutorTest {
+  private static final int TIMEOUT_SECONDS = 5;
+
+  @Test
+  void verifyRunAtStart() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    PeriodicDelay delay = new TestPeriodicDelay(Duration.ofSeconds(0));
+
+    PeriodicTaskExecutor.create(delay).start(latch::countDown);
+
+    if (!latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      fail("Timed out waiting");
+    }
+  }
+
+  @Test
+  void verifyRerunAfterFinishedRunning() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+    PeriodicDelay delay = new TestPeriodicDelay(Duration.ofMillis(500));
+
+    PeriodicTaskExecutor.create(delay).start(latch::countDown);
+
+    if (!latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      fail("Timed out waiting");
+    }
+  }
+
+  @Test
+  void verifyRunningImmediatelyWhenRequested() {
+    PeriodicDelay delay = new TestPeriodicDelay(Duration.ofMinutes(1));
+    ScheduledExecutorService executorService = mock();
+    Runnable task = mock(Runnable.class);
+    PeriodicTaskExecutor executor = new PeriodicTaskExecutor(executorService, delay);
+    executor.start(task);
+
+    executor.executeNow();
+
+    verify(executorService).execute(task);
+  }
+
+  @Test
+  void verifyKeepingOriginalScheduleAfterRunningImmediately() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+    PeriodicDelay delay = new TestPeriodicDelay(Duration.ofSeconds(1));
+
+    PeriodicTaskExecutor executor = PeriodicTaskExecutor.create(delay);
+    executor.start(latch::countDown);
+
+    executor.executeNow();
+
+    if (!latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      fail("Timed out waiting");
+    }
+  }
+
+  @Test
+  void verifyDelayValueUsed() {
+    Duration duration = Duration.ofSeconds(1);
+    PeriodicDelay delay = new TestPeriodicDelay(duration);
+    ScheduledExecutorService executorService = mock();
+
+    PeriodicTaskExecutor executor = new PeriodicTaskExecutor(executorService, delay);
+
+    executor.start(() -> {});
+
+    verify(executorService)
+        .schedule(any(Runnable.class), eq(duration.toNanos()), eq(TimeUnit.NANOSECONDS));
+  }
+
+  @Test
+  void verifyDelayChange() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    PeriodicDelay delay = new TestPeriodicDelay(Duration.ofMinutes(1));
+
+    PeriodicTaskExecutor executor = PeriodicTaskExecutor.create(delay);
+    executor.start(latch::countDown);
+
+    executor.setPeriodicDelay(new TestPeriodicDelay(Duration.ofSeconds(1)));
+
+    if (!latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      fail("Timed out waiting");
+    }
+  }
+
+  @Test
+  void verifyPreviousTaskCancelledWhenDelayChanges() {
+    ScheduledExecutorService executorService = mock();
+    ScheduledFuture firstTaskFuture = mock(ScheduledFuture.class);
+    when(executorService.schedule(any(Runnable.class), anyLong(), any()))
+        .thenReturn(firstTaskFuture);
+
+    PeriodicTaskExecutor executor =
+        new PeriodicTaskExecutor(executorService, new TestPeriodicDelay(Duration.ofSeconds(1)));
+
+    executor.start(() -> {});
+
+    executor.setPeriodicDelay(new TestPeriodicDelay(Duration.ofSeconds(2)));
+
+    verify(firstTaskFuture).cancel(false);
+  }
+
+  @Test
+  void verifyNewPeriodicDelayGetsResetBeforeBeingUsed() {
+    ScheduledExecutorService executorService = mock();
+    ScheduledFuture firstTaskFuture = mock(ScheduledFuture.class);
+    when(executorService.schedule(any(Runnable.class), anyLong(), any()))
+        .thenReturn(firstTaskFuture);
+    PeriodicDelay delayChange = mock();
+
+    PeriodicTaskExecutor executor =
+        new PeriodicTaskExecutor(executorService, new TestPeriodicDelay(Duration.ofSeconds(1)));
+
+    executor.start(() -> {});
+
+    executor.setPeriodicDelay(delayChange);
+
+    InOrder inOrder = inOrder(delayChange);
+    inOrder.verify(delayChange).reset();
+    inOrder.verify(delayChange).getNextDelay();
+  }
+
+  @Test
+  void verifyStop() {
+    ScheduledExecutorService executorService = mock();
+
+    PeriodicTaskExecutor executor =
+        new PeriodicTaskExecutor(executorService, new TestPeriodicDelay(Duration.ofSeconds(1)));
+    executor.stop();
+
+    verify(executorService).shutdown();
+  }
+
+  private static class TestPeriodicDelay implements PeriodicDelay {
+    private final Duration delay;
+
+    private TestPeriodicDelay(Duration delay) {
+      this.delay = delay;
+    }
+
+    @Override
+    public Duration getNextDelay() {
+      return delay;
+    }
+
+    @Override
+    public void reset() {}
+  }
+}

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutorTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/delay/PeriodicTaskExecutorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.delay;
 
 import static org.junit.jupiter.api.Assertions.fail;

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -1,0 +1,319 @@
+package io.opentelemetry.opamp.client.internal.request.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.opamp.client.internal.connectivity.http.HttpErrorException;
+import io.opentelemetry.opamp.client.internal.connectivity.http.HttpSender;
+import io.opentelemetry.opamp.client.internal.request.Request;
+import io.opentelemetry.opamp.client.internal.request.delay.AcceptsDelaySuggestion;
+import io.opentelemetry.opamp.client.internal.request.delay.PeriodicDelay;
+import io.opentelemetry.opamp.client.internal.request.delay.PeriodicTaskExecutor;
+import io.opentelemetry.opamp.client.internal.response.Response;
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+import opamp.proto.AgentToServer;
+import opamp.proto.RetryInfo;
+import opamp.proto.ServerErrorResponse;
+import opamp.proto.ServerErrorResponseType;
+import opamp.proto.ServerToAgent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class HttpRequestServiceTest {
+  @Mock private HttpSender requestSender;
+  @Mock private PeriodicDelay periodicRequestDelay;
+  @Mock private TestPeriodicRetryDelay periodicRetryDelay;
+  @Mock private PeriodicTaskExecutor executor;
+  @Mock private RequestService.Callback callback;
+  @Mock private Supplier<Request> requestSupplier;
+  private int requestSize = -1;
+  private HttpRequestService httpRequestService;
+
+  @BeforeEach
+  void setUp() {
+    httpRequestService =
+        new HttpRequestService(requestSender, executor, periodicRequestDelay, periodicRetryDelay);
+  }
+
+  @Test
+  void verifyStart() {
+    httpRequestService.start(callback, requestSupplier);
+
+    InOrder inOrder = inOrder(periodicRequestDelay, executor);
+    inOrder.verify(executor).start(httpRequestService);
+
+    // Try starting it again:
+    try {
+      httpRequestService.start(callback, requestSupplier);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("RequestDispatcher is already running");
+    }
+  }
+
+  @Test
+  void verifyStop() {
+    httpRequestService.start(callback, requestSupplier);
+    httpRequestService.stop();
+
+    verify(executor).stop();
+
+    // Try stopping it again:
+    clearInvocations(executor);
+    httpRequestService.stop();
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void verifyStop_whenNotStarted() {
+    httpRequestService.stop();
+
+    verifyNoInteractions(executor, requestSender, periodicRequestDelay);
+  }
+
+  @Test
+  void whenTryingToStartAfterStopHasBeenCalled_throwException() {
+    httpRequestService.start(callback, requestSupplier);
+    httpRequestService.stop();
+    try {
+      httpRequestService.start(callback, requestSupplier);
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("RequestDispatcher has been stopped");
+    }
+  }
+
+  @Test
+  void verifySendingRequest_happyPath() {
+    HttpSender.Response httpResponse = mock();
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().build();
+    attachServerToAgentMessage(serverToAgent.encodeByteString().toByteArray(), httpResponse);
+    prepareRequest();
+    enqueueResponse(httpResponse);
+
+    httpRequestService.run();
+
+    verify(requestSender).send(any(), eq(requestSize));
+    verify(callback).onRequestSuccess(Response.create(serverToAgent));
+  }
+
+  @Test
+  void verifySendingRequest_whenTheresAParsingError() {
+    HttpSender.Response httpResponse = mock();
+    attachServerToAgentMessage(new byte[] {1, 2, 3}, httpResponse);
+    prepareRequest();
+    enqueueResponse(httpResponse);
+
+    httpRequestService.run();
+
+    verify(requestSender).send(any(), eq(requestSize));
+    verify(callback).onRequestFailed(any());
+  }
+
+  @Test
+  void verifySendingRequest_whenThereIsAnExecutionError()
+      throws ExecutionException, InterruptedException {
+    prepareRequest();
+    CompletableFuture<HttpSender.Response> future = mock();
+    when(requestSender.send(any(), anyInt())).thenReturn(future);
+    Exception myException = mock();
+    doThrow(new ExecutionException(myException)).when(future).get();
+
+    httpRequestService.run();
+
+    verify(requestSender).send(any(), eq(requestSize));
+    verify(callback).onRequestFailed(myException);
+  }
+
+  @Test
+  void verifySendingRequest_whenThereIsAnInterruptedException()
+      throws ExecutionException, InterruptedException {
+    prepareRequest();
+    CompletableFuture<HttpSender.Response> future = mock();
+    when(requestSender.send(any(), anyInt())).thenReturn(future);
+    InterruptedException myException = mock();
+    doThrow(myException).when(future).get();
+
+    httpRequestService.run();
+
+    verify(requestSender).send(any(), eq(requestSize));
+    verify(callback).onRequestFailed(myException);
+  }
+
+  @Test
+  void verifySendingRequest_whenThereIsAGenericHttpError() {
+    HttpSender.Response response = mock();
+    when(response.statusCode()).thenReturn(500);
+    when(response.statusMessage()).thenReturn("Error message");
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(callback).onRequestFailed(new HttpErrorException(500, "Error message"));
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void verifySendingRequest_whenThereIsATooManyRequestsError() {
+    HttpSender.Response response = mock();
+    when(response.statusCode()).thenReturn(429);
+    when(response.statusMessage()).thenReturn("Error message");
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(callback).onRequestFailed(new HttpErrorException(429, "Error message"));
+    verify(executor).setPeriodicDelay(periodicRetryDelay);
+  }
+
+  @Test
+  void verifySendingRequest_whenServerProvidesRetryInfo_usingTheProvidedInfo() {
+    HttpSender.Response response = mock();
+    long nanosecondsToWaitForRetry = 1000;
+    ServerErrorResponse errorResponse =
+        new ServerErrorResponse.Builder()
+            .type(ServerErrorResponseType.ServerErrorResponseType_Unavailable)
+            .retry_info(
+                new RetryInfo.Builder().retry_after_nanoseconds(nanosecondsToWaitForRetry).build())
+            .build();
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().error_response(errorResponse).build();
+    attachServerToAgentMessage(serverToAgent.encodeByteString().toByteArray(), response);
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(callback).onRequestSuccess(Response.create(serverToAgent));
+    verify(periodicRetryDelay).suggestDelay(Duration.ofNanos(nanosecondsToWaitForRetry));
+    verify(executor).setPeriodicDelay(periodicRetryDelay);
+  }
+
+  @Test
+  void verifySendingRequest_whenServerIsUnavailable() {
+    HttpSender.Response response = mock();
+    ServerErrorResponse errorResponse =
+        new ServerErrorResponse.Builder()
+            .type(ServerErrorResponseType.ServerErrorResponseType_Unavailable)
+            .build();
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().error_response(errorResponse).build();
+    attachServerToAgentMessage(serverToAgent.encodeByteString().toByteArray(), response);
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(callback).onRequestSuccess(Response.create(serverToAgent));
+    verify(periodicRetryDelay, never()).suggestDelay(any());
+    verify(executor).setPeriodicDelay(periodicRetryDelay);
+  }
+
+  @Test
+  void verifySendingRequest_whenThereIsAServiceUnavailableError() {
+    HttpSender.Response response = mock();
+    when(response.statusCode()).thenReturn(503);
+    when(response.statusMessage()).thenReturn("Error message");
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(callback).onRequestFailed(new HttpErrorException(503, "Error message"));
+    verify(executor).setPeriodicDelay(periodicRetryDelay);
+  }
+
+  @Test
+  void verifySendingRequest_duringRegularMode() {
+    httpRequestService.sendRequest();
+
+    verify(executor).executeNow();
+  }
+
+  @Test
+  void verifySendingRequest_duringRetryMode() {
+    enableRetryMode();
+
+    httpRequestService.sendRequest();
+
+    verify(executor, never()).executeNow();
+  }
+
+  @Test
+  void verifySuccessfulSendingRequest_duringRetryMode() {
+    enableRetryMode();
+    HttpSender.Response response = mock();
+    attachServerToAgentMessage(
+        new ServerToAgent.Builder().build().encodeByteString().toByteArray(), response);
+    enqueueResponse(response);
+
+    httpRequestService.run();
+
+    verify(executor).setPeriodicDelay(periodicRequestDelay);
+  }
+
+  private void enableRetryMode() {
+    HttpSender.Response response = mock();
+    when(response.statusCode()).thenReturn(503);
+    when(response.statusMessage()).thenReturn("Error message");
+    prepareRequest();
+    enqueueResponse(response);
+
+    httpRequestService.run();
+  }
+
+  private void prepareRequest() {
+    httpRequestService.start(callback, requestSupplier);
+    clearInvocations(executor);
+    AgentToServer agentToServer = new AgentToServer.Builder().sequence_num(10).build();
+    requestSize = agentToServer.encodeByteString().size();
+    Request request = Request.create(agentToServer);
+    when(requestSupplier.get()).thenReturn(request);
+  }
+
+  private void enqueueResponse(HttpSender.Response httpResponse) {
+    when(requestSender.send(any(), anyInt()))
+        .thenReturn(CompletableFuture.completedFuture(httpResponse));
+  }
+
+  private static void attachServerToAgentMessage(
+      byte[] serverToAgent, HttpSender.Response httpResponse) {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serverToAgent);
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.bodyInputStream()).thenReturn(byteArrayInputStream);
+  }
+
+  private static class TestPeriodicRetryDelay implements PeriodicDelay, AcceptsDelaySuggestion {
+
+    @Override
+    public void suggestDelay(Duration delay) {}
+
+    @Override
+    public Duration getNextDelay() {
+      return null;
+    }
+
+    @Override
+    public void reset() {}
+  }
+}

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.opamp.client.internal.request.service;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
**Description:**

This is a continuation of the OpAMP implementation work. The changes here are focused on adding the RequestService interface along with its HTTP implementation.

The RequestService interface serves as an abstraction layer that accommodates both HTTP and WebSocket protocols, so that the OpampClient implementation doesn't have to know which protocol is used.