### PR TITLE
Fix workflow when issue is a PR

### DIFF
--- a/.github/workflows/issue-management-feedback-label.yml
+++ b/.github/workflows/issue-management-feedback-label.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     if: >
       contains(github.event.issue.labels.*.name, 'needs author feedback') &&
       github.event.comment.user.login == github.event.issue.user.login


### PR DESCRIPTION
Tested on my fork and "pull-request: write" is needed when the "issue" is a pull request