### PR TITLE
Common Expression Language (CEL) sampler

### DIFF
--- a/samplers/README.md
+++ b/samplers/README.md
@@ -5,14 +5,15 @@
 The following samplers support [declarative configuration](https://opentelemetry.io/docs/languages/java/configuration/#declarative-configuration):
 
 * `RuleBasedRoutingSampler`
+* `CelBasedSampler`
 
 To use:
 
 * Add a dependency on `io.opentelemetry:opentelemetry-sdk-extension-incubator:<version>`
 * Follow the [instructions](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/incubator/README.md#file-configuration) to configure OpenTelemetry with declarative configuration.
-* Configure the `.tracer_provider.sampler` to include the `rule_based_routing` sampler.
+* Configure the `.tracer_provider.sampler` to include the `rule_based_routing` or `cel_based` sampler.
 
-NOTE: Not yet available for use with the OTEL java agent, but should be in the near future. Please check back for updates.
+## RuleBasedRoutingSampler
 
 Schema for `rule_based_routing` sampler:
 
@@ -57,6 +58,66 @@ tracer_provider:
             - action: DROP
               attribute: url.path
               pattern: /actuator.*
+```
+
+## CelBasedSampler
+
+The `CelBasedSampler` uses [Common Expression Language (CEL)](https://github.com/google/cel-spec) to create advanced sampling rules based on span attributes. CEL provides a powerful, yet simple expression language that allows you to create complex matching conditions.
+
+To use:
+
+* Add a dependency on `io.opentelemetry:opentelemetry-sdk-extension-incubator:<version>`
+* Follow the [instructions](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/incubator/README.md#file-configuration) to configure OpenTelemetry with declarative configuration.
+* Configure the `.tracer_provider.sampler` to include the `cel_based` sampler.
+
+Schema for `cel_based` sampler:
+
+```yaml
+# The fallback sampler to use if no expressions match.
+fallback_sampler:
+  always_on:
+# List of CEL expressions to evaluate. Expressions are evaluated in order.
+expressions:
+  # The action to take when the expression evaluates to true. Must be one of: DROP, RECORD_AND_SAMPLE.
+  - action: DROP
+    # The CEL expression to evaluate. Must return a boolean.
+    expression: attribute['url.path'].startsWith('/actuator')
+  - action: RECORD_AND_SAMPLE
+    expression: attribute['http.method'] == 'GET' && attribute['http.status_code'] < 400
+```
+
+Available variables in CEL expressions:
+
+* `name` (string): The span name
+* `spanKind` (string): The span kind (e.g., "SERVER", "CLIENT")
+* `attribute` (map): A map of span attributes
+
+Example of using `cel_based` sampler as the root sampler in `parent_based` sampler configuration:
+
+```yaml
+tracer_provider:
+  sampler:
+    parent_based:
+      root:
+        cel_based:
+          fallback_sampler:
+            always_on:
+          expressions:
+            # Drop health check endpoints
+            - action: DROP
+              expression: spanKind == 'SERVER' && attribute['url.path'].startsWith('/health')
+            # Drop actuator endpoints
+            - action: DROP
+              expression: spanKind == 'SERVER' && attribute['url.path'].startsWith('/actuator')
+            # Sample only HTTP GET requests with successful responses
+            - action: RECORD_AND_SAMPLE
+              expression: spanKind == 'SERVER' && attribute['http.method'] == 'GET' && attribute['http.status_code'] < 400
+            # Selectively sample based on span name
+            - action: RECORD_AND_SAMPLE
+              expression: name.contains('checkout') || name.contains('payment')
+            # Drop spans with specific name patterns
+            - action: DROP
+              expression: name.matches('.*internal.*') && spanKind == 'INTERNAL'
 ```
 
 ## Component owners

--- a/samplers/build.gradle.kts
+++ b/samplers/build.gradle.kts
@@ -9,6 +9,8 @@ otelJava.moduleName.set("io.opentelemetry.contrib.sampler")
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
 
+  implementation("dev.cel:cel:0.9.0")
+
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
   compileOnly("io.opentelemetry:opentelemetry-api-incubator")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSampler.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSampler.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler;
+
+import static java.util.Objects.requireNonNull;
+
+import dev.cel.common.types.SimpleType;
+import dev.cel.compiler.CelCompiler;
+import dev.cel.compiler.CelCompilerFactory;
+import dev.cel.runtime.CelEvaluationException;
+import dev.cel.runtime.CelRuntime;
+import dev.cel.runtime.CelRuntimeFactory;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * This sampler accepts a list of {@link CelBasedSamplingExpression}s and tries to match every
+ * proposed span against those rules. Every rule describes a span's attribute, a pattern against
+ * which to match attribute's value, and a sampler that will make a decision about given span if
+ * match was successful.
+ *
+ * <p>Matching is performed by {@link Pattern}.
+ *
+ * <p>Provided span kind is checked first and if differs from the one given to {@link
+ * #builder(Sampler)}, the default fallback sampler will make a decision.
+ *
+ * <p>Note that only attributes that were set on {@link SpanBuilder} will be taken into account,
+ * attributes set after the span has been started are not used
+ *
+ * <p>If none of the rules matched, the default fallback sampler will make a decision.
+ */
+public final class CelBasedSampler implements Sampler {
+
+  private static final Logger logger = Logger.getLogger(CelBasedSampler.class.getName());
+
+  private static final CelCompiler celCompiler =
+      CelCompilerFactory.standardCelCompilerBuilder()
+          .addVar("name", SimpleType.STRING) // Span name
+          .addVar("spanKind", SimpleType.STRING) // Span kind as string
+          .addVar("attribute", SimpleType.DYN) // Attributes as a map
+          .setResultType(SimpleType.BOOL) // Expression must return boolean
+          .build();
+  final CelRuntime celRuntime;
+
+  private final Sampler fallback;
+  private final List<CelBasedSamplingExpression> expressions;
+
+  public CelBasedSampler(Sampler fallback, List<CelBasedSamplingExpression> expressions) {
+    this.fallback = fallback;
+    this.expressions = expressions;
+    this.celRuntime = CelRuntimeFactory.standardCelRuntimeBuilder().build();
+  }
+
+  public static CelBasedSamplerBuilder builder(Sampler fallback) {
+    return new CelBasedSamplerBuilder(
+        requireNonNull(fallback, "fallback sampler must not be null"), celCompiler);
+  }
+
+  @Override
+  public SamplingResult shouldSample(
+      Context parentContext,
+      String traceId,
+      String name,
+      SpanKind spanKind,
+      Attributes attributes,
+      List<LinkData> parentLinks) {
+
+    // Prepare the evaluation context with span data
+    Map<String, Object> evaluationContext = new HashMap<>();
+    evaluationContext.put("name", name);
+    evaluationContext.put("spanKind", spanKind.name());
+    evaluationContext.put("attribute", convertAttributesToMap(attributes));
+
+    for (CelBasedSamplingExpression expression : expressions) {
+      try {
+        CelRuntime.Program program = celRuntime.createProgram(expression.abstractSyntaxTree);
+        Object result = program.eval(evaluationContext);
+        // Happy path: Perform sampling based on the boolean result
+        if (result instanceof Boolean && ((Boolean) result)) {
+          return expression.delegate.shouldSample(
+              parentContext, traceId, name, spanKind, attributes, parentLinks);
+        }
+        // If result is not boolean, treat as false
+        logger.log(
+            Level.FINE,
+            "Expression '" + expression.expression + "' returned non-boolean result: " + result);
+      } catch (CelEvaluationException e) {
+        logger.log(
+            Level.FINE,
+            "Expression '" + expression.expression + "' evaluation error: " + e.getMessage());
+      }
+    }
+
+    return fallback.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+  }
+
+  /** Convert OpenTelemetry Attributes to a Map that CEL can work with */
+  private static Map<String, Object> convertAttributesToMap(Attributes attributes) {
+    Map<String, Object> map = new HashMap<>();
+    attributes.forEach(
+        (key, value) -> {
+          // Convert attribute values to appropriate types
+          if (value instanceof String) {
+            map.put(key.getKey(), value);
+          } else if (value instanceof Long) {
+            map.put(key.getKey(), value);
+          } else if (value instanceof Double) {
+            map.put(key.getKey(), value);
+          } else if (value instanceof Boolean) {
+            map.put(key.getKey(), value);
+          } else {
+            // For other types, convert to string
+            map.put(key.getKey(), value.toString());
+          }
+        });
+    return map;
+  }
+
+  @Override
+  public String getDescription() {
+    return "CelBasedSampler{" + "fallback=" + fallback + ", expressions=" + expressions + '}';
+  }
+
+  @Override
+  public String toString() {
+    return getDescription();
+  }
+}

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplerBuilder.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplerBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import dev.cel.common.CelAbstractSyntaxTree;
+import dev.cel.common.CelValidationException;
+import dev.cel.compiler.CelCompiler;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CelBasedSamplerBuilder {
+  private final CelCompiler celCompiler;
+  private final List<CelBasedSamplingExpression> expressions = new ArrayList<>();
+  private final Sampler defaultDelegate;
+
+  CelBasedSamplerBuilder(Sampler defaultDelegate, CelCompiler celCompiler) {
+    this.defaultDelegate = defaultDelegate;
+    this.celCompiler = celCompiler;
+  }
+
+  /**
+   * Use the provided sampler when the value of the provided {@link AttributeKey} matches the
+   * provided pattern.
+   */
+  @CanIgnoreReturnValue
+  public CelBasedSamplerBuilder customize(Sampler sampler, String expression)
+      throws CelValidationException {
+
+    CelAbstractSyntaxTree abstractSyntaxTree = celCompiler.compile(expression).getAst();
+
+    expressions.add(
+        new CelBasedSamplingExpression(
+            requireNonNull(sampler, "sampler must not be null"),
+            requireNonNull(expression, "expression must not be null"),
+            requireNonNull(abstractSyntaxTree, "abstractSyntaxTree must not be null")));
+    return this;
+  }
+
+  /**
+   * Drop all spans when the value of the provided {@link AttributeKey} matches the provided
+   * pattern.
+   */
+  @CanIgnoreReturnValue
+  public CelBasedSamplerBuilder drop(String expression) throws CelValidationException {
+    return customize(Sampler.alwaysOff(), expression);
+  }
+
+  /**
+   * Record and sample all spans when the value of the provided {@link AttributeKey} matches the
+   * provided pattern.
+   */
+  @CanIgnoreReturnValue
+  public CelBasedSamplerBuilder recordAndSample(String expression) throws CelValidationException {
+    return customize(Sampler.alwaysOn(), expression);
+  }
+
+  /** Build the sampler based on the rules provided. */
+  public CelBasedSampler build() {
+    return new CelBasedSampler(defaultDelegate, expressions);
+  }
+}

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplingExpression.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplingExpression.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler;
+
+import dev.cel.common.CelAbstractSyntaxTree;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public class CelBasedSamplingExpression {
+  final Sampler delegate;
+  final String expression;
+  final CelAbstractSyntaxTree abstractSyntaxTree;
+
+  CelBasedSamplingExpression(
+      Sampler delegate, String expression, CelAbstractSyntaxTree abstractSyntaxTree) {
+    this.delegate = delegate;
+    this.expression = expression;
+    this.abstractSyntaxTree = abstractSyntaxTree;
+  }
+
+  @Override
+  public String toString() {
+    return "CelBasedSamplingExpression{"
+        + "delegate="
+        + delegate
+        + ", expression='"
+        + expression
+        + '}';
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CelBasedSamplingExpression)) {
+      return false;
+    }
+    CelBasedSamplingExpression that = (CelBasedSamplingExpression) o;
+    return Objects.equals(delegate, that.delegate)
+        && Objects.equals(expression, that.expression)
+        && Objects.equals(abstractSyntaxTree, that.abstractSyntaxTree);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(delegate, expression, abstractSyntaxTree);
+  }
+}

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
@@ -17,10 +17,10 @@ import io.opentelemetry.sdk.trace.samplers.SamplingResult;
 import java.util.List;
 
 /**
- * This sampler accepts a list of {@link SamplingRule}s and tries to match every proposed span
- * against those rules. Every rule describes a span's attribute, a pattern against which to match
- * attribute's value, and a sampler that will make a decision about given span if match was
- * successful.
+ * This sampler accepts a list of {@link RuleBasedRoutingSamplingRule}s and tries to match every
+ * proposed span against those rules. Every rule describes a span's attribute, a pattern against
+ * which to match attribute's value, and a sampler that will make a decision about given span if
+ * match was successful.
  *
  * <p>Matching is performed by {@link java.util.regex.Pattern}.
  *
@@ -37,11 +37,12 @@ public final class RuleBasedRoutingSampler implements Sampler {
   // inlined incubating attribute to prevent direct dependency on incubating semconv
   private static final AttributeKey<String> THREAD_NAME = AttributeKey.stringKey("thread.name");
 
-  private final List<SamplingRule> rules;
+  private final List<RuleBasedRoutingSamplingRule> rules;
   private final SpanKind kind;
   private final Sampler fallback;
 
-  RuleBasedRoutingSampler(List<SamplingRule> rules, SpanKind kind, Sampler fallback) {
+  RuleBasedRoutingSampler(
+      List<RuleBasedRoutingSamplingRule> rules, SpanKind kind, Sampler fallback) {
     this.kind = requireNonNull(kind);
     this.fallback = requireNonNull(fallback);
     this.rules = requireNonNull(rules);
@@ -64,18 +65,18 @@ public final class RuleBasedRoutingSampler implements Sampler {
     if (kind != spanKind) {
       return fallback.shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
     }
-    for (SamplingRule samplingRule : rules) {
+    for (RuleBasedRoutingSamplingRule ruleBasedRoutingSamplingRule : rules) {
       String attributeValue;
-      if (samplingRule.attributeKey.getKey().equals(THREAD_NAME.getKey())) {
+      if (ruleBasedRoutingSamplingRule.attributeKey.getKey().equals(THREAD_NAME.getKey())) {
         attributeValue = Thread.currentThread().getName();
       } else {
-        attributeValue = attributes.get(samplingRule.attributeKey);
+        attributeValue = attributes.get(ruleBasedRoutingSamplingRule.attributeKey);
       }
       if (attributeValue == null) {
         continue;
       }
-      if (samplingRule.pattern.matcher(attributeValue).find()) {
-        return samplingRule.delegate.shouldSample(
+      if (ruleBasedRoutingSamplingRule.pattern.matcher(attributeValue).find()) {
+        return ruleBasedRoutingSamplingRule.delegate.shouldSample(
             parentContext, traceId, name, spanKind, attributes, parentLinks);
       }
     }

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class RuleBasedRoutingSamplerBuilder {
-  private final List<SamplingRule> rules = new ArrayList<>();
+  private final List<RuleBasedRoutingSamplingRule> rules = new ArrayList<>();
   private final SpanKind kind;
   private final Sampler defaultDelegate;
 
@@ -41,7 +41,7 @@ public final class RuleBasedRoutingSamplerBuilder {
   public RuleBasedRoutingSamplerBuilder customize(
       AttributeKey<String> attributeKey, String pattern, Sampler sampler) {
     rules.add(
-        new SamplingRule(
+        new RuleBasedRoutingSamplingRule(
             requireNonNull(attributeKey, "attributeKey must not be null"),
             requireNonNull(pattern, "pattern must not be null"),
             requireNonNull(sampler, "sampler must not be null")));

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplingRule.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplingRule.java
@@ -11,12 +11,13 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
-class SamplingRule {
+class RuleBasedRoutingSamplingRule {
   final AttributeKey<String> attributeKey;
   final Sampler delegate;
   final Pattern pattern;
 
-  SamplingRule(AttributeKey<String> attributeKey, String pattern, Sampler delegate) {
+  RuleBasedRoutingSamplingRule(
+      AttributeKey<String> attributeKey, String pattern, Sampler delegate) {
     this.attributeKey = attributeKey;
     this.pattern = Pattern.compile(pattern);
     this.delegate = delegate;
@@ -24,7 +25,7 @@ class SamplingRule {
 
   @Override
   public String toString() {
-    return "SamplingRule{"
+    return "RuleBasedRoutingSamplingRule{"
         + "attributeKey="
         + attributeKey
         + ", delegate="
@@ -39,10 +40,10 @@ class SamplingRule {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SamplingRule)) {
+    if (!(o instanceof RuleBasedRoutingSamplingRule)) {
       return false;
     }
-    SamplingRule that = (SamplingRule) o;
+    RuleBasedRoutingSamplingRule that = (RuleBasedRoutingSamplingRule) o;
     return attributeKey.equals(that.attributeKey) && pattern.equals(that.pattern);
   }
 

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/internal/CelBasedSamplerComponentProvider.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/internal/CelBasedSamplerComponentProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.sampler.internal;
+
+import dev.cel.common.CelValidationException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.contrib.sampler.CelBasedSampler;
+import io.opentelemetry.contrib.sampler.CelBasedSamplerBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.List;
+
+/**
+ * Declarative configuration SPI implementation for {@link CelBasedSampler}.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ */
+public class CelBasedSamplerComponentProvider implements ComponentProvider<Sampler> {
+
+  private static final String ACTION_RECORD_AND_SAMPLE = "RECORD_AND_SAMPLE";
+  private static final String ACTION_DROP = "DROP";
+
+  @Override
+  public Class<Sampler> getType() {
+    return Sampler.class;
+  }
+
+  @Override
+  public String getName() {
+    return "cel_based";
+  }
+
+  @Override
+  public Sampler create(DeclarativeConfigProperties config) {
+    DeclarativeConfigProperties fallbackModel = config.getStructured("fallback_sampler");
+    if (fallbackModel == null) {
+      throw new DeclarativeConfigException(
+          "cel_based sampler .fallback_sampler is required but is null");
+    }
+    Sampler fallbackSampler;
+    try {
+      fallbackSampler = DeclarativeConfiguration.createSampler(fallbackModel);
+    } catch (DeclarativeConfigException e) {
+      throw new DeclarativeConfigException(
+          "cel_based sampler failed to create .fallback_sampler sampler", e);
+    }
+
+    List<DeclarativeConfigProperties> expressions = config.getStructuredList("expressions");
+    if (expressions == null || expressions.isEmpty()) {
+      throw new DeclarativeConfigException("cel_based sampler .expressions is required");
+    }
+
+    CelBasedSamplerBuilder builder = CelBasedSampler.builder(fallbackSampler);
+
+    for (DeclarativeConfigProperties expressionConfig : expressions) {
+      String expression = expressionConfig.getString("expression");
+      if (expression == null) {
+        throw new DeclarativeConfigException(
+            "cel_based sampler .expressions[].expression is required");
+      }
+
+      String action = expressionConfig.getString("action");
+      if (action == null) {
+        throw new DeclarativeConfigException("cel_based sampler .expressions[].action is required");
+      }
+
+      try {
+        if (action.equals(ACTION_RECORD_AND_SAMPLE)) {
+          builder.recordAndSample(expression);
+        } else if (action.equals(ACTION_DROP)) {
+          builder.drop(expression);
+        } else {
+          throw new DeclarativeConfigException(
+              "cel_based sampler .expressions[].action must be "
+                  + ACTION_RECORD_AND_SAMPLE
+                  + " or "
+                  + ACTION_DROP);
+        }
+      } catch (CelValidationException e) {
+        throw new DeclarativeConfigException("Failed to compile CEL expression: " + expression, e);
+      }
+    }
+    return builder.build();
+  }
+}

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProvider.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProvider.java
@@ -42,14 +42,14 @@ public class RuleBasedRoutingSamplerComponentProvider implements ComponentProvid
     DeclarativeConfigProperties fallbackModel = config.getStructured("fallback_sampler");
     if (fallbackModel == null) {
       throw new DeclarativeConfigException(
-          "rule_based_routing sampler .fallback is required but is null");
+          "rule_based_routing sampler .fallback_sampler is required but is null");
     }
     Sampler fallbackSampler;
     try {
       fallbackSampler = DeclarativeConfiguration.createSampler(fallbackModel);
     } catch (DeclarativeConfigException e) {
       throw new DeclarativeConfigException(
-          "rule_Based_routing sampler failed to create .fallback sampler", e);
+          "rule_Based_routing sampler failed to create .fallback_sampler sampler", e);
     }
 
     String spanKindString = config.getString("span_kind", "SERVER");

--- a/samplers/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
+++ b/samplers/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
@@ -1,1 +1,2 @@
 io.opentelemetry.contrib.sampler.internal.RuleBasedRoutingSamplerComponentProvider
+io.opentelemetry.contrib.sampler.internal.CelBasedSamplerComponentProvider

--- a/samplers/src/test/java/internal/CelBasedSamplerComponentProviderTest.java
+++ b/samplers/src/test/java/internal/CelBasedSamplerComponentProviderTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package internal;
+
+import static io.opentelemetry.sdk.trace.samplers.SamplingResult.recordAndSample;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.cel.common.CelValidationException;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigException;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.contrib.sampler.CelBasedSampler;
+import io.opentelemetry.contrib.sampler.CelBasedSamplerBuilder;
+import io.opentelemetry.contrib.sampler.internal.CelBasedSamplerComponentProvider;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CelBasedSamplerComponentProviderTest {
+
+  private static final CelBasedSamplerComponentProvider PROVIDER =
+      new CelBasedSamplerComponentProvider();
+
+  @Test
+  void endToEnd() {
+    String yaml =
+        "file_format: 0.4\n"
+            + "tracer_provider:\n"
+            + "  sampler:\n"
+            + "    parent_based:\n"
+            + "      root:\n"
+            + "        cel_based:\n"
+            + "          fallback_sampler:\n"
+            + "            always_on:\n"
+            + "          expressions:\n"
+            + "            - action: DROP\n"
+            + "              expression: 'spanKind == \"SERVER\" && attribute[\"url.path\"].matches(\"/actuator.*\")'\n";
+    OpenTelemetrySdk openTelemetrySdk =
+        DeclarativeConfiguration.parseAndCreate(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+    Sampler sampler = openTelemetrySdk.getSdkTracerProvider().getSampler();
+    assertThat(sampler.toString())
+        .isEqualTo(
+            "ParentBased{"
+                + "root:CelBasedSampler{"
+                + "fallback=AlwaysOnSampler, "
+                + "expressions=["
+                + "CelBasedSamplingExpression{"
+                + "delegate=AlwaysOffSampler, "
+                + "expression='spanKind == \"SERVER\" && attribute[\"url.path\"].matches(\"/actuator.*\")"
+                + "}"
+                + "]},"
+                + "remoteParentSampled:AlwaysOnSampler,"
+                + "remoteParentNotSampled:AlwaysOffSampler,"
+                + "localParentSampled:AlwaysOnSampler,"
+                + "localParentNotSampled:AlwaysOffSampler"
+                + "}");
+
+    // SERVER span to /actuator.* path should be dropped
+    assertThat(
+            sampler.shouldSample(
+                Context.root(),
+                IdGenerator.random().generateTraceId(),
+                "GET /actuator/health",
+                SpanKind.SERVER,
+                Attributes.builder().put("url.path", "/actuator/health").build(),
+                Collections.emptyList()))
+        .isEqualTo(SamplingResult.drop());
+
+    // SERVER span to other path should be recorded and sampled
+    assertThat(
+            sampler.shouldSample(
+                Context.root(),
+                IdGenerator.random().generateTraceId(),
+                "GET /v1/users",
+                SpanKind.SERVER,
+                Attributes.builder().put("url.path", "/v1/users").build(),
+                Collections.emptyList()))
+        .isEqualTo(recordAndSample());
+  }
+
+  static Sampler dropSampler(Sampler fallback, String... expressions) {
+    CelBasedSamplerBuilder builder = CelBasedSampler.builder(fallback);
+    for (String expression : expressions) {
+      try {
+        builder.drop(expression);
+      } catch (CelValidationException e) {
+        // Delegate to the provider to handle the exception
+      }
+    }
+    return builder.build();
+  }
+
+  static Sampler recordAndSampleSampler(Sampler fallback, String... expressions) {
+    CelBasedSamplerBuilder builder = CelBasedSampler.builder(fallback);
+    for (String expression : expressions) {
+      try {
+        builder.recordAndSample(expression);
+      } catch (CelValidationException e) {
+        // Delegate to the provider to handle the exception
+      }
+    }
+    return builder.build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("createValidArgs")
+  void create_Valid(String yaml, CelBasedSampler expectedSampler) {
+    DeclarativeConfigProperties configProperties =
+        DeclarativeConfiguration.toConfigProperties(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    Sampler sampler = PROVIDER.create(configProperties);
+    assertThat(sampler.toString()).isEqualTo(expectedSampler.toString());
+  }
+
+  static Stream<Arguments> createValidArgs() {
+    return Stream.of(
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_on:\n"
+                + "expressions:\n"
+                + "  - action: DROP\n"
+                + "    expression: 'spanKind == \"CLIENT\"'\n",
+            dropSampler(Sampler.alwaysOn(), "spanKind == \"CLIENT\"")),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_off:\n"
+                + "expressions:\n"
+                + "  - action: RECORD_AND_SAMPLE\n"
+                + "    expression: 'attribute[\"url.path\"] == \"/v1/user\"'\n",
+            recordAndSampleSampler(Sampler.alwaysOff(), "attribute[\"url.path\"] == \"/v1/user\"")),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_off:\n"
+                + "expressions:\n"
+                + "  - action: DROP\n"
+                + "    expression: 'attribute[\"http.request.method\"] == \"GET\"'\n"
+                + "  - action: DROP\n"
+                + "    expression: 'attribute[\"url.path\"] == \"/foo/bar\"'\n"
+                + "    action: DROP\n",
+            dropSampler(
+                Sampler.alwaysOff(),
+                "attribute[\"http.request.method\"] == \"GET\"",
+                "attribute[\"url.path\"] == \"/foo/bar\"")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("createInvalidArgs")
+  void create_Invalid(String yaml, String expectedErrorMessage) {
+    DeclarativeConfigProperties configProperties =
+        DeclarativeConfiguration.toConfigProperties(
+            new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+    assertThatThrownBy(() -> PROVIDER.create(configProperties))
+        .isInstanceOf(DeclarativeConfigException.class)
+        .hasMessage(expectedErrorMessage);
+  }
+
+  static Stream<Arguments> createInvalidArgs() {
+    return Stream.of(
+        Arguments.of(
+            "expressions:\n" + "  - action: DROP\n" + "    expression: 'spanKind == \"CLIENT\"'\n",
+            "cel_based sampler .fallback_sampler is required but is null"),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  foo:\n"
+                + "expressions:\n"
+                + "  - action: DROP\n"
+                + "    expression: 'spanKind == \"CLIENT\"'\n",
+            "cel_based sampler failed to create .fallback_sampler sampler"),
+        Arguments.of(
+            "fallback_sampler:\n" + "  always_on: {}\n",
+            "cel_based sampler .expressions is required"),
+        Arguments.of(
+            "fallback_sampler:\n" + "  always_on: {}\n" + "expressions: []\n",
+            "cel_based sampler .expressions is required"),
+        Arguments.of(
+            "fallback_sampler:\n" + "  always_on: {}\n" + "expressions:\n" + "  - action: DROP\n",
+            "cel_based sampler .expressions[].expression is required"),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_on: {}\n"
+                + "expressions:\n"
+                + "  - expression: 'spanKind == \"CLIENT\"'\n",
+            "cel_based sampler .expressions[].action is required"),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_on: {}\n"
+                + "expressions:\n"
+                + "  - action: INVALID\n"
+                + "    expression: 'spanKind == \"CLIENT\"'\n",
+            "cel_based sampler .expressions[].action must be RECORD_AND_SAMPLE or DROP"),
+        Arguments.of(
+            "fallback_sampler:\n"
+                + "  always_on: {}\n"
+                + "expressions:\n"
+                + "  - action: DROP\n"
+                + "    expression: 'invalid cel expression!'\n",
+            "Failed to compile CEL expression: invalid cel expression!"));
+  }
+}

--- a/samplers/src/test/java/internal/RuleBasedRoutingSamplerComponentProviderTest.java
+++ b/samplers/src/test/java/internal/RuleBasedRoutingSamplerComponentProviderTest.java
@@ -60,7 +60,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
             "ParentBased{"
                 + "root:RuleBasedRoutingSampler{"
                 + "rules=["
-                + "SamplingRule{attributeKey=url.path, delegate=AlwaysOffSampler, pattern=/actuator.*}"
+                + "RuleBasedRoutingSamplingRule{attributeKey=url.path, delegate=AlwaysOffSampler, pattern=/actuator.*}"
                 + "], "
                 + "kind=SERVER, "
                 + "fallback=AlwaysOnSampler"
@@ -165,7 +165,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
                 + "rules:\n"
                 + "  - attribute: url.path\n"
                 + "    pattern: path\n",
-            "rule_based_routing sampler .fallback is required but is null"),
+            "rule_based_routing sampler .fallback_sampler is required but is null"),
         Arguments.of(
             "fallback_sampler:\n"
                 + "  foo:\n"
@@ -173,7 +173,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
                 + "rules:\n"
                 + "  - attribute: url.path\n"
                 + "    pattern: path\n",
-            "rule_Based_routing sampler failed to create .fallback sampler"),
+            "rule_Based_routing sampler failed to create .fallback_sampler sampler"),
         Arguments.of(
             "fallback_sampler:\n"
                 + "  always_on:\n"

--- a/samplers/src/test/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerTest.java
@@ -48,7 +48,7 @@ class RuleBasedRoutingSamplerTest {
       SpanContext.create(traceId, parentSpanId, TraceFlags.getSampled(), TraceState.getDefault());
   private final Context parentContext = Context.root().with(Span.wrap(sampledSpanContext));
 
-  private final List<SamplingRule> patterns = new ArrayList<>();
+  private final List<RuleBasedRoutingSamplingRule> patterns = new ArrayList<>();
 
   @Mock(strictness = Mock.Strictness.LENIENT)
   private Sampler delegate;
@@ -58,8 +58,8 @@ class RuleBasedRoutingSamplerTest {
     when(delegate.shouldSample(any(), any(), any(), any(), any(), any()))
         .thenReturn(SamplingResult.create(SamplingDecision.RECORD_AND_SAMPLE));
 
-    patterns.add(new SamplingRule(URL_FULL, ".*/healthcheck", Sampler.alwaysOff()));
-    patterns.add(new SamplingRule(URL_PATH, "/actuator", Sampler.alwaysOff()));
+    patterns.add(new RuleBasedRoutingSamplingRule(URL_FULL, ".*/healthcheck", Sampler.alwaysOff()));
+    patterns.add(new RuleBasedRoutingSamplingRule(URL_PATH, "/actuator", Sampler.alwaysOff()));
   }
 
   @Test
@@ -190,7 +190,7 @@ class RuleBasedRoutingSamplerTest {
 
   @Test
   void testThreadNameSampler() {
-    patterns.add(new SamplingRule(THREAD_NAME, "Test.*", Sampler.alwaysOff()));
+    patterns.add(new RuleBasedRoutingSamplingRule(THREAD_NAME, "Test.*", Sampler.alwaysOff()));
     Attributes attributes = Attributes.of(THREAD_NAME, "Test worker");
     RuleBasedRoutingSampler sampler = new RuleBasedRoutingSampler(patterns, SPAN_KIND, delegate);
     SamplingResult samplingResult =


### PR DESCRIPTION
This pull request introduces a new `CelBasedSampler` to the OpenTelemetry Java SDK, enabling advanced sampling rules using the [Common Expression Language (CEL)](https://cel.dev/). It also includes updates to the existing `RuleBasedRoutingSampler` for consistency and clarity. Below is a summary of the most important changes grouped by theme:

### New `CelBasedSampler` Implementation:
* Added the `CelBasedSampler` class, which evaluates CEL expressions to make sampling decisions based on span attributes. It includes a fallback sampler and supports multiple expressions. (`samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSampler.java`)
* Introduced the `CelBasedSamplerBuilder` to construct `CelBasedSampler` instances with methods for adding expressions and specifying actions (e.g., `DROP` or `RECORD_AND_SAMPLE`). (`samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplerBuilder.java`)
* Added the `CelBasedSamplingExpression` class to encapsulate individual CEL expressions and their associated samplers. (`samplers/src/main/java/io/opentelemetry/contrib/sampler/CelBasedSamplingExpression.java`)
* Implemented a declarative configuration provider for `CelBasedSampler`, enabling configuration through YAML files. (`samplers/src/main/java/io/opentelemetry/contrib/sampler/internal/CelBasedSamplerComponentProvider.java`)

```yaml
# The fallback sampler to use if no expressions match.
fallback_sampler:
  always_on:
# List of CEL expressions to evaluate. Expressions are evaluated in order.
expressions:
  # The action to take when the expression evaluates to true. Must be one of: DROP, RECORD_AND_SAMPLE.
  - action: DROP
    # The CEL expression to evaluate. Must return a boolean.
    expression: attribute['url.path'].startsWith('/actuator')
  - action: RECORD_AND_SAMPLE
    expression: attribute['http.method'] == 'GET' && attribute['http.status_code'] < 400
```

### Documentation Updates:
* Updated `samplers/README.md` to document the new `CelBasedSampler`, including its usage, schema, and example configurations. (`samplers/README.md`) [[1]](diffhunk://#diff-04f8ddc21bc0d07866fd15df18a227ab8a2ff3077a49237b291417b30f603350R8-R16) [[2]](diffhunk://#diff-04f8ddc21bc0d07866fd15df18a227ab8a2ff3077a49237b291417b30f603350R63-R122)

### Dependency Additions:
* Added a dependency on the `dev.cel:cel:0.9.0` library to enable CEL expression evaluation. (`samplers/build.gradle.kts`)

### Updates to `RuleBasedRoutingSampler`:
* Renamed `SamplingRule` to `RuleBasedRoutingSamplingRule` for clarity and updated all related references in the `RuleBasedRoutingSampler` and its builder. (`samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java`, `samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java`, `samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplingRule.java`) [[1]](diffhunk://#diff-8d5c9e7a1055658bca746fc511be27d559d5a05784bee429b66f8d4828b181d8L20-R23) [[2]](diffhunk://#diff-8d5c9e7a1055658bca746fc511be27d559d5a05784bee429b66f8d4828b181d8L40-R45) [[3]](diffhunk://#diff-8d5c9e7a1055658bca746fc511be27d559d5a05784bee429b66f8d4828b181d8L67-R79) [[4]](diffhunk://#diff-6d709cd7757cda0e51ba7d356b3c29290dda9d04b43e4d6edc2919c8fd7f0dd7L18-R18) [[5]](diffhunk://#diff-6d709cd7757cda0e51ba7d356b3c29290dda9d04b43e4d6edc2919c8fd7f0dd7L44-R44) [[6]](diffhunk://#diff-6afb6bd80bcafb5070370afc04daff9a0b0641e85b158cd0c013ab32595a33e4L14-R28) [[7]](diffhunk://#diff-6afb6bd80bcafb5070370afc04daff9a0b0641e85b158cd0c013ab32595a33e4L42-R46)

These changes collectively enhance the SDK's sampling capabilities, allowing users to define sophisticated sampling rules using CEL while maintaining compatibility with existing samplers.