### PR TITLE
Revert "Update version to 1.48.0-SNAPSHOT"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## Version 1.47.0 (2025-05-19)
-
 ### GCP authentication extension
 
 - Update the internal implementation such that the required headers are retrieved

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
-val stableVersion = "1.48.0-SNAPSHOT"
-val alphaVersion = "1.48.0-alpha-SNAPSHOT"
+val stableVersion = "1.47.0-SNAPSHOT"
+val alphaVersion = "1.47.0-alpha-SNAPSHOT"
 
 allprojects {
   if (findProperty("otel.stable") != "true") {


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-java-contrib#1898

Looks like I prepared the release last month, but never made it.

Rolling back so I can re-prepare and so this month's release will be 1.47.0