### PR TITLE
fix tomcat integration test

### DIFF
--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/JvmIntegrationTest.java
@@ -32,12 +32,6 @@ public class JvmIntegrationTest extends TargetSystemIntegrationTest {
       JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
     return scraper
         .withTargetSystem("jvm")
-        // Since JVM metrics were be added to instrumentation, the default "auto" source
-        // means that the definitions in instrumentation will be used, and thus this test will fail
-        // due to metrics differences, adding an explicit "legacy" source is required to continue
-        // testing the JVM metrics defined in this project.
-        // https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13392
-        .withTargetSystemSource("legacy")
         // also testing custom yaml
         .withCustomYaml("custom-metrics.yaml");
   }

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TargetSystemIntegrationTest.java
@@ -143,6 +143,12 @@ public abstract class TargetSystemIntegrationTest {
     // Create and initialize scraper container
     scraper =
         new JmxScraperContainer(otlpEndpoint, scraperBaseImage())
+            // Since JVM metrics were be added to instrumentation, the default "auto" source
+            // means that the definitions in instrumentation will be used, and thus tests will fail
+            // due to metrics differences, adding an explicit "legacy" source is required to
+            // continue
+            // testing metrics defined in this project.
+            .withTargetSystemSource("legacy")
             .withLogConsumer(new Slf4jLogConsumer(jmxScraperLogger))
             .withNetwork(network)
             .withRmiServiceUrl(TARGET_SYSTEM_NETWORK_ALIAS, JMX_PORT);

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
@@ -42,7 +42,7 @@ public class TomcatIntegrationTest extends TargetSystemIntegrationTest {
   @Override
   protected JmxScraperContainer customizeScraperContainer(
       JmxScraperContainer scraper, GenericContainer<?> target, Path tempDir) {
-    return scraper.withTargetSystemSource("legacy").withTargetSystem("tomcat");
+    return scraper.withTargetSystem("tomcat");
   }
 
   @Override


### PR DESCRIPTION
Tomcat integration test breaks when updating to the new instrumentation. This fixes it. Would love to have a look from @SylvainJuge and @robsunday. Thanks!