### PR TITLE
Also open issue on workflow dispatch failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    if: github.event_name == 'schedule' && always()
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()
     needs:
       - build
       - test


### PR DESCRIPTION
This is nice for testing, and also for re-running sporadic failure which will then autoclose the issue if it succeeds.