### PR TITLE
refactor ConsistentFixedThresholdSampler to setup for dynamic alternative

### DIFF
--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentFixedThresholdSampler.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.sampler.consistent56;
 
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.calculateSamplingProbability;
+import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.calculateThreshold;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.checkThreshold;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getInvalidThreshold;
 import static io.opentelemetry.contrib.sampler.consistent56.ConsistentSamplingUtil.getMaxThreshold;
@@ -22,9 +23,20 @@ public class ConsistentFixedThresholdSampler extends ConsistentSampler {
   private final String description;
 
   protected ConsistentFixedThresholdSampler(long threshold) {
-    checkThreshold(threshold);
-    this.threshold = threshold;
+    this.threshold = getThreshold(threshold);
+    this.description = getThresholdDescription(threshold);
+  }
 
+  protected ConsistentFixedThresholdSampler(double samplingProbability) {
+    this(calculateThreshold(samplingProbability));
+  }
+
+  private static long getThreshold(long threshold) {
+    checkThreshold(threshold);
+    return threshold;
+  }
+
+  private static String getThresholdDescription(long threshold) {
     String thresholdString;
     if (threshold == getMaxThreshold()) {
       thresholdString = "max";
@@ -35,12 +47,11 @@ public class ConsistentFixedThresholdSampler extends ConsistentSampler {
               .toString();
     }
 
-    this.description =
-        "ConsistentFixedThresholdSampler{threshold="
-            + thresholdString
-            + ", sampling probability="
-            + calculateSamplingProbability(threshold)
-            + "}";
+    return "ConsistentFixedThresholdSampler{threshold="
+        + thresholdString
+        + ", sampling probability="
+        + calculateSamplingProbability(threshold)
+        + "}";
   }
 
   @Override


### PR DESCRIPTION
**Description:**

Per https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2016 this refactors ConsistentFixedThresholdSampler to setup for a subsequent change that allows for a fixed (final threshold) and a dynamic (volatile threshold) sampler as subclasses

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2016 

**Testing:**

Tested a variant in a distribution per the issue, will repeat the full test with the final implementation when the issue is complete

**Documentation:**

No change needed (yet)

**Outstanding items:**

Refactoring to an abstract class and addition of two concrete subclasses Fixed and Dynamic
