### PR TITLE
2007_ConsistentRateLimitingSampler

### DIFF
--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSampler.java
@@ -186,10 +186,20 @@ public abstract class ConsistentSampler implements Sampler, Composable {
     boolean isSampled;
     boolean isAdjustedCountCorrect;
     if (isValidThreshold(threshold)) {
-      long randomness = getRandomness(otelTraceState, traceId);
-      isSampled = threshold <= randomness;
       isAdjustedCountCorrect = intent.isAdjustedCountReliable();
-    } else { // DROP
+      // determine the randomness value to use
+      long randomness;
+      randomness = getRandomness(otelTraceState, traceId);
+      if (isAdjustedCountCorrect) {
+        randomness = getRandomness(otelTraceState, traceId);
+      } else {
+        // We cannot assume any particular distribution of the provided trace randomness,
+        // because the sampling decision may depend directly or indirectly on the randomness value;
+        // however, we still want to sample with probability corresponding to the obtained threshold
+        randomness = RandomValueGenerators.getDefault().generate(traceId);
+      }
+      isSampled = threshold <= randomness;
+    } else { // invalid threshold, DROP
       isSampled = false;
       isAdjustedCountCorrect = false;
     }

--- a/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSampler.java
+++ b/consistent-sampling/src/main/java/io/opentelemetry/contrib/sampler/consistent56/ConsistentSampler.java
@@ -189,7 +189,6 @@ public abstract class ConsistentSampler implements Sampler, Composable {
       isAdjustedCountCorrect = intent.isAdjustedCountReliable();
       // determine the randomness value to use
       long randomness;
-      randomness = getRandomness(otelTraceState, traceId);
       if (isAdjustedCountCorrect) {
         randomness = getRandomness(otelTraceState, traceId);
       } else {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2007.

**Description:**

Using a new randomness value whenever making sampling decision with unreliable adjusted count.

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2007


**Testing:**

Added unit test for this scenario.

