### PR TITLE
Fix flaky aws remote sampler test

### DIFF
--- a/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
+++ b/aws-xray/src/test/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSamplerTest.java
@@ -196,7 +196,6 @@ class AwsXrayRemoteSamplerTest {
             .setEndpoint(server.httpUri().toString())
             .setPollingInterval(Duration.ofMinutes(5))
             .build()) {
-      assertThat(samplerWithLongerPollingInterval.getNextSamplerUpdateScheduledDuration()).isNull();
       await()
           .untilAsserted(
               () -> {


### PR DESCRIPTION
Sampler update time is set up in a background thread. By the time the removed assertion is run it is usually not set, but sometimes is.
