### PR TITLE
Remove Triagers section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,6 @@ For more information about the maintainer role, see the [community repository](h
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 
-### Triagers
-
-- All [component owners](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/.github/component_owners.yml) are given Triager permissions to this repository.
-
-For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
-
 ### Emeritus maintainers
 
 - [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek)


### PR DESCRIPTION
We don't have any general triagers in this repo currently (only component based triagers)

Related to https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2052