### PR TITLE
Add golden e2e tests for ibm-mq-metrics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: Run End to End tests for IBM MQ Metrics
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - ibm-mq-metrics/**
+  pull_request:
+    paths:
+      - ibm-mq-metrics/**
+
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Docker images.
+        uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
+        with:
+          key: docker-mq-e2e
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Build the jar
+        run: |
+          ./gradlew ibm-mq-metrics:clean ibm-mq-metrics:shadowJar
+
+      - name: Make a local copy of the ibm client jar
+        run: |
+          ./gradlew ibm-mq-metrics:copyIbmClientJar
+
+      - name: Start MQ and the test services
+        run: |
+          cd ibm-mq-metrics/golden
+          docker compose up -d --wait
+
+      - name: Run the integration
+        run: |
+          cd ibm-mq-metrics/golden
+          ./run.sh &
+          exit_code=$(docker wait golden)
+          docker logs golden
+          if [ "$exit_code" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Notify failed build
+        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b # v1.2.0
+        if: failure() && github.event.pull_request == null
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/ibm-mq-metrics/build.gradle.kts
+++ b/ibm-mq-metrics/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.provideDelegate
+
 plugins {
   application
   id("com.gradleup.shadow")
@@ -66,4 +68,10 @@ tasks.shadowJar {
   dependencies {
     exclude(dependency("com.ibm.mq:com.ibm.mq.allclient"))
   }
+}
+
+task("copyIbmClientJar", Copy::class) {
+  from(ibmClientJar) {
+    rename { "com.ibm.mq.allclient.jar" }
+  }.into("build/libs")
 }

--- a/ibm-mq-metrics/golden/config.yml
+++ b/ibm-mq-metrics/golden/config.yml
@@ -1,0 +1,217 @@
+#Run it as a scheduled task instead of running every minute.
+#If you want to run this every minute, comment this out
+#taskSchedule:
+#  numberOfThreads: 20
+#  taskDelaySeconds: 300
+
+#This is the timeout on queue metrics and channel metrics threads.Default value is 20 seconds.
+#No need to change the default unless you know what you are doing.
+#queueMetricsCollectionTimeoutInSeconds: 40
+#channelMetricsCollectionTimeoutInSeconds: 40
+#topicMetricsCollectionTimeoutInSeconds: 40
+
+queueManagers:
+  - name: "QM1"
+    host: "0.0.0.0"
+    port: 1414
+
+    # Indicate the MaxActiveChannels as set in qm.ini, see https://www.ibm.com/docs/en/ibm-mq/9.3.x?topic=qmini-channels-stanza-file
+    maxActiveChannels: 4200
+
+    #The transport type for the queue manager connection, the default is "Bindings" for a binding type connection
+    #For bindings type, connection WMQ extension (i.e machine agent) need to be on the same machine on which WebbsphereMQ server is running
+    #For client type, connection change it to "Client".
+    transportType: "Client"
+
+    #Channel name of the queue manager, channel should be server-conn type.
+    #This field is not required in case of transportType: Bindings
+    channelName: DEV.ADMIN.SVRCONN
+
+    #for user access level, please check "Access Permissions" section on the extensions page
+    #comment out the username and password in case of transportType: Bindings.
+    username: "admin"
+    password: "passw0rd"
+
+    #PCF requests are always sent to SYSTEM.ADMIN.COMMAND.QUEUE. The PCF responses to these requests are sent to the default reply-to queue called
+    #SYSTEM.DEFAULT.MODEL.QUEUE. However, you can override this behavior and send it to a temporary dynamic queue by changing the modelQueueName and replyQueuePrefix fields.
+    #For more details around this https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q083240_.htm & https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.adm.doc/q020010_.htm
+    #modelQueueName: ""
+    #replyQueuePrefix: ""
+
+    # Name of the temporary dynamic queue holding the configuration events. This queue contains information regarding the configuration of the queue manager, notable MaxChannels and MaxActiveChannels.
+    # If unset, the default queue name `SYSTEM.ADMIN.CONFIG.EVENT` is applied.
+    # Configuration events need to be enabled explicitly in the queue manager configuration. See https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=monitoring-configuration-events for reference.
+    #configurationQueueName: "SYSTEM.ADMIN.CONFIG.EVENT"
+
+    # Interval in milliseconds at which the configuration events in the configuration queue can be consumed.
+    # By default, no events are consumed.
+    #consumeConfigurationEventInterval: 600000 # 10 minutes
+
+    # Enable running a queue manager refresh request to reload its configuration and create a configuration event.
+    # This action is only executed if no configuration events are found when reading the configuration queue.name:
+    # By default, this action is disabled.
+    #refreshQueueManagerConfigurationEnabled: false
+
+    #Sets the CCSID used in the message descriptor of request and response messages. The default value is MQC.MQCCSI_Q_MGR.
+    #To set this, please use the integer value.
+    #ccsid:
+
+    #Sets the encoding used in the message descriptor of request and response messages. The default value is MQC.MQENC_NATIVE.
+    #To set this, please use the integer value.
+    #encoding:
+
+    # IBM Cipher Suite e.g. "SSL_RSA_WITH_AES_128_CBC_SHA256"..
+    # For translation to IBM Cipher  http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q113210_.htm
+    # A cipher working for IBM Cloud MQ and Temurin JDK 8 is TLS_AES_128_GCM_SHA256
+    #cipherSuite:  "TLS_AES_128_GCM_SHA256"
+
+
+    queueFilters:
+        #Can provide complete queue name or generic names. A generic name is a character string followed by an asterisk (*),
+        #for example ABC*, and it selects all objects having names that start with the selected character string.
+        #An asterisk on its own matches all possible names.
+        include: ["*"]
+        exclude:
+             #type value: STARTSWITH, EQUALS, ENDSWITH, CONTAINS
+           - type: "STARTSWITH"
+             #The name of the queue or queue name pattern as per queue filter, comma separated values
+             values: ["SYSTEM","AMQ"]
+
+
+    channelFilters:
+        #Can provide complete channel name or generic names. A generic name is a character string followed by an asterisk (*),
+        #for example ABC*, and it selects all objects having names that start with the selected character string.
+        #An asterisk on its own matches all possible names.
+        include: ["*"]
+        exclude:
+           #type value: STARTSWITH, EQUALS, ENDSWITH, CONTAINS
+           - type: "STARTSWITH"
+           #The name of the queue or queue name pattern as per queue filter, comma separated values
+             values: ["SYSTEM"]
+
+    listenerFilters:
+        #Can provide complete channel name or generic names. A generic name is a character string followed by an asterisk (*),
+        #for example ABC*, and it selects all objects having names that start with the selected character string.
+        #An asterisk on its own matches all possible names.
+        include: ["*"]
+        exclude:
+           #type value: STARTSWITH, EQUALS, ENDSWITH, CONTAINS
+           - type: "STARTSWITH"
+           #The name of the queue or queue name pattern as per queue filter, comma separated values
+             values: ["SYSTEM"]
+
+    topicFilters:
+        # For topics, IBM MQ uses the topic wildcard characters ('#' and '+') and does not treat a trailing asterisk as a wildcard
+        # https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q005020_.htm
+        include: ["#"]
+        exclude:
+             #type value: STARTSWITH, EQUALS, ENDSWITH, CONTAINS
+           - type: "STARTSWITH"
+             #The name of the queue or queue name pattern as per queue filter, comma separated values
+             values: ["SYSTEM","$SYS"]
+
+metrics:
+  "ibm.mq.message.retry.count":  # Number of message retries
+    enabled: true
+  "ibm.mq.status":  # Channel status
+    enabled: true
+  "ibm.mq.max.sharing.conversations":  # Maximum number of conversations permitted on this channel instance.
+    enabled: true
+  "ibm.mq.current.sharing.conversations":  # Current number of conversations permitted on this channel instance.
+    enabled: true
+  "ibm.mq.byte.received":  # Number of bytes received
+    enabled: true
+  "ibm.mq.byte.sent":  # Number of bytes sent
+    enabled: true
+  "ibm.mq.buffers.received":  # Buffers received
+    enabled: true
+  "ibm.mq.buffers.sent":  # Buffers sent
+    enabled: true
+  "ibm.mq.message.count":  # Message count
+    enabled: true
+  "ibm.mq.open.input.count":  # Count of applications sending messages to the queue
+    enabled: true
+  "ibm.mq.open.output.count":  # Count of applications consuming messages from the queue
+    enabled: true
+  "ibm.mq.high.queue.depth":  # The current high queue depth
+    enabled: true
+  "ibm.mq.service.interval":  # The queue service interval
+    enabled: true
+  "ibm.mq.queue.depth.full.event":  # The number of full queue events
+    enabled: true
+  "ibm.mq.queue.depth.high.event":  # The number of high queue events
+    enabled: true
+  "ibm.mq.queue.depth.low.event":  # The number of low queue events
+    enabled: true
+  "ibm.mq.uncommitted.messages":  # Number of uncommitted messages
+    enabled: true
+  "ibm.mq.oldest.msg.age":  # Queue message oldest age
+    enabled: true
+  "ibm.mq.current.max.queue.filesize":  # Current maximum queue file size
+    enabled: true
+  "ibm.mq.current.queue.filesize":  # Current queue file size
+    enabled: true
+  "ibm.mq.instances.per.client":  # Instances per client
+    enabled: true
+  "ibm.mq.message.deq.count":  # Message dequeue count
+    enabled: true
+  "ibm.mq.message.enq.count":  # Message enqueue count
+    enabled: true
+  "ibm.mq.queue.depth":  # Current queue depth
+    enabled: true
+  "ibm.mq.service.interval.event":  # Queue service interval event
+    enabled: true
+  "ibm.mq.reusable.log.size":  # The amount of space occupied, in megabytes, by log extents available to be reused.
+    enabled: true
+  "ibm.mq.manager.active.channels":  # The queue manager active maximum channels limit
+    enabled: true
+  "ibm.mq.restart.log.size":  # Size of the log data required for restart recovery in megabytes.
+    enabled: true
+  "ibm.mq.max.queue.depth":  # Maximum queue depth
+    enabled: true
+  "ibm.mq.onqtime.short_period":  # Amount of time, in microseconds, that a message spent on the queue, over a short period
+    enabled: true
+  "ibm.mq.onqtime.long_period":  # Amount of time, in microseconds, that a message spent on the queue, over a longer period
+    enabled: true
+  "ibm.mq.message.received.count":  # Number of messages received
+    enabled: true
+  "ibm.mq.message.sent.count":  # Number of messages sent
+    enabled: true
+  "ibm.mq.max.instances":  # Max channel instances
+    enabled: true
+  "ibm.mq.connection.count":  # Active connections count
+    enabled: true
+  "ibm.mq.manager.status":  # Queue manager status
+    enabled: true
+  "ibm.mq.heartbeat":  # Queue manager heartbeat
+    enabled: true
+  "ibm.mq.archive.log.size":  # Queue manager archive log size
+    enabled: true
+  "ibm.mq.manager.max.active.channels":  # Queue manager max active channels
+    enabled: true
+  "ibm.mq.manager.statistics.interval":  # Queue manager statistics interval
+    enabled: true
+  "ibm.mq.publish.count":  # Topic publication count
+    enabled: true
+  "ibm.mq.subscription.count":  # Topic subscription count
+    enabled: true
+  "ibm.mq.listener.status":  # Listener status
+    enabled: true
+  "ibm.mq.unauthorized.event":  # Number of authentication error events
+    enabled: true
+  "ibm.mq.manager.max.handles":  # Max open handles
+    enabled: true
+
+sslConnection:
+  trustStorePath: ""
+  trustStorePassword: ""
+
+  keyStorePath: ""
+  keyStorePassword: ""
+
+otlpExporter:
+  otel.metric.export.interval: 20s
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.exporter.otlp.endpoint: http://0.0.0.0:4318
+  otel.logs.exporter: none
+  otel.traces.exporter: none

--- a/ibm-mq-metrics/golden/config.yml
+++ b/ibm-mq-metrics/golden/config.yml
@@ -1,8 +1,8 @@
 #Run it as a scheduled task instead of running every minute.
-#If you want to run this every minute, comment this out
-#taskSchedule:
-#  numberOfThreads: 20
-#  taskDelaySeconds: 300
+#If you want to run this every 10s, comment this out
+taskSchedule:
+  numberOfThreads: 20
+  taskDelaySeconds: 10
 
 #This is the timeout on queue metrics and channel metrics threads.Default value is 20 seconds.
 #No need to change the default unless you know what you are doing.

--- a/ibm-mq-metrics/golden/data/expected.yaml
+++ b/ibm-mq-metrics/golden/data/expected.yaml
@@ -1,0 +1,3837 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: The queue service interval
+            gauge:
+              dataPoints:
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: model-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.APP.MODEL.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.service.interval
+            unit: '{percent}'
+          - description: Active connections count
+            gauge:
+              dataPoints:
+                - asInt: "25"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.connection.count
+            unit: '{connection}'
+          - description: Maximum queue depth
+            gauge:
+              dataPoints:
+                - asInt: "5000"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5000"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5000"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5000"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5000"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: model-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.APP.MODEL.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.max.queue.depth
+            unit: '{message}'
+          - description: The current high queue depth
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.high.queue.depth
+            unit: '{percent}'
+          - description: Number of bytes received
+            gauge:
+              dataPoints:
+                - asInt: "17120"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16976"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16320"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9672"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16320"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "14780"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16320"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17124"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16320"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16320"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.byte.received
+            unit: By
+          - description: Number of bytes sent
+            gauge:
+              dataPoints:
+                - asInt: "102660"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "67460"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "71332"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "71332"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "67460"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "67460"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "70224"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11884"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "70224"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53660"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "70224"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "71332"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "71332"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "67460"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "71332"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "66352"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "70224"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.byte.sent
+            unit: By
+          - description: Queue manager heartbeat
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.heartbeat
+            unit: "1"
+          - description: The queue manager active maximum channels limit
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.manager.active.channels
+            unit: '{channel}'
+          - description: Channel status
+            gauge:
+              dataPoints:
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.status
+            unit: "1"
+          - description: The amount of space occupied, in megabytes, by log extents available to be reused.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.reusable.log.size
+            unit: By
+          - description: Buffers received
+            gauge:
+              dataPoints:
+                - asInt: "114"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "112"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "99"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.buffers.received
+            unit: '{buffer}'
+          - description: Current number of conversations permitted on this channel instance.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.current.sharing.conversations
+            unit: '{conversation}'
+          - description: Max channel instances
+            gauge:
+              dataPoints:
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.APP.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.max.instances
+            unit: '{instance}'
+          - description: Buffers sent
+            gauge:
+              dataPoints:
+                - asInt: "113"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "109"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "109"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "97"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "109"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "109"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "109"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.buffers.sent
+            unit: '{buffer}'
+          - description: Number of uncommitted messages
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.uncommitted.messages
+            unit: '{message}'
+          - description: Current queue file size
+            gauge:
+              dataPoints:
+                - asInt: "1048576"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1048576"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.current.queue.filesize
+            unit: By
+          - description: Queue manager statistics interval
+            gauge:
+              dataPoints:
+                - asInt: "1800"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.manager.statistics.interval
+            unit: "1"
+          - description: Size of the log data required for restart recovery in megabytes.
+            gauge:
+              dataPoints:
+                - asInt: "1048576"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.restart.log.size
+            unit: By
+          - description: Current queue depth
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.queue.depth
+            unit: '{message}'
+          - description: Queue message oldest age
+            gauge:
+              dataPoints:
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.oldest.msg.age
+            unit: microseconds
+          - description: Number of messages received
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.APP.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.received.count
+            unit: '{message}'
+          - description: Instances per client
+            gauge:
+              dataPoints:
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "999999999"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.APP.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.instances.per.client
+            unit: '{instance}'
+          - description: Topic publication count
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: dev
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: dev/
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.publish.count
+            unit: '{publication}'
+          - description: Queue manager max active channels
+            gauge:
+              dataPoints:
+                - asInt: "4200"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.manager.max.active.channels
+            unit: '{channel}'
+          - description: Topic subscription count
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: dev
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: dev/
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.subscription.count
+            unit: '{subscription}'
+          - description: Queue manager archive log size
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.archive.log.size
+            unit: By
+          - description: Queue manager status
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.manager.status
+            unit: "1"
+          - description: Amount of time, in microseconds, that a message spent on the queue, over a short period
+            gauge:
+              dataPoints:
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.onqtime.short_period
+            unit: microseconds
+          - description: Count of applications consuming messages from the queue
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.open.output.count
+            unit: '{application}'
+          - description: Number of messages sent
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.APP.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.sent.count
+            unit: '{message}'
+          - description: Number of message retries
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.APP.SVRCONN
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.retry.count
+            unit: '{message}'
+          - description: Current maximum queue file size
+            gauge:
+              dataPoints:
+                - asInt: "2190433320960"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2190433320960"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2190433320960"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2190433320960"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.current.max.queue.filesize
+            unit: By
+          - description: Message count
+            gauge:
+              dataPoints:
+                - asInt: "110"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "106"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "30"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "106"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "94"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "106"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "108"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "106"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "106"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.count
+            unit: '{message}'
+          - description: Message dequeue count
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.deq.count
+            unit: '{message}'
+          - description: Message enqueue count
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.message.enq.count
+            unit: '{message}'
+          - description: Count of applications sending messages to the queue
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.open.input.count
+            unit: '{application}'
+          - description: Queue service interval event
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: model-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.APP.MODEL.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.service.interval.event
+            unit: "1"
+          - description: Maximum number of conversations permitted on this channel instance.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988505"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000007"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988565"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988625"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000000F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988685"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000013"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988745"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000017"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988805"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988865"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000001F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988925"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000023"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759988985"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000027"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989045"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989105"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000002F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989165"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000033"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989225"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000037"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989285"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003B
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989345"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: 000007360000003F
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989405"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000043"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "10"
+                  attributes:
+                    - key: ibm.mq.channel.name
+                      value:
+                        stringValue: DEV.ADMIN.SVRCONN
+                    - key: ibm.mq.channel.start.time
+                      value:
+                        intValue: "1759989465"
+                    - key: ibm.mq.channel.type
+                      value:
+                        stringValue: server-connection
+                    - key: ibm.mq.job.name
+                      value:
+                        stringValue: "0000073600000045"
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.max.sharing.conversations
+            unit: '{conversation}'
+          - description: Amount of time, in microseconds, that a message spent on the queue, over a longer period
+            gauge:
+              dataPoints:
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.DEAD.LETTER.QUEUE
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.2
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "-1"
+                  attributes:
+                    - key: ibm.mq.queue.manager
+                      value:
+                        stringValue: QM1
+                    - key: ibm.mq.queue.type
+                      value:
+                        stringValue: local-normal
+                    - key: messaging.destination.name
+                      value:
+                        stringValue: DEV.QUEUE.3
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: ibm.mq.onqtime.long_period
+            unit: microseconds
+        scope:
+          name: websphere/mq

--- a/ibm-mq-metrics/golden/docker-compose.yaml
+++ b/ibm-mq-metrics/golden/docker-compose.yaml
@@ -1,0 +1,52 @@
+services:
+  mq:
+    image: icr.io/ibm-messaging/mq:9.4.2.1-r1
+    ports:
+      - 1414:1414
+      - 9443:9443
+    environment:
+      LICENSE: accept
+      MQ_QMGR_NAME: QM1
+      MQ_ADMIN_USER: admin
+      MQ_ADMIN_PASSWORD: passw0rd
+      MQ_APP_USER: app
+      MQ_APP_PASSWORD: passw0rd # deprecated, but needed for app user in some setups
+      MQ_ENABLE_METRICS: true
+    command: >-
+      --name ibm-mq-test
+      --health-cmd "echo > /dev/tcp/localhost/1414"
+      --health-interval=10s
+      --health-timeout=5s
+      --health-retries=5
+    healthcheck:
+      test: curl -k https://localhost:9443/ || exit 1
+      interval: 5s
+      retries: 20
+  collector:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.137.0
+    ports:
+      - 4317:4317
+      - 4318:4318
+    volumes:
+      - ./otelconf.yaml:/etc/otelcol-contrib/config.yaml
+  golden:
+    container_name: golden
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/golden:v0.137.0
+    volumes:
+      - ./data:/var/data
+    command: >-
+      --expected /var/data/expected.yaml
+      --otlp-http-endpoint 0.0.0.0:4318
+      --otlp-endpoint 0.0.0.0:4317
+      --ignore-timestamp
+      --ignore-start-timestamp
+      --timeout 2m
+      --ignore-metric-attribute-value channel.start.time
+      --ignore-metric-attribute-value job.name
+      --ignore-resource-metrics-order
+      --ignore-scope-metrics-order
+      --ignore-metrics-order
+      --ignore-metrics-data-points-order
+      --ignore-metric-values
+      --ignore-data-points-attributes-order
+#      --write-expected

--- a/ibm-mq-metrics/golden/docker-compose.yaml
+++ b/ibm-mq-metrics/golden/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     ports:
       - 4317:4317
       - 4318:4318
+      - 8888:8888
     volumes:
       - ./otelconf.yaml:/etc/otelcol-contrib/config.yaml
   golden:

--- a/ibm-mq-metrics/golden/otelconf.yaml
+++ b/ibm-mq-metrics/golden/otelconf.yaml
@@ -1,0 +1,34 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: detailed
+  otlp:
+    endpoint: http://golden:4317
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: false
+    sending_queue:
+      enabled: false
+processors:
+  groupbyattrs:
+  batch:
+    send_batch_size: 5000
+    timeout: 10s
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - otlp
+      processors:
+        - batch
+        - groupbyattrs
+      exporters:
+        - debug
+        - otlp

--- a/ibm-mq-metrics/golden/otelconf.yaml
+++ b/ibm-mq-metrics/golden/otelconf.yaml
@@ -22,6 +22,14 @@ processors:
     send_batch_size: 5000
     timeout: 10s
 service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
   pipelines:
     metrics:
       receivers:

--- a/ibm-mq-metrics/golden/run.sh
+++ b/ibm-mq-metrics/golden/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eux
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+jar=$(find "$SCRIPT_DIR/../build/libs" -name "opentelemetry-ibm-mq-metrics-*")
+java -cp "$jar:$SCRIPT_DIR/../build/libs/com.ibm.mq.allclient.jar" \
+  -Dotel.logs.exporter=none -Dotel.traces.exporter=none \
+  io.opentelemetry.ibm.mq.opentelemetry.Main "$SCRIPT_DIR/config.yml"

--- a/ibm-mq-metrics/golden/run.sh
+++ b/ibm-mq-metrics/golden/run.sh
@@ -3,7 +3,7 @@
 set -eux
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-jar=$(find "$SCRIPT_DIR/../build/libs" -name "opentelemetry-ibm-mq-metrics-*")
+jar=$(find "$SCRIPT_DIR/../build/libs" -name "opentelemetry-ibm-mq-metrics-*-all.jar")
 java -cp "$jar:$SCRIPT_DIR/../build/libs/com.ibm.mq.allclient.jar" \
   -Dotel.logs.exporter=none -Dotel.traces.exporter=none \
   io.opentelemetry.ibm.mq.opentelemetry.Main "$SCRIPT_DIR/config.yml"

--- a/ibm-mq-metrics/golden/run.sh
+++ b/ibm-mq-metrics/golden/run.sh
@@ -3,7 +3,11 @@
 set -eux
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-jar=$(find "$SCRIPT_DIR/../build/libs" -name "opentelemetry-ibm-mq-metrics-*-all.jar")
+jar=$(find "$SCRIPT_DIR/../build/libs" -maxdepth 1 -name "opentelemetry-ibm-mq-metrics-*-all.jar" -print -quit)
+if [[ -z "$jar" ]]; then
+  echo "Error: Shadow JAR not found in $SCRIPT_DIR/../build/libs (expected opentelemetry-ibm-mq-metrics-*-all.jar)" >&2
+  exit 1
+fi
 java -cp "$jar:$SCRIPT_DIR/../build/libs/com.ibm.mq.allclient.jar" \
   -Dotel.logs.exporter=none -Dotel.traces.exporter=none \
   io.opentelemetry.ibm.mq.opentelemetry.Main "$SCRIPT_DIR/config.yml"

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -161,8 +161,11 @@ public final class ChannelMetricsCollector implements Consumer<MetricsCollectorC
 
     logger.info(
         "Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
-    activeChannelsGauge.set(
-        activeChannels.size(), Attributes.of(IBM_MQ_QUEUE_MANAGER, context.getQueueManagerName()));
+    if (context.getMetricsConfig().isIbmMqManagerActiveChannelsEnabled()) {
+      activeChannelsGauge.set(
+          activeChannels.size(),
+          Attributes.of(IBM_MQ_QUEUE_MANAGER, context.getQueueManagerName()));
+    }
 
     long exitTime = System.currentTimeMillis() - entryTime;
     logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);


### PR DESCRIPTION
**Description:**

Test changes to add an e2e test for the ibm-mq-metrics component.

**Existing Issue(s):**

Fixes #2112
