### PR TITLE
Use a more efficient serializer and write bytes directly to disk

### DIFF
--- a/disk-buffering/build.gradle.kts
+++ b/disk-buffering/build.gradle.kts
@@ -18,6 +18,7 @@ val protos by configurations.creating
 dependencies {
   api("io.opentelemetry:opentelemetry-sdk")
   implementation("io.opentelemetry:opentelemetry-api-incubator")
+  implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
   compileOnly("com.google.auto.value:auto-value-annotations")
   annotationProcessor("com.google.auto.value:auto-value")
   signature("com.toasttab.android:gummy-bears-api-21:0.12.0:coreLib@signature")
@@ -63,9 +64,10 @@ wire {
   }
 
   root(
-    "opentelemetry.proto.trace.v1.TracesData",
-    "opentelemetry.proto.metrics.v1.MetricsData",
-    "opentelemetry.proto.logs.v1.LogsData",
+    // These are the types used by the Java SDK's OTLP exporters.
+    "opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest",
+    "opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest",
+    "opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest",
   )
 }
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/NoopSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/NoopSerializer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.exporter;
+
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+
+class NoopSerializer<T> implements SignalSerializer<T> {
+
+  @Override
+  public NoopSerializer<T> initialize(Collection<T> data) {
+    return this;
+  }
+
+  @Override
+  public void writeBinaryTo(OutputStream output) throws IOException {}
+
+  @Override
+  public int getBinarySerializedSize() {
+    return 0;
+  }
+
+  @Override
+  public void reset() {}
+}

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterBuilder.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 
 public final class ToDiskExporterBuilder<T> {
 
-  private SignalSerializer<T> serializer = ts -> new byte[0];
+  private SignalSerializer<T> serializer = new NoopSerializer<T>();
 
   private final Storage storage;
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializer.java
@@ -7,7 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.deseriali
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.ProtoLogsDataMapper;
 import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
-import io.opentelemetry.proto.logs.v1.LogsData;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +24,8 @@ public final class LogRecordDataDeserializer implements SignalDeserializer<LogRe
   @Override
   public List<LogRecordData> deserialize(byte[] source) throws DeserializationException {
     try {
-      return ProtoLogsDataMapper.getInstance().fromProto(LogsData.ADAPTER.decode(source));
+      return ProtoLogsDataMapper.getInstance()
+          .fromProto(ExportLogsServiceRequest.ADAPTER.decode(source));
     } catch (IOException e) {
       throw new DeserializationException(e);
     }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializer.java
@@ -7,7 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.deseriali
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.metrics.ProtoMetricsDataMapper;
 import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
-import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +24,8 @@ public final class MetricDataDeserializer implements SignalDeserializer<MetricDa
   @Override
   public List<MetricData> deserialize(byte[] source) throws DeserializationException {
     try {
-      return ProtoMetricsDataMapper.getInstance().fromProto(MetricsData.ADAPTER.decode(source));
+      return ProtoMetricsDataMapper.getInstance()
+          .fromProto(ExportMetricsServiceRequest.ADAPTER.decode(source));
     } catch (IOException e) {
       throw new DeserializationException(e);
     }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializer.java
@@ -7,7 +7,7 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.deseriali
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.ProtoSpansDataMapper;
 import io.opentelemetry.contrib.disk.buffering.internal.utils.SignalTypes;
-import io.opentelemetry.proto.trace.v1.TracesData;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +24,8 @@ public final class SpanDataDeserializer implements SignalDeserializer<SpanData> 
   @Override
   public List<SpanData> deserialize(byte[] source) throws DeserializationException {
     try {
-      return ProtoSpansDataMapper.getInstance().fromProto(TracesData.ADAPTER.decode(source));
+      return ProtoSpansDataMapper.getInstance()
+          .fromProto(ExportTraceServiceRequest.ADAPTER.decode(source));
     } catch (IOException e) {
       throw new DeserializationException(e);
     }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/ByteStringMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/ByteStringMapper.java
@@ -16,10 +16,10 @@ public final class ByteStringMapper {
   }
 
   public ByteString stringToProto(String source) {
-    return ByteString.encodeUtf8(source);
+    return ByteString.decodeHex(source);
   }
 
   public String protoToString(ByteString source) {
-    return source.utf8();
+    return source.hex();
   }
 }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapper.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.common.BaseProtoSignalsDataMapper;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.logs.v1.LogRecord;
-import io.opentelemetry.proto.logs.v1.LogsData;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.logs.v1.ScopeLogs;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public final class ProtoLogsDataMapper
     extends BaseProtoSignalsDataMapper<
-        LogRecordData, LogRecord, LogsData, ResourceLogs, ScopeLogs> {
+        LogRecordData, LogRecord, ExportLogsServiceRequest, ResourceLogs, ScopeLogs> {
 
   private static final ProtoLogsDataMapper INSTANCE = new ProtoLogsDataMapper();
 
@@ -39,12 +39,12 @@ public final class ProtoLogsDataMapper
   }
 
   @Override
-  protected List<ResourceLogs> getProtoResources(LogsData logsData) {
+  protected List<ResourceLogs> getProtoResources(ExportLogsServiceRequest logsData) {
     return logsData.resource_logs;
   }
 
   @Override
-  protected LogsData createProtoData(
+  protected ExportLogsServiceRequest createProtoData(
       Map<Resource, Map<InstrumentationScopeInfo, List<LogRecord>>> itemsByResource) {
     List<ResourceLogs> items = new ArrayList<>();
     itemsByResource.forEach(
@@ -58,7 +58,7 @@ public final class ProtoLogsDataMapper
           }
           items.add(resourceLogsBuilder.build());
         });
-    return new LogsData.Builder().resource_logs(items).build();
+    return new ExportLogsServiceRequest.Builder().resource_logs(items).build();
   }
 
   private ScopeLogs.Builder createProtoScopeBuilder(InstrumentationScopeInfo scopeInfo) {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapper.java
@@ -6,8 +6,8 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.metrics;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.common.BaseProtoSignalsDataMapper;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.metrics.v1.Metric;
-import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public final class ProtoMetricsDataMapper
     extends BaseProtoSignalsDataMapper<
-        MetricData, Metric, MetricsData, ResourceMetrics, ScopeMetrics> {
+        MetricData, Metric, ExportMetricsServiceRequest, ResourceMetrics, ScopeMetrics> {
 
   private static final ProtoMetricsDataMapper INSTANCE = new ProtoMetricsDataMapper();
 
@@ -39,12 +39,12 @@ public final class ProtoMetricsDataMapper
   }
 
   @Override
-  protected List<ResourceMetrics> getProtoResources(MetricsData protoData) {
+  protected List<ResourceMetrics> getProtoResources(ExportMetricsServiceRequest protoData) {
     return protoData.resource_metrics;
   }
 
   @Override
-  protected MetricsData createProtoData(
+  protected ExportMetricsServiceRequest createProtoData(
       Map<Resource, Map<InstrumentationScopeInfo, List<Metric>>> itemsByResource) {
     List<ResourceMetrics> items = new ArrayList<>();
     itemsByResource.forEach(
@@ -58,7 +58,7 @@ public final class ProtoMetricsDataMapper
           }
           items.add(resourceMetricsBuilder.build());
         });
-    return new MetricsData.Builder().resource_metrics(items).build();
+    return new ExportMetricsServiceRequest.Builder().resource_metrics(items).build();
   }
 
   private ScopeMetrics.Builder createProtoScopeBuilder(InstrumentationScopeInfo scopeInfo) {

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapper.java
@@ -6,10 +6,10 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.common.BaseProtoSignalsDataMapper;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
-import io.opentelemetry.proto.trace.v1.TracesData;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -18,7 +18,8 @@ import java.util.List;
 import java.util.Map;
 
 public final class ProtoSpansDataMapper
-    extends BaseProtoSignalsDataMapper<SpanData, Span, TracesData, ResourceSpans, ScopeSpans> {
+    extends BaseProtoSignalsDataMapper<
+        SpanData, Span, ExportTraceServiceRequest, ResourceSpans, ScopeSpans> {
 
   private static final ProtoSpansDataMapper INSTANCE = new ProtoSpansDataMapper();
 
@@ -32,7 +33,7 @@ public final class ProtoSpansDataMapper
   }
 
   @Override
-  protected List<ResourceSpans> getProtoResources(TracesData protoData) {
+  protected List<ResourceSpans> getProtoResources(ExportTraceServiceRequest protoData) {
     return protoData.resource_spans;
   }
 
@@ -43,7 +44,7 @@ public final class ProtoSpansDataMapper
   }
 
   @Override
-  protected TracesData createProtoData(
+  protected ExportTraceServiceRequest createProtoData(
       Map<Resource, Map<InstrumentationScopeInfo, List<Span>>> itemsByResource) {
     List<ResourceSpans> items = new ArrayList<>();
     itemsByResource.forEach(
@@ -57,7 +58,7 @@ public final class ProtoSpansDataMapper
           }
           items.add(resourceSpansBuilder.build());
         });
-    return new TracesData.Builder().resource_spans(items).build();
+    return new ExportTraceServiceRequest.Builder().resource_spans(items).build();
   }
 
   @Override

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SignalSerializer.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/SignalSerializer.java
@@ -8,21 +8,29 @@ package io.opentelemetry.contrib.disk.buffering.internal.serialization.serialize
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Collection;
 
 public interface SignalSerializer<SDK_ITEM> {
 
   static SignalSerializer<SpanData> ofSpans() {
-    return SpanDataSerializer.getInstance();
+    return new SpanDataSerializer();
   }
 
   static SignalSerializer<MetricData> ofMetrics() {
-    return MetricDataSerializer.getInstance();
+    return new MetricDataSerializer();
   }
 
   static SignalSerializer<LogRecordData> ofLogs() {
-    return LogRecordDataSerializer.getInstance();
+    return new LogRecordDataSerializer();
   }
 
-  byte[] serialize(Collection<SDK_ITEM> items);
+  SignalSerializer<SDK_ITEM> initialize(Collection<SDK_ITEM> data);
+
+  void writeBinaryTo(OutputStream output) throws IOException;
+
+  int getBinarySerializedSize();
+
+  void reset();
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporterTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporterTest.java
@@ -86,7 +86,7 @@ class SpanFromDiskExporterTest {
     SpanData span2 = makeSpan2(TraceFlags.getSampled(), now);
     List<SpanData> spans = Arrays.asList(span1, span2);
 
-    storage.write(SignalSerializer.ofSpans().serialize(spans));
+    storage.write(SignalSerializer.ofSpans().initialize(spans));
     storage.flush();
     return spans;
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/exporter/ToDiskExporterTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.exporter;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,8 +30,6 @@ class ToDiskExporterTest {
 
   private final List<String> records = Arrays.asList("one", "two", "three");
 
-  private final byte[] serialized = "one,two,three".getBytes(UTF_8);
-
   @Mock private SignalSerializer<String> serializer;
 
   @Mock private Storage storage;
@@ -50,21 +48,20 @@ class ToDiskExporterTest {
           return exportFnResultToReturn.get();
         };
     toDiskExporter = new ToDiskExporter<>(serializer, exportFn, storage);
-    when(serializer.serialize(records)).thenReturn(serialized);
   }
 
   @Test
   void whenWritingSucceedsOnExport_returnSuccessfulResultCode() throws Exception {
-    when(storage.write(serialized)).thenReturn(true);
+    when(storage.write(any())).thenReturn(true);
     CompletableResultCode completableResultCode = toDiskExporter.export(records);
     assertThat(completableResultCode.isSuccess()).isTrue();
-    verify(storage).write(serialized);
+    verify(storage).write(any());
     assertThat(exportedFnSeen).isNull();
   }
 
   @Test
   void whenWritingFailsOnExport_doExportRightAway() throws Exception {
-    when(storage.write(serialized)).thenReturn(false);
+    when(storage.write(any())).thenReturn(false);
     exportFnResultToReturn.set(CompletableResultCode.ofSuccess());
 
     CompletableResultCode completableResultCode = toDiskExporter.export(records);
@@ -75,7 +72,7 @@ class ToDiskExporterTest {
 
   @Test
   void whenExceptionInWrite_doExportRightAway() throws Exception {
-    when(storage.write(serialized)).thenThrow(new IOException("boom"));
+    when(storage.write(any())).thenThrow(new IOException("boom"));
     exportFnResultToReturn.set(CompletableResultCode.ofFailure());
 
     CompletableResultCode completableResultCode = toDiskExporter.export(records);

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapperTest.java
@@ -12,8 +12,8 @@ import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs.models.LogRecordDataImpl;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
 import io.opentelemetry.proto.logs.v1.LogRecord;
-import io.opentelemetry.proto.logs.v1.LogsData;
 import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.logs.v1.ScopeLogs;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -104,7 +104,7 @@ class ProtoLogsDataMapperTest {
   void verifyConversionDataStructure() {
     List<LogRecordData> signals = Collections.singletonList(LOG_RECORD);
 
-    LogsData result = mapToProto(signals);
+    ExportLogsServiceRequest result = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = result.resource_logs;
     assertEquals(1, resourceLogsList.size());
@@ -118,7 +118,7 @@ class ProtoLogsDataMapperTest {
   void verifyMultipleLogsWithSameResourceAndScope() {
     List<LogRecordData> signals = Arrays.asList(LOG_RECORD, OTHER_LOG_RECORD);
 
-    LogsData proto = mapToProto(signals);
+    ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
     assertEquals(1, resourceLogsList.size());
@@ -139,7 +139,7 @@ class ProtoLogsDataMapperTest {
     List<LogRecordData> signals =
         Arrays.asList(LOG_RECORD, LOG_RECORD_WITH_DIFFERENT_SCOPE_SAME_RESOURCE);
 
-    LogsData proto = mapToProto(signals);
+    ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
     assertEquals(1, resourceLogsList.size());
@@ -159,7 +159,7 @@ class ProtoLogsDataMapperTest {
   void verifyMultipleLogsWithDifferentResource() {
     List<LogRecordData> signals = Arrays.asList(LOG_RECORD, LOG_RECORD_WITH_DIFFERENT_RESOURCE);
 
-    LogsData proto = mapToProto(signals);
+    ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
     assertEquals(2, resourceLogsList.size());
@@ -183,7 +183,7 @@ class ProtoLogsDataMapperTest {
   void verifyLogWithEventName() {
     List<LogRecordData> signals = Collections.singletonList(LOG_RECORD_WITH_EVENT_NAME);
 
-    LogsData result = mapToProto(signals);
+    ExportLogsServiceRequest result = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = result.resource_logs;
     LogRecord firstLog = resourceLogsList.get(0).scope_logs.get(0).log_records.get(0);
@@ -192,11 +192,11 @@ class ProtoLogsDataMapperTest {
     assertThat(mapFromProto(result)).containsExactlyInAnyOrderElementsOf(signals);
   }
 
-  private static LogsData mapToProto(Collection<LogRecordData> signals) {
+  private static ExportLogsServiceRequest mapToProto(Collection<LogRecordData> signals) {
     return ProtoLogsDataMapper.getInstance().toProto(signals);
   }
 
-  private static List<LogRecordData> mapFromProto(LogsData protoData) {
+  private static List<LogRecordData> mapFromProto(ExportLogsServiceRequest protoData) {
     return ProtoLogsDataMapper.getInstance().fromProto(protoData);
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapperTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
 import io.opentelemetry.proto.metrics.v1.Metric;
-import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
 import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -30,7 +30,7 @@ class ProtoMetricsDataMapperTest {
     MetricData expectedGauge1 = TestData.makeLongGauge(TraceFlags.getSampled());
     List<MetricData> expectedSignals = Collections.singletonList(expectedGauge1);
 
-    MetricsData proto = mapToProto(signals);
+    ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
     assertEquals(1, resourceMetrics.size());
@@ -49,7 +49,7 @@ class ProtoMetricsDataMapperTest {
     MetricData expectedGauge2 = TestData.makeLongGauge(TraceFlags.getSampled());
     List<MetricData> expectedSignals = Arrays.asList(expectedGauge1, expectedGauge2);
 
-    MetricsData proto = mapToProto(signals);
+    ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
     assertEquals(1, resourceMetrics.size());
@@ -78,7 +78,7 @@ class ProtoMetricsDataMapperTest {
     List<MetricData> signals = Arrays.asList(gauge1, gauge2);
     List<MetricData> expectedSignals = Arrays.asList(expectedGauge1, expectedGauge2);
 
-    MetricsData proto = mapToProto(signals);
+    ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
     assertEquals(1, resourceMetrics.size());
@@ -113,7 +113,7 @@ class ProtoMetricsDataMapperTest {
     //    , LONG_GAUGE_METRIC_WITH_DIFFERENT_RESOURCE);
     //    List<MetricData> expectedSignals = Arrays.asList(expected);
 
-    MetricsData proto = mapToProto(signals);
+    ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
     assertEquals(2, resourceMetrics.size());
@@ -133,11 +133,11 @@ class ProtoMetricsDataMapperTest {
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(expectedSignals);
   }
 
-  private static MetricsData mapToProto(Collection<MetricData> signals) {
+  private static ExportMetricsServiceRequest mapToProto(Collection<MetricData> signals) {
     return ProtoMetricsDataMapper.getInstance().toProto(signals);
   }
 
-  private static List<MetricData> mapFromProto(MetricsData protoData) {
+  private static List<MetricData> mapFromProto(ExportMetricsServiceRequest protoData) {
     return ProtoMetricsDataMapper.getInstance().fromProto(protoData);
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapperTest.java
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
-import io.opentelemetry.proto.trace.v1.TracesData;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -116,7 +116,7 @@ class ProtoSpansDataMapperTest {
   void verifyConversionDataStructure() {
     List<SpanData> signals = Collections.singletonList(SPAN_DATA);
 
-    TracesData proto = mapToProto(signals);
+    ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
     assertEquals(1, resourceSpans.size());
@@ -130,7 +130,7 @@ class ProtoSpansDataMapperTest {
   void verifyMultipleSpansWithSameResourceAndScope() {
     List<SpanData> signals = Arrays.asList(SPAN_DATA, OTHER_SPAN_DATA);
 
-    TracesData proto = mapToProto(signals);
+    ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
     assertEquals(1, resourceSpans.size());
@@ -146,7 +146,7 @@ class ProtoSpansDataMapperTest {
   void verifyMultipleSpansWithSameResourceDifferentScope() {
     List<SpanData> signals = Arrays.asList(SPAN_DATA, SPAN_DATA_WITH_DIFFERENT_SCOPE_SAME_RESOURCE);
 
-    TracesData proto = mapToProto(signals);
+    ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
     assertEquals(1, resourceSpans.size());
@@ -166,7 +166,7 @@ class ProtoSpansDataMapperTest {
   void verifyMultipleSpansWithDifferentResource() {
     List<SpanData> signals = Arrays.asList(SPAN_DATA, SPAN_DATA_WITH_DIFFERENT_RESOURCE);
 
-    TracesData proto = mapToProto(signals);
+    ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
     assertEquals(2, resourceSpans.size());
@@ -186,11 +186,11 @@ class ProtoSpansDataMapperTest {
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
 
-  private static TracesData mapToProto(Collection<SpanData> signals) {
+  private static ExportTraceServiceRequest mapToProto(Collection<SpanData> signals) {
     return ProtoSpansDataMapper.getInstance().toProto(signals);
   }
 
-  private static List<SpanData> mapFromProto(TracesData protoData) {
+  private static List<SpanData> mapFromProto(ExportTraceServiceRequest protoData) {
     return ProtoSpansDataMapper.getInstance().fromProto(protoData);
   }
 }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/ByteArraySerializer.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/serializers/ByteArraySerializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+
+public final class ByteArraySerializer implements SignalSerializer<Object> {
+
+  private final byte[] data;
+
+  public ByteArraySerializer(byte[] data) {
+    this.data = data;
+  }
+
+  @CanIgnoreReturnValue
+  @Override
+  public SignalSerializer<Object> initialize(Collection<Object> data) {
+    return null;
+  }
+
+  @Override
+  public void writeBinaryTo(OutputStream output) throws IOException {
+    output.write(data);
+  }
+
+  @Override
+  public int getBinarySerializedSize() {
+    return data.length;
+  }
+
+  @Override
+  public void reset() {}
+}

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.ByteArraySerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.ReadableFile;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.WritableFile;
 import io.opentelemetry.sdk.common.Clock;
@@ -83,7 +84,7 @@ class FolderManagerTest {
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(createdFileTime));
 
     WritableFile writableFile = folderManager.createWritableFile();
-    writableFile.append(new byte[3]);
+    writableFile.append(new ByteArraySerializer(new byte[3]));
 
     when(clock.now())
         .thenReturn(MILLISECONDS.toNanos(createdFileTime + MIN_FILE_AGE_FOR_READ_MILLIS));

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.contrib.disk.buffering.config.StorageConfiguration;
+import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.ByteArraySerializer;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.ReadableFile;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.WritableFile;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.ProcessResult;
@@ -87,7 +88,7 @@ class StorageTest {
 
   @Test
   void whenWritingMultipleTimes_reuseWriter() throws IOException {
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
     WritableFile anotherWriter = createWritableFile();
     when(folderManager.createWritableFile()).thenReturn(writableFile).thenReturn(anotherWriter);
 
@@ -108,7 +109,7 @@ class StorageTest {
   @Test
   void whenAttemptingToWriteAfterClosed_returnFalse() throws IOException {
     storage.close();
-    assertFalse(storage.write(new byte[1]));
+    assertFalse(storage.write(new ByteArraySerializer(new byte[1])));
   }
 
   @Test
@@ -159,7 +160,7 @@ class StorageTest {
   @Test
   void appendDataToFile() throws IOException {
     when(folderManager.createWritableFile()).thenReturn(writableFile);
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
 
     storage.write(data);
 
@@ -168,7 +169,7 @@ class StorageTest {
 
   @Test
   void whenWritingTimeoutHappens_retryWithNewFile() throws IOException {
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
     WritableFile workingWritableFile = createWritableFile();
     when(folderManager.createWritableFile())
         .thenReturn(writableFile)
@@ -182,7 +183,7 @@ class StorageTest {
 
   @Test
   void whenThereIsNoSpaceAvailableForWriting_retryWithNewFile() throws IOException {
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
     WritableFile workingWritableFile = createWritableFile();
     when(folderManager.createWritableFile())
         .thenReturn(writableFile)
@@ -196,7 +197,7 @@ class StorageTest {
 
   @Test
   void whenWritingResourceIsClosed_retryWithNewFile() throws IOException {
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
     WritableFile workingWritableFile = createWritableFile();
     when(folderManager.createWritableFile())
         .thenReturn(writableFile)
@@ -210,7 +211,7 @@ class StorageTest {
 
   @Test
   void whenEveryAttemptToWriteFails_returnFalse() throws IOException {
-    byte[] data = new byte[1];
+    ByteArraySerializer data = new ByteArraySerializer(new byte[1]);
     when(folderManager.createWritableFile()).thenReturn(writableFile);
     when(writableFile.append(data)).thenReturn(WritableResult.FAILED);
 
@@ -223,7 +224,7 @@ class StorageTest {
   void whenClosing_closeWriterAndReaderIfNotNull() throws IOException {
     when(folderManager.createWritableFile()).thenReturn(writableFile);
     when(folderManager.getReadableFile()).thenReturn(readableFile);
-    storage.write(new byte[1]);
+    storage.write(new ByteArraySerializer(new byte[1]));
     storage.readAndProcess(processing);
 
     storage.close();

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/ReadableFileTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -105,14 +106,12 @@ class ReadableFileTest {
   }
 
   private static void addFileContents(File source) throws IOException {
-    List<byte[]> items = new ArrayList<>();
-    items.add(SERIALIZER.serialize(Collections.singleton(FIRST_LOG_RECORD)));
-    items.add(SERIALIZER.serialize(Collections.singleton(SECOND_LOG_RECORD)));
-    items.add(SERIALIZER.serialize(Collections.singleton(THIRD_LOG_RECORD)));
-
     try (FileOutputStream out = new FileOutputStream(source)) {
-      for (byte[] item : items) {
-        out.write(item);
+      for (LogRecordData item :
+          Arrays.asList(FIRST_LOG_RECORD, SECOND_LOG_RECORD, THIRD_LOG_RECORD)) {
+        SERIALIZER.initialize(Collections.singleton(item));
+        SERIALIZER.writeBinaryTo(out);
+        SERIALIZER.reset();
       }
     }
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/BaseSignalSerializerTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializer
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.DelimitedProtoStreamReader;
 import io.opentelemetry.contrib.disk.buffering.internal.storage.files.reader.StreamReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +21,17 @@ import java.util.Objects;
 @SuppressWarnings("unchecked")
 public abstract class BaseSignalSerializerTest<SIGNAL_SDK_ITEM> {
   protected byte[] serialize(SIGNAL_SDK_ITEM... items) {
-    return getSerializer().serialize(Arrays.asList(items));
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    SignalSerializer<SIGNAL_SDK_ITEM> serializer = getSerializer();
+    try {
+      serializer.initialize(Arrays.asList(items));
+      serializer.writeBinaryTo(byteArrayOutputStream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      serializer.reset();
+    }
+    return byteArrayOutputStream.toByteArray();
   }
 
   protected List<SIGNAL_SDK_ITEM> deserialize(byte[] source) {


### PR DESCRIPTION
Instead of an intermediary byte array.

The OTel Java SDK has a hand-coded and optimized serializer implementation that is well tested and used extensively. This PR switches to using that serializer.

It is also more efficient to serialize directly to the file output stream instead of an intermediary byte array, so I used the same marshaling strategy used by the SDK and passed the marshaler down to the WritableFile.

See relevant discussion here:
https://github.com/open-telemetry/opentelemetry-java-contrib/discussions/1911

