### PR TITLE
Add copilot coding agent setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,34 @@
+# Custom setup steps for GitHub Copilot coding agent to speed up Copilot's work on coding tasks
+name: "Copilot Setup Steps"
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps: # Job name required by GitHub Copilot coding agent
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+
+      - name: Build project and download dependencies
+        run: ./gradlew build -x test


### PR DESCRIPTION
We haven't enable copilot coding agent on this repo yet, but this will help people who are running it in their forks (and I'd like to eventually enable it in this repo, I've heard that the CNCF and GitHub are close to reaching some kind of licensing agreement).