### PR TITLE
Convert JUnit assertions to AssertJ assertions

### DIFF
--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/utils/FileStreamTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/utils/FileStreamTest.java
@@ -61,7 +61,7 @@ class FileStreamTest {
 
     // Truncate all available data
     stream.truncateTop(3);
-    assertThat(stream.size()).isEqualTo(0);
+    assertThat(stream).isEmpty();
     assertThat(readString(temporaryFile)).isEqualTo("");
 
     stream.close();

--- a/gcp-resources/src/test/java/io/opentelemetry/contrib/gcp/resource/GCPResourceProviderTest.java
+++ b/gcp-resources/src/test/java/io/opentelemetry/contrib/gcp/resource/GCPResourceProviderTest.java
@@ -52,7 +52,7 @@ import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_
 import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_NAME;
 import static io.opentelemetry.semconv.incubating.HostIncubatingAttributes.HOST_TYPE;
 import static io.opentelemetry.semconv.incubating.K8sIncubatingAttributes.K8S_CLUSTER_NAME;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.opentelemetry.detection.DetectedPlatform;

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/FlightRecorderDiagnosticCommandConnectionTest.java
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.contrib.jfr.connection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -33,32 +33,32 @@ class FlightRecorderDiagnosticCommandConnectionTest {
 
   @Test
   void assertCommercialFeaturesLockedThrows() throws Exception {
-    assertThrows(
-        JfrConnectionException.class,
-        () -> {
-          ObjectName objectName = mock(ObjectName.class);
-          MBeanServerConnection mBeanServerConnection = mockMbeanServer(objectName, "locked");
-          FlightRecorderDiagnosticCommandConnection.assertCommercialFeaturesUnlocked(
-              mBeanServerConnection, objectName);
-        });
+    assertThatThrownBy(
+            () -> {
+              ObjectName objectName = mock(ObjectName.class);
+              MBeanServerConnection mBeanServerConnection = mockMbeanServer(objectName, "locked");
+              FlightRecorderDiagnosticCommandConnection.assertCommercialFeaturesUnlocked(
+                  mBeanServerConnection, objectName);
+            })
+        .isInstanceOf(JfrConnectionException.class);
   }
 
   @Test
   void closeRecording() throws Exception {
-    assertThrows(UnsupportedOperationException.class, () -> createconnection().closeRecording(1));
+    assertThatThrownBy(() -> createconnection().closeRecording(1))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void testGetStream() throws Exception {
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> createconnection().getStream(1L, null, null, 0L));
+    assertThatThrownBy(() -> createconnection().getStream(1L, null, null, 0L))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void testCloneRecording() throws Exception {
-    assertThrows(
-        UnsupportedOperationException.class, () -> createconnection().cloneRecording(1, false));
+    assertThatThrownBy(() -> createconnection().cloneRecording(1, false))
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
@@ -73,7 +73,7 @@ class FlightRecorderDiagnosticCommandConnectionTest {
     long id =
         connection.startRecording(
             new RecordingOptions.Builder().build(), RecordingConfiguration.PROFILE_CONFIGURATION);
-    assertEquals(id, 99);
+    assertThat(id).isEqualTo(99);
   }
 
   @Test

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/OpenDataUtilsTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/OpenDataUtilsTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.jfr.connection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
@@ -49,6 +49,6 @@ class OpenDataUtilsTest {
             mBeanServerConnection.invoke(
                 objectInstance.getObjectName(), "getRecordingSettings", args, argTypes);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 }

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingConfigurationTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingConfigurationTest.java
@@ -5,10 +5,9 @@
 
 package io.opentelemetry.contrib.jfr.connection;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,18 +43,20 @@ class RecordingConfigurationTest {
 
   @Test
   void nullConfigThrows() {
-    assertThrows(IllegalArgumentException.class, () -> new JfcFileConfiguration(null));
+    assertThatThrownBy(() -> new JfcFileConfiguration(null))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void brokenJfcConfigFileThrowsError() {
-    assertThrows(RuntimeMBeanException.class, () -> executeRecording("brokenJfcFile.jfc"));
+    assertThatThrownBy(() -> executeRecording("brokenJfcFile.jfc"))
+        .isInstanceOf(RuntimeMBeanException.class);
   }
 
   @Test
   void jfcFileFromInputStreamCanBeRead() {
     IItemCollection recordingContent = executeRecording("sampleJfcFile.jfc");
-    assertTrue(containsEvent(recordingContent, "jdk.ThreadAllocationStatistics"));
+    assertThat(containsEvent(recordingContent, "jdk.ThreadAllocationStatistics")).isTrue();
   }
 
   @Test
@@ -68,9 +69,9 @@ class RecordingConfigurationTest {
     RecordingConfiguration recordingConfiguration = new MapConfiguration(recordingConfigAsMap);
 
     IItemCollection recordingContent = excecuteRecordingWithConfig(recordingConfiguration);
-    assertNotNull(recordingContent, "excecuteRecordingWithConfig returned null");
-    assertTrue(containsEvent(recordingContent, "jdk.ObjectAllocationInNewTLAB"));
-    assertTrue(containsEvent(recordingContent, "jdk.ObjectAllocationOutsideTLAB"));
+    assertThat(recordingContent).isNotNull();
+    assertThat(containsEvent(recordingContent, "jdk.ObjectAllocationInNewTLAB")).isTrue();
+    assertThat(containsEvent(recordingContent, "jdk.ObjectAllocationOutsideTLAB")).isTrue();
   }
 
   private static boolean containsEvent(IItemCollection recordingContent, String eventName) {
@@ -110,7 +111,7 @@ class RecordingConfigurationTest {
       }
       recording.stop();
       recording.dump(dumpFile.toString());
-      assertTrue(Files.exists(dumpFile));
+      assertThat(dumpFile).exists();
 
       try {
         return JfrLoaderToolkit.loadEvents(dumpFile.toFile());

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingOptionsTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingOptionsTest.java
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.contrib.jfr.connection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.errorprone.annotations.Keep;
 import java.util.HashMap;
@@ -33,14 +33,14 @@ class RecordingOptionsTest {
   @MethodSource
   void testGetName(String testValue, String expected) {
     RecordingOptions opts = new RecordingOptions.Builder().name(testValue).build();
-    assertEquals(expected, opts.getName());
+    assertThat(opts.getName()).isEqualTo(expected);
   }
 
   @Test
   void testGetNameDefault() {
     String expected = "";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getName());
+    assertThat(opts.getName()).isEqualTo(expected);
   }
 
   @Keep
@@ -64,14 +64,14 @@ class RecordingOptionsTest {
   @MethodSource
   void testGetMaxAge(String testValue, String expected) {
     RecordingOptions opts = new RecordingOptions.Builder().maxAge(testValue).build();
-    assertEquals(expected, opts.getMaxAge());
+    assertThat(opts.getMaxAge()).isEqualTo(expected);
   }
 
   @Test
   void testGetMaxAgeDefault() {
     String expected = "0";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getMaxAge());
+    assertThat(opts.getMaxAge()).isEqualTo(expected);
   }
 
   @Keep
@@ -91,9 +91,8 @@ class RecordingOptionsTest {
   @ParameterizedTest
   @MethodSource
   void testGetMaxAgeNegative(String badValue) {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new RecordingOptions.Builder().maxAge(badValue).build());
+    assertThatThrownBy(() -> new RecordingOptions.Builder().maxAge(badValue).build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Keep
@@ -113,14 +112,14 @@ class RecordingOptionsTest {
   @MethodSource
   void testGetMaxSize(String testValue, String expected) {
     RecordingOptions opts = new RecordingOptions.Builder().maxSize(testValue).build();
-    assertEquals(expected, opts.getMaxSize());
+    assertThat(opts.getMaxSize()).isEqualTo(expected);
   }
 
   @Test
   void testGetMaxSizeDefault() {
     String expected = "0";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getMaxSize());
+    assertThat(opts.getMaxSize()).isEqualTo(expected);
   }
 
   @Keep
@@ -135,30 +134,29 @@ class RecordingOptionsTest {
   @ParameterizedTest
   @MethodSource
   void testGetMaxSizeNegative(String badValue) {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new RecordingOptions.Builder().maxSize(badValue).build());
+    assertThatThrownBy(() -> new RecordingOptions.Builder().maxSize(badValue).build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void testGetDumpOnExit() {
     String expected = "true";
     RecordingOptions opts = new RecordingOptions.Builder().dumpOnExit(expected).build();
-    assertEquals(expected, opts.getDumpOnExit());
+    assertThat(opts.getDumpOnExit()).isEqualTo(expected);
   }
 
   @Test
   void testGetDumpOnExitDefault() {
     String expected = "false";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getDumpOnExit());
+    assertThat(opts.getDumpOnExit()).isEqualTo(expected);
   }
 
   @Test
   void testGetDumpOnExitBadValue() {
     String expected = "false";
     RecordingOptions opts = new RecordingOptions.Builder().dumpOnExit("BAD_VALUE").build();
-    assertEquals(expected, opts.getDumpOnExit());
+    assertThat(opts.getDumpOnExit()).isEqualTo(expected);
   }
 
   @Keep
@@ -175,35 +173,35 @@ class RecordingOptionsTest {
   @MethodSource
   void testGetDestination(String testValue, String expected) {
     RecordingOptions opts = new RecordingOptions.Builder().destination(testValue).build();
-    assertEquals(expected, opts.getDestination());
+    assertThat(opts.getDestination()).isEqualTo(expected);
   }
 
   @Test
   void testGetDestinationDefault() {
     String expected = "";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getDestination());
+    assertThat(opts.getDestination()).isEqualTo(expected);
   }
 
   @Test
   void testGetDisk() {
     String expected = "true";
     RecordingOptions opts = new RecordingOptions.Builder().disk(expected).build();
-    assertEquals(expected, opts.getDisk());
+    assertThat(opts.getDisk()).isEqualTo(expected);
   }
 
   @Test
   void testGetDiskDefault() {
     String expected = "false";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getDisk());
+    assertThat(opts.getDisk()).isEqualTo(expected);
   }
 
   @Test
   void testGetDiskBadValue() {
     String expected = "false";
     RecordingOptions opts = new RecordingOptions.Builder().disk("BAD_VALUE").build();
-    assertEquals(expected, opts.getDisk());
+    assertThat(opts.getDisk()).isEqualTo(expected);
   }
 
   @Keep
@@ -227,14 +225,14 @@ class RecordingOptionsTest {
   @MethodSource
   void testGetDuration(String testValue, String expected) {
     RecordingOptions opts = new RecordingOptions.Builder().duration(testValue).build();
-    assertEquals(expected, opts.getDuration());
+    assertThat(opts.getDuration()).isEqualTo(expected);
   }
 
   @Test
   void testGetDurationDefault() {
     String expected = "0";
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getDuration());
+    assertThat(opts.getDuration()).isEqualTo(expected);
   }
 
   @Keep
@@ -254,9 +252,8 @@ class RecordingOptionsTest {
   @ParameterizedTest
   @MethodSource
   void testGetDurationNegative(String badValue) {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new RecordingOptions.Builder().duration(badValue).build());
+    assertThatThrownBy(() -> new RecordingOptions.Builder().duration(badValue).build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -279,7 +276,7 @@ class RecordingOptionsTest {
             .disk("true")
             .duration("120 s")
             .build();
-    assertEquals(expected, opts.getRecordingOptions());
+    assertThat(opts.getRecordingOptions()).isEqualTo(expected);
   }
 
   @Test
@@ -289,6 +286,6 @@ class RecordingOptionsTest {
     // to insure consistent behaviour.
     expected.put("disk", "false");
     RecordingOptions opts = new RecordingOptions.Builder().build();
-    assertEquals(expected, opts.getRecordingOptions());
+    assertThat(opts.getRecordingOptions()).isEqualTo(expected);
   }
 }

--- a/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingTest.java
+++ b/jfr-connection/src/test/java/io/opentelemetry/contrib/jfr/connection/RecordingTest.java
@@ -5,12 +5,8 @@
 
 package io.opentelemetry.contrib.jfr.connection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.errorprone.annotations.Keep;
 import java.io.FileInputStream;
@@ -109,8 +105,8 @@ class RecordingTest {
   @Test
   void assertNewRecordingInitialValues() {
     try (Recording recording = flightRecorderConnection.newRecording(null, null)) {
-      assertEquals(Recording.State.NEW, recording.getState());
-      assertEquals(-1, recording.getId());
+      assertThat(recording.getState()).isEqualTo(Recording.State.NEW);
+      assertThat(recording.getId()).isEqualTo(-1);
     } catch (IOException | IllegalStateException | JfrConnectionException exception) {
       fail("assertNewRecordingInitialValues caught exception", exception);
     }
@@ -120,8 +116,8 @@ class RecordingTest {
   void assertRecordingStartIdAndState() {
     try (Recording recording = flightRecorderConnection.newRecording(null, null)) {
       long id = recording.start();
-      assertEquals(id, recording.getId());
-      assertEquals(Recording.State.RECORDING, recording.getState());
+      assertThat(recording.getId()).isEqualTo(id);
+      assertThat(recording.getState()).isEqualTo(Recording.State.RECORDING);
     } catch (IOException | IllegalStateException | JfrConnectionException e) {
       fail("assertRecordingStartIdAndState caught exception", e);
     }
@@ -131,9 +127,9 @@ class RecordingTest {
   void assertRecordingStopState() {
     try (Recording recording = flightRecorderConnection.newRecording(null, null)) {
       long id = recording.start();
-      assertEquals(id, recording.getId());
+      assertThat(recording.getId()).isEqualTo(id);
       recording.stop();
-      assertEquals(Recording.State.STOPPED, recording.getState());
+      assertThat(recording.getState()).isEqualTo(Recording.State.STOPPED);
     } catch (IOException | IllegalStateException | JfrConnectionException e) {
       fail("assertRecordingStopState caught exception", e);
     }
@@ -143,9 +139,9 @@ class RecordingTest {
   void assertRecordingCloseState() {
     try (Recording recording = flightRecorderConnection.newRecording(null, null)) {
       long id = recording.start();
-      assertEquals(id, recording.getId());
+      assertThat(recording.getId()).isEqualTo(id);
       recording.close();
-      assertEquals(Recording.State.CLOSED, recording.getState());
+      assertThat(recording.getState()).isEqualTo(Recording.State.CLOSED);
     } catch (IOException | IllegalStateException | JfrConnectionException e) {
       fail("assertRecordingCloseState caught exception", e);
     }
@@ -255,7 +251,7 @@ class RecordingTest {
     try (Recording recording = flightRecorderConnection.newRecording(null, null)) {
       reflectivelyInvokeMethods(recording, args);
     } catch (InvocationTargetException invocationTargetException) {
-      assertTrue(invocationTargetException.getCause() instanceof IllegalStateException);
+      assertThat(invocationTargetException.getCause()).isInstanceOf(IllegalStateException.class);
     } catch (Exception e) {
       fail("Bad test code", e);
     }
@@ -322,7 +318,7 @@ class RecordingTest {
                   "getRecordingOptions",
                   new Object[] {id},
                   new String[] {long.class.getName()});
-      assertFalse(flightRecorderMXBeanOptions.isEmpty());
+      assertThat(flightRecorderMXBeanOptions.isEmpty()).isFalse();
       ((Collection<CompositeData>) flightRecorderMXBeanOptions.values())
           .forEach(
               compositeData -> {
@@ -344,7 +340,7 @@ class RecordingTest {
                   // and for destination since FlightRecorderMXBean returns null as default
                   if (!("name".equals(key) && "".equals(actual))
                       && !("destination".equals(key) && "".equals(actual))) {
-                    assertEquals(expected, actual, getter);
+                    assertThat(actual).as(getter).isEqualTo(expected);
                   }
                 } catch (NoSuchMethodException
                     | IllegalArgumentException
@@ -393,7 +389,7 @@ class RecordingTest {
       recording.stop();
       Path dumpFile = Paths.get(System.getProperty("user.dir"), "testRecordingDump_dumped.jfr");
       recording.dump(dumpFile.toString());
-      assertTrue(Files.exists(dumpFile));
+      assertThat(dumpFile).exists();
     } catch (IllegalArgumentException badData) {
       fail("Issue in test data: " + badData.getMessage());
     } catch (IOException ioe) {
@@ -428,7 +424,7 @@ class RecordingTest {
         fail(e.getMessage(), e);
       }
 
-      assertTrue(Files.exists(streamedFile));
+      assertThat(streamedFile).exists();
 
     } catch (IllegalArgumentException badData) {
       fail("Issue in test data: " + badData.getMessage());
@@ -502,9 +498,9 @@ class RecordingTest {
     try (Recording recording = flightRecorderConnection.newRecording(recordingOptions, null)) {
       recording.start();
       Recording clone = recording.clone(true);
-      assertSame(recording.getState(), Recording.State.RECORDING);
-      assertSame(clone.getState(), Recording.State.STOPPED);
-      assertNotEquals(recording.getId(), clone.getId());
+      assertThat(recording.getState()).isEqualTo(Recording.State.RECORDING);
+      assertThat(clone.getState()).isEqualTo(Recording.State.STOPPED);
+      assertThat(recording.getId()).isNotEqualTo(clone.getId());
       recording.stop();
     } catch (IOException ioe) {
       // possible that this can be thrown, but should not happen in this context

--- a/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterBuilderTest.java
+++ b/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterBuilderTest.java
@@ -9,8 +9,8 @@ import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CON
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -49,7 +49,7 @@ class KafkaSpanExporterBuilderTest {
                     .build())
             .build();
 
-    assertNotNull(actual);
+    assertThat(actual).isNotNull();
     actual.close();
   }
 
@@ -74,7 +74,7 @@ class KafkaSpanExporterBuilderTest {
                     .build())
             .build();
 
-    assertNotNull(actual);
+    assertThat(actual).isNotNull();
     actual.close();
   }
 
@@ -91,33 +91,32 @@ class KafkaSpanExporterBuilderTest {
             VALUE_SERIALIZER_CLASS_CONFIG,
             valueSerializerMock.getClass().getName());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setProducer(
-                    KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
-                        .setConfig(producerConfig)
-                        .build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setProducer(
+                        KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
+                            .setConfig(producerConfig)
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void buildWithMissingProducer() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new KafkaSpanExporterBuilder().setTopicName("a-topic").build());
+    assertThatThrownBy(() -> new KafkaSpanExporterBuilder().setTopicName("a-topic").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void buildWithMissingProducerConfig() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setTopicName("a-topic")
-                .setProducer(KafkaSpanExporterBuilder.ProducerBuilder.newInstance().build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setTopicName("a-topic")
+                    .setProducer(KafkaSpanExporterBuilder.ProducerBuilder.newInstance().build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -129,16 +128,16 @@ class KafkaSpanExporterBuilderTest {
             ProducerConfig.CLIENT_ID_CONFIG,
             "some clientId");
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setTopicName("a-topic")
-                .setProducer(
-                    KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
-                        .setConfig(producerConfig)
-                        .build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setTopicName("a-topic")
+                    .setProducer(
+                        KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
+                            .setConfig(producerConfig)
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -152,17 +151,17 @@ class KafkaSpanExporterBuilderTest {
             KEY_SERIALIZER_CLASS_CONFIG,
             keySerializerMock.getClass().getName());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setTopicName("a-topic")
-                .setProducer(
-                    KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
-                        .setConfig(producerConfig)
-                        .setValueSerializer(valueSerializerMock)
-                        .build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setTopicName("a-topic")
+                    .setProducer(
+                        KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
+                            .setConfig(producerConfig)
+                            .setValueSerializer(valueSerializerMock)
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -176,17 +175,17 @@ class KafkaSpanExporterBuilderTest {
             VALUE_SERIALIZER_CLASS_CONFIG,
             valueSerializerMock.getClass().getName());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setTopicName("a-topic")
-                .setProducer(
-                    KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
-                        .setConfig(producerConfig)
-                        .setKeySerializer(keySerializerMock)
-                        .build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setTopicName("a-topic")
+                    .setProducer(
+                        KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
+                            .setConfig(producerConfig)
+                            .setKeySerializer(keySerializerMock)
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -202,17 +201,17 @@ class KafkaSpanExporterBuilderTest {
             VALUE_SERIALIZER_CLASS_CONFIG,
             valueSerializerMock.getClass().getName());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            new KafkaSpanExporterBuilder()
-                .setTopicName("a-topic")
-                .setProducer(
-                    KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
-                        .setConfig(producerConfig)
-                        .setKeySerializer(keySerializerMock)
-                        .setValueSerializer(valueSerializerMock)
-                        .build())
-                .build());
+    assertThatThrownBy(
+            () ->
+                new KafkaSpanExporterBuilder()
+                    .setTopicName("a-topic")
+                    .setProducer(
+                        KafkaSpanExporterBuilder.ProducerBuilder.newInstance()
+                            .setConfig(producerConfig)
+                            .setKeySerializer(keySerializerMock)
+                            .setValueSerializer(valueSerializerMock)
+                            .build())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/SpanDataDeserializerTest.java
+++ b/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/SpanDataDeserializerTest.java
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.contrib.kafka;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.resource.v1.Resource;
@@ -38,16 +36,16 @@ class SpanDataDeserializerTest {
 
     ExportTraceServiceRequest actual = testSubject.deserialize("test-topic", data);
 
-    assertEquals(request, actual);
+    assertThat(actual).isEqualTo(request);
   }
 
   @Test
   void deserializeNullData() {
-    assertNull(testSubject.deserialize("test-topic", null));
+    assertThat(testSubject.deserialize("test-topic", null)).isNull();
   }
 
   @Test
   void deserializeEmptyData() {
-    assertNotNull(testSubject.deserialize("test-topic", new byte[0]));
+    assertThat(testSubject.deserialize("test-topic", new byte[0])).isNotNull();
   }
 }

--- a/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/SpanDataSerializerTest.java
+++ b/kafka-exporter/src/test/java/io/opentelemetry/contrib/kafka/SpanDataSerializerTest.java
@@ -6,8 +6,7 @@
 package io.opentelemetry.contrib.kafka;
 
 import static io.opentelemetry.contrib.kafka.TestUtil.makeBasicSpan;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -28,14 +27,14 @@ class SpanDataSerializerTest {
 
     byte[] actual = testSubject.serialize("test-topic", spans);
 
-    assertNotNull(actual);
+    assertThat(actual).isNotNull();
   }
 
   @Test
   void serializeEmptyData() {
     byte[] actual = testSubject.serialize("test-topic", Collections.emptySet());
 
-    assertEquals(0, actual.length);
+    assertThat(actual).isEmpty();
   }
 
   @Test
@@ -46,16 +45,18 @@ class SpanDataSerializerTest {
 
     ExportTraceServiceRequest actual = testSubject.convertSpansToRequest(spans);
 
-    assertNotNull(actual);
-    assertEquals("span-1", actual.getResourceSpans(0).getScopeSpans(0).getSpans(0).getName());
-    assertEquals("span-2", actual.getResourceSpans(0).getScopeSpans(0).getSpans(1).getName());
+    assertThat(actual).isNotNull();
+    assertThat(actual.getResourceSpans(0).getScopeSpans(0).getSpans(0).getName())
+        .isEqualTo("span-1");
+    assertThat(actual.getResourceSpans(0).getScopeSpans(0).getSpans(1).getName())
+        .isEqualTo("span-2");
   }
 
   @Test
   void convertSpansToRequestForEmptySpans() {
     ExportTraceServiceRequest actual = testSubject.convertSpansToRequest(Collections.emptySet());
 
-    assertNotNull(actual);
-    assertEquals(ExportTraceServiceRequest.getDefaultInstance(), actual);
+    assertThat(actual).isNotNull();
+    assertThat(actual).isEqualTo(ExportTraceServiceRequest.getDefaultInstance());
   }
 }

--- a/processors/src/test/java/io/opentelemetry/contrib/filter/FilteringLogRecordProcessorTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/filter/FilteringLogRecordProcessorTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.trace.Span;
@@ -93,14 +93,14 @@ public class FilteringLogRecordProcessorTest {
       sdk.getLogsBridge().get("test").logRecordBuilder().setBody("One Log").emit();
       List<LogRecordData> finishedLogRecordItems =
           memoryLogRecordExporter.getFinishedLogRecordItems();
-      assertEquals(1, finishedLogRecordItems.size());
+      assertThat(finishedLogRecordItems.size()).isEqualTo(1);
       try (Scope scope = span.makeCurrent()) {
 
       } finally {
         span.end();
       }
       List<SpanData> finishedSpans = spansExporter.getFinishedSpanItems();
-      assertEquals(1, finishedSpans.size());
+      assertThat(finishedSpans.size()).isEqualTo(1);
     }
   }
 
@@ -109,6 +109,6 @@ public class FilteringLogRecordProcessorTest {
     logger.logRecordBuilder().setBody("One Log").emit();
     List<LogRecordData> finishedLogRecordItems =
         memoryLogRecordExporter.getFinishedLogRecordItems();
-    assertEquals(0, finishedLogRecordItems.size());
+    assertThat(finishedLogRecordItems.size()).isEqualTo(0);
   }
 }

--- a/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableLogRecordExporterTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableLogRecordExporterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -62,13 +62,13 @@ class InterceptableLogRecordExporterTest {
 
     List<LogRecordData> finishedLogRecordItems =
         memoryLogRecordExporter.getFinishedLogRecordItems();
-    assertEquals(1, finishedLogRecordItems.size());
+    assertThat(finishedLogRecordItems.size()).isEqualTo(1);
     LogRecordData logRecordData = finishedLogRecordItems.get(0);
-    assertEquals(2, logRecordData.getAttributes().size());
-    assertEquals(
-        "from interceptor",
-        logRecordData.getAttributes().get(AttributeKey.stringKey("global.attr")));
-    assertEquals("local", logRecordData.getAttributes().get(AttributeKey.stringKey("local.attr")));
+    assertThat(logRecordData.getAttributes().size()).isEqualTo(2);
+    assertThat(logRecordData.getAttributes().get(AttributeKey.stringKey("global.attr")))
+        .isEqualTo("from interceptor");
+    assertThat(logRecordData.getAttributes().get(AttributeKey.stringKey("local.attr")))
+        .isEqualTo("local");
   }
 
   @Test
@@ -87,9 +87,9 @@ class InterceptableLogRecordExporterTest {
 
     List<LogRecordData> finishedLogRecordItems =
         memoryLogRecordExporter.getFinishedLogRecordItems();
-    assertEquals(2, finishedLogRecordItems.size());
-    assertEquals(Value.of("One log"), finishedLogRecordItems.get(0).getBodyValue());
-    assertEquals(Value.of("Another log"), finishedLogRecordItems.get(1).getBodyValue());
+    assertThat(finishedLogRecordItems.size()).isEqualTo(2);
+    assertThat(finishedLogRecordItems.get(0).getBodyValue()).isEqualTo(Value.of("One log"));
+    assertThat(finishedLogRecordItems.get(1).getBodyValue()).isEqualTo(Value.of("Another log"));
   }
 
   private static class ModifiableLogRecordData implements LogRecordData {

--- a/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableMetricExporterTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableMetricExporterTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.contrib.interceptor.common.ComposableInterceptor;
@@ -55,8 +54,8 @@ class InterceptableMetricExporterTest {
     meterProvider.forceFlush();
 
     List<MetricData> finishedMetricItems = memoryMetricExporter.getFinishedMetricItems();
-    assertEquals(1, finishedMetricItems.size());
-    assertEquals("ModifiedName", finishedMetricItems.get(0).getName());
+    assertThat(finishedMetricItems.size()).isEqualTo(1);
+    assertThat(finishedMetricItems.get(0).getName()).isEqualTo("ModifiedName");
   }
 
   @Test
@@ -75,7 +74,7 @@ class InterceptableMetricExporterTest {
     meterProvider.forceFlush();
 
     List<MetricData> finishedMetricItems = memoryMetricExporter.getFinishedMetricItems();
-    assertEquals(2, finishedMetricItems.size());
+    assertThat(finishedMetricItems.size()).isEqualTo(2);
     List<String> names = new ArrayList<>();
     for (MetricData item : finishedMetricItems) {
       names.add(item.getName());

--- a/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableSpanExporterTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/interceptor/InterceptableSpanExporterTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -51,12 +51,12 @@ class InterceptableSpanExporterTest {
     tracer.spanBuilder("Test span").setAttribute("local.attr", 10).startSpan().end();
 
     List<SpanData> finishedSpanItems = memorySpanExporter.getFinishedSpanItems();
-    assertEquals(1, finishedSpanItems.size());
+    assertThat(finishedSpanItems.size()).isEqualTo(1);
     SpanData spanData = finishedSpanItems.get(0);
-    assertEquals(2, spanData.getAttributes().size());
-    assertEquals(
-        "from interceptor", spanData.getAttributes().get(AttributeKey.stringKey("global.attr")));
-    assertEquals(10, spanData.getAttributes().get(AttributeKey.longKey("local.attr")));
+    assertThat(spanData.getAttributes().size()).isEqualTo(2);
+    assertThat(spanData.getAttributes().get(AttributeKey.stringKey("global.attr")))
+        .isEqualTo("from interceptor");
+    assertThat(spanData.getAttributes().get(AttributeKey.longKey("local.attr"))).isEqualTo(10L);
   }
 
   @Test
@@ -74,9 +74,9 @@ class InterceptableSpanExporterTest {
     tracer.spanBuilder("Another span").startSpan().end();
 
     List<SpanData> finishedSpanItems = memorySpanExporter.getFinishedSpanItems();
-    assertEquals(2, finishedSpanItems.size());
-    assertEquals("One span", finishedSpanItems.get(0).getName());
-    assertEquals("Another span", finishedSpanItems.get(1).getName());
+    assertThat(finishedSpanItems.size()).isEqualTo(2);
+    assertThat(finishedSpanItems.get(0).getName()).isEqualTo("One span");
+    assertThat(finishedSpanItems.get(1).getName()).isEqualTo("Another span");
   }
 
   private static class ModifiableSpanData extends DelegatingSpanData {

--- a/resource-providers/src/test/java/io/opentelemetry/contrib/resourceproviders/JettyServiceNameDetectorTest.java
+++ b/resource-providers/src/test/java/io/opentelemetry/contrib/resourceproviders/JettyServiceNameDetectorTest.java
@@ -6,8 +6,7 @@
 package io.opentelemetry.contrib.resourceproviders;
 
 import static io.opentelemetry.contrib.resourceproviders.JettyAppServer.parseJettyBase;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,17 +18,17 @@ public class JettyServiceNameDetectorTest {
 
   @Test
   void testJettyBase(@TempDir Path tempDir) throws IOException {
-    assertNull(parseJettyBase(null));
-    assertNull(parseJettyBase(""));
-    assertNull(parseJettyBase("jetty.base="));
-    assertEquals(tempDir.toString(), parseJettyBase("jetty.base=" + tempDir).toString());
-    assertEquals(
-        tempDir.toString(), parseJettyBase("foo jetty.base=" + tempDir + " bar").toString());
+    assertThat(parseJettyBase(null)).isNull();
+    assertThat(parseJettyBase("")).isNull();
+    assertThat(parseJettyBase("jetty.base=")).isNull();
+    assertThat(parseJettyBase("jetty.base=" + tempDir).toString()).isEqualTo(tempDir.toString());
+    assertThat(parseJettyBase("foo jetty.base=" + tempDir + " bar").toString())
+        .isEqualTo(tempDir.toString());
 
     Path otherDir = tempDir.resolve("jetty test");
     Files.createDirectory(otherDir);
-    assertEquals(otherDir.toString(), parseJettyBase("jetty.base=" + otherDir).toString());
-    assertEquals(
-        otherDir.toString(), parseJettyBase("foo jetty.base=" + otherDir + " bar").toString());
+    assertThat(parseJettyBase("jetty.base=" + otherDir).toString()).isEqualTo(otherDir.toString());
+    assertThat(parseJettyBase("foo jetty.base=" + otherDir + " bar").toString())
+        .isEqualTo(otherDir.toString());
   }
 }


### PR DESCRIPTION
This seems to be the typical convention across the OTel Java repos.

I've also added it to style-guide in #2170 (https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2170/files#diff-f7147e02aa637a8af1e9e23f53b8d13389c8940ebeb9ae756bf37baff4380722R115-R118).