### PR TITLE
Fix the build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -202,5 +202,15 @@
       depNameTemplate: 'java',
       extractVersionTemplate: '^(?<version>\\d+)',
     },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'github-releases',
+      managerFilePatterns: [
+        '**/build.gradle.kts',
+      ],
+      matchStrings: [
+        '"https://github.com/(?<depName>[^/]+/[^/]+)/zipball/(?<currentValue>.+?)"',
+      ],
+    },
   ],
 }

--- a/opamp-client/build.gradle.kts
+++ b/opamp-client/build.gradle.kts
@@ -1,6 +1,4 @@
 import de.undercouch.gradle.tasks.download.DownloadExtension
-import java.net.HttpURLConnection
-import java.net.URL
 
 plugins {
   id("otel.java-conventions")
@@ -53,19 +51,7 @@ abstract class DownloadOpampProtos @Inject constructor(
 
   @TaskAction
   fun execute() {
-    // Get the latest release tag by following the redirect from GitHub's latest release URL
-    val latestReleaseUrl = "https://github.com/open-telemetry/opamp-spec/releases/latest"
-    val connection = URL(latestReleaseUrl).openConnection() as HttpURLConnection
-    connection.instanceFollowRedirects = false
-    connection.requestMethod = "HEAD"
-
-    val redirectLocation = connection.getHeaderField("Location")
-    connection.disconnect()
-
-    // Extract tag from URL like: https://github.com/open-telemetry/opamp-spec/releases/tag/v0.12.0
-    val latestTag = redirectLocation.substringAfterLast("/")
-    // Download the source code for the latest release
-    val zipUrl = "https://github.com/open-telemetry/opamp-spec/zipball/$latestTag"
+    val zipUrl = "https://github.com/open-telemetry/opamp-spec/zipball/v0.14.0"
 
     download.run {
       src(zipUrl)


### PR DESCRIPTION
It looks like recently opamp-spec releases were all marked as prereleases (since they are), but that means there's no "latest" release according to github, so let's pin and use renovate to keep it up-to-date.