### PR TITLE
Fix GCP Integration test

### DIFF
--- a/gcp-auth-extension/build.gradle.kts
+++ b/gcp-auth-extension/build.gradle.kts
@@ -103,6 +103,9 @@ tasks.register<Copy>("copyAgent") {
 }
 
 tasks.register<Test>("IntegrationTestUserCreds") {
+  testClassesDirs = sourceSets.test.get().output.classesDirs
+  classpath = sourceSets.test.get().runtimeClasspath
+
   dependsOn(tasks.shadowJar)
   dependsOn(tasks.named("copyAgent"))
 


### PR DESCRIPTION
Gradle 9 [has a new requirement](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_tasks_may_no_longer_execute_expected_tests) for test tasks:

> In previous releases, it was possible to create Test tasks without any additional configuration. By convention, Gradle used the classpath and test classes from the test source set.
> The convention has been removed, but builds will not fail if they were relying on this behavior. Builds that emitted the deprecation warning will silently stop executing tests. In the example above, otherTest will be skipped and execute no tests because it has no test classes configured.

If you run this test locally you will see it doesn't do anything at the moment:

<img width="1854" height="447" alt="Screenshot 2025-08-31 at 7 32 17 AM" src="https://github.com/user-attachments/assets/0968cc50-f236-4c7f-97b0-45f8640bd96a" />

Specifying the classes/classpath we now see results:

<img width="1882" height="371" alt="Screenshot 2025-08-31 at 7 33 24 AM" src="https://github.com/user-attachments/assets/2bf51d60-148a-4169-94fc-1f46a73ef2c4" />


