### PR TITLE
Update style guide

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -78,8 +78,7 @@ packages contain implementation details that should not be used by external cons
 
 ### `final` keyword usage
 
-Public non-internal classes should be declared `final` where possible. Internal and non-public
-classes should not be declared `final`.
+Public non-internal classes should be declared `final` where possible.
 
 Methods should only be declared `final` if they are in public non-internal non-final classes.
 
@@ -123,19 +122,6 @@ messages.
 Test classes and test methods should generally be package-protected (no explicit visibility
 modifier) rather than `public`. This follows the principle of minimal necessary visibility and is
 sufficient for JUnit to discover and execute tests.
-
-### AutoService
-
-Use the `@AutoService` annotation when implementing SPI interfaces. This automatically generates the
-necessary `META-INF/services/` files at compile time, eliminating the need to manually create and
-maintain service registration files.
-
-```java
-@AutoService(AutoConfigurationCustomizerProvider.class)
-public class MyCustomizerProvider implements AutoConfigurationCustomizerProvider {
-  // implementation
-}
-```
 
 ### Gradle
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -78,9 +78,9 @@ packages contain implementation details that should not be used by external cons
 
 ### `final` keyword usage
 
-Public non-internal classes should be declared `final` where possible.
+Public non-internal non-test classes should be declared `final` where possible.
 
-Methods should only be declared `final` if they are in public non-internal non-final classes.
+Methods should only be declared `final` if they are in public non-internal non-test non-final classes.
 
 Fields should be declared `final` where possible.
 


### PR DESCRIPTION
Based on discussions in #2182

This is why I'm removing the AutoService guidance for now: https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2182#discussion_r2312690066

Removing it for now until we can dig into it and decide between:

- AutoService with `compileOnly` dependency - potentially inflicts issue on downstream consumers
- AutoService with `implementation` dependency - are we ok with this third-party dependency everywhere?
- No AutoService, back to manually constructing META-INF/services files
- ?