### PR TITLE
Apply final to public API classes where possible - azure-resources, cloudfoundry-resources, baggage-processor

### DIFF
--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAksResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAksResourceProvider.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-public class AzureAksResourceProvider extends CloudResourceProvider {
+public final class AzureAksResourceProvider extends CloudResourceProvider {
 
   private static final Map<String, AzureVmResourceProvider.Entry> COMPUTE_MAPPING = new HashMap<>();
 

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-public class AzureAppServiceResourceProvider extends CloudResourceProvider {
+public final class AzureAppServiceResourceProvider extends CloudResourceProvider {
 
   static final AttributeKey<String> AZURE_APP_SERVICE_STAMP_RESOURCE_ATTRIBUTE =
       AttributeKey.stringKey("azure.app.service.stamp");

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProvider.java
@@ -16,7 +16,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AzureContainersResourceProvider extends CloudResourceProvider {
+public final class AzureContainersResourceProvider extends CloudResourceProvider {
 
   static final String CONTAINER_APP_NAME = "CONTAINER_APP_NAME";
 

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
@@ -19,7 +19,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AzureFunctionsResourceProvider extends CloudResourceProvider {
+public final class AzureFunctionsResourceProvider extends CloudResourceProvider {
 
   static final String FUNCTIONS_VERSION = "FUNCTIONS_EXTENSION_VERSION";
   private static final String FUNCTIONS_MEM_LIMIT = "WEBSITE_MEMORY_LIMIT_MB";

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureMetadataService.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureMetadataService.java
@@ -20,7 +20,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-public class AzureMetadataService {
+public final class AzureMetadataService {
   static final JsonFactory JSON_FACTORY = new JsonFactory();
   private static final URL METADATA_URL;
   private static final Duration TIMEOUT = Duration.ofSeconds(5);

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureResourceDetector.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureResourceDetector.java
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 
-public class AzureResourceDetector implements ComponentProvider<Resource> {
+public final class AzureResourceDetector implements ComponentProvider<Resource> {
 
   @Override
   public Class<Resource> getType() {

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureVmResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureVmResourceProvider.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
-public class AzureVmResourceProvider extends CloudResourceProvider {
+public final class AzureVmResourceProvider extends CloudResourceProvider {
 
   private static final Map<String, Entry> COMPUTE_MAPPING = new HashMap<>();
 

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
  * This log record processor copies attributes stored in {@link Baggage} into each newly created log
  * record.
  */
-public class BaggageLogRecordProcessor implements LogRecordProcessor {
+public final class BaggageLogRecordProcessor implements LogRecordProcessor {
 
   private final Predicate<String> baggageKeyPredicate;
 

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageProcessorCustomizer.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageProcessorCustomizer.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import java.util.List;
 
-public class BaggageProcessorCustomizer implements AutoConfigurationCustomizerProvider {
+public final class BaggageProcessorCustomizer implements AutoConfigurationCustomizerProvider {
   @Override
   public void customize(AutoConfigurationCustomizer autoConfigurationCustomizer) {
     autoConfigurationCustomizer

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
  * This span processor copies attributes stored in {@link Baggage} into each newly created {@link
  * io.opentelemetry.api.trace.Span}.
  */
-public class BaggageSpanProcessor implements SpanProcessor {
+public final class BaggageSpanProcessor implements SpanProcessor {
   private final Predicate<String> baggageKeyPredicate;
 
   /**

--- a/cloudfoundry-resources/src/main/java/io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResourceDetector.java
+++ b/cloudfoundry-resources/src/main/java/io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResourceDetector.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class CloudFoundryResourceDetector implements ComponentProvider<Resource> {
+public final class CloudFoundryResourceDetector implements ComponentProvider<Resource> {
 
   @Override
   public Class<Resource> getType() {

--- a/cloudfoundry-resources/src/main/java/io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResourceProvider.java
+++ b/cloudfoundry-resources/src/main/java/io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResourceProvider.java
@@ -9,7 +9,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
 
-public class CloudFoundryResourceProvider implements ResourceProvider {
+public final class CloudFoundryResourceProvider implements ResourceProvider {
 
   @Override
   public Resource createResource(ConfigProperties configProperties) {


### PR DESCRIPTION
Applying the style guide section:

> Public non-internal classes should be declared `final` where possible.