### PR TITLE
Apply final to public API classes where possible - ibm-mq-metrics

### DIFF
--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/WmqContext.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/WmqContext.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * authorization.<br>
  * It also validates the arguments passed for various scenarios.
  */
-public class WmqContext {
+public final class WmqContext {
   private static final String TRANSPORT_TYPE_CLIENT = "Client";
   private static final String TRANSPORT_TYPE_BINDINGS = "Bindings";
 

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/WmqMonitor.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/WmqMonitor.java
@@ -43,7 +43,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WmqMonitor {
+public final class WmqMonitor {
 
   private static final Logger logger = LoggerFactory.getLogger(WmqMonitor.class);
 

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/ExcludeFilters.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/ExcludeFilters.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A jackson databind class used for config. */
-public class ExcludeFilters {
+public final class ExcludeFilters {
 
   private String type = "UNKNOWN";
   private Set<String> values = new HashSet<>();

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/QueueManager.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/QueueManager.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 
 /** This is a jackson databind class used purely for config. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueueManager {
+public final class QueueManager {
 
   @Nullable private String host;
   private int port = -1;

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/ResourceFilters.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/config/ResourceFilters.java
@@ -8,7 +8,7 @@ package io.opentelemetry.ibm.mq.config;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ResourceFilters {
+public final class ResourceFilters {
 
   private Set<String> include = new HashSet<>();
   private Set<ExcludeFilters> exclude = new HashSet<>();

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/MessageBuddy.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/MessageBuddy.java
@@ -12,7 +12,7 @@ import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import java.time.Instant;
 
-public class MessageBuddy {
+public final class MessageBuddy {
 
   private MessageBuddy() {}
 

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/util/WmqUtil.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/util/WmqUtil.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WmqUtil {
+public final class WmqUtil {
 
   private static final Logger logger = LoggerFactory.getLogger(WmqUtil.class);
 


### PR DESCRIPTION
Applying the style guide section:

> Public non-internal classes should be declared `final` where possible.