### PR TITLE
Apply final to public API classes where possible - jmx-scraper, jmx-metrics

### DIFF
--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/InvalidArgumentException.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/InvalidArgumentException.java
@@ -9,7 +9,7 @@ package io.opentelemetry.contrib.jmxscraper;
  * Exception indicating something is wrong with the provided arguments or reading the configuration
  * from them
  */
-public class InvalidArgumentException extends Exception {
+public final class InvalidArgumentException extends Exception {
 
   private static final long serialVersionUID = 0L;
 

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxConnectorBuilder.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxConnectorBuilder.java
@@ -34,7 +34,7 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.RealmCallback;
 
-public class JmxConnectorBuilder {
+public final class JmxConnectorBuilder {
 
   private static final Logger logger = Logger.getLogger(JmxConnectorBuilder.class.getName());
 

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 
-public class JmxScraper {
+public final class JmxScraper {
   private static final Logger logger = Logger.getLogger(JmxScraper.class.getName());
   private static final String CONFIG_ARG = "-config";
   private static final String TEST_ARG = "-test";

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/JmxScraperConfig.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/JmxScraperConfig.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /** This class keeps application settings */
-public class JmxScraperConfig {
+public final class JmxScraperConfig {
 
   private static final Logger logger = Logger.getLogger(JmxScraperConfig.class.getName());
 

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/PropertiesCustomizer.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/PropertiesCustomizer.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /** Customizer of default SDK configuration and provider of effective scraper config */
-public class PropertiesCustomizer implements Function<ConfigProperties, Map<String, String>> {
+public final class PropertiesCustomizer implements Function<ConfigProperties, Map<String, String>> {
 
   private static final Logger logger = Logger.getLogger(PropertiesCustomizer.class.getName());
 

--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/PropertiesSupplier.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/config/PropertiesSupplier.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 import java.util.function.Supplier;
 
 /** Configuration supplier for java properties */
-public class PropertiesSupplier implements Supplier<Map<String, String>> {
+public final class PropertiesSupplier implements Supplier<Map<String, String>> {
 
   private final Properties properties;
 


### PR DESCRIPTION
Applying the style guide section:

> Public non-internal classes should be declared `final` where possible.