### PR TITLE
Apply final to public API classes where possible - disk-buffering

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-public class LogRecordFromDiskExporter implements FromDiskExporter {
+public final class LogRecordFromDiskExporter implements FromDiskExporter {
 
   private final FromDiskExporterImpl<LogRecordData> delegate;
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/LogRecordToDiskExporter.java
@@ -18,7 +18,8 @@ import java.util.Collection;
  * This class implements a {@link LogRecordExporter} that delegates to an instance of {@code
  * ToDiskExporter<LogRecordData>}.
  */
-public class LogRecordToDiskExporter implements LogRecordExporter {
+public final class LogRecordToDiskExporter implements LogRecordExporter {
+
   private final ToDiskExporter<LogRecordData> delegate;
 
   /**

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-public class MetricFromDiskExporter implements FromDiskExporter {
+public final class MetricFromDiskExporter implements FromDiskExporter {
 
   private final FromDiskExporterImpl<MetricData> delegate;
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/MetricToDiskExporter.java
@@ -21,7 +21,7 @@ import java.util.Collection;
  * This class implements a {@link MetricExporter} that delegates to an instance of {@code
  * ToDiskExporter<MetricData>}.
  */
-public class MetricToDiskExporter implements MetricExporter {
+public final class MetricToDiskExporter implements MetricExporter {
 
   private final ToDiskExporter<MetricData> delegate;
   private final AggregationTemporalitySelector aggregationTemporalitySelector;

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-public class SpanFromDiskExporter implements FromDiskExporter {
+public final class SpanFromDiskExporter implements FromDiskExporter {
 
   private final FromDiskExporterImpl<SpanData> delegate;
 

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanToDiskExporter.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/SpanToDiskExporter.java
@@ -18,7 +18,7 @@ import java.util.Collection;
  * This class implements a SpanExporter that delegates to an instance of {@code
  * ToDiskExporter<SpanData>}.
  */
-public class SpanToDiskExporter implements SpanExporter {
+public final class SpanToDiskExporter implements SpanExporter {
 
   private final ToDiskExporter<SpanData> delegate;
 


### PR DESCRIPTION
Applying the style guide section:

> Public non-internal classes should be declared `final` where possible.