### PR TITLE
Apply final to public API classes where possible - kafka-exporter, micrometer-meter-provider, noop-api, processors, resource-providers, samplers

### DIFF
--- a/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/KafkaSpanExporter.java
+++ b/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/KafkaSpanExporter.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 @ThreadSafe
 @SuppressWarnings("FutureReturnValueIgnored")
-public class KafkaSpanExporter implements SpanExporter {
+public final class KafkaSpanExporter implements SpanExporter {
   private static final Logger logger = LoggerFactory.getLogger(KafkaSpanExporter.class);
   private final String topicName;
   private final Producer<String, Collection<SpanData>> producer;

--- a/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterBuilder.java
+++ b/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/KafkaSpanExporterBuilder.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serializer;
 
-public class KafkaSpanExporterBuilder {
+public final class KafkaSpanExporterBuilder {
   private static final long DEFAULT_TIMEOUT_IN_SECONDS = 5L;
   private String topicName;
   private Producer<String, Collection<SpanData>> producer;

--- a/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/SpanDataDeserializer.java
+++ b/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/SpanDataDeserializer.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 
-public class SpanDataDeserializer implements Deserializer<ExportTraceServiceRequest> {
+public final class SpanDataDeserializer implements Deserializer<ExportTraceServiceRequest> {
   @SuppressWarnings("NullAway")
   @Override
   public ExportTraceServiceRequest deserialize(String topic, byte[] data) {

--- a/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/SpanDataSerializer.java
+++ b/kafka-exporter/src/main/java/io/opentelemetry/contrib/kafka/SpanDataSerializer.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 
-public class SpanDataSerializer implements Serializer<Collection<SpanData>> {
+public final class SpanDataSerializer implements Serializer<Collection<SpanData>> {
   @Override
   public byte[] serialize(String topic, Collection<SpanData> data) {
     if (Objects.isNull(data)) {

--- a/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/MicrometerMeterProviderBuilder.java
+++ b/micrometer-meter-provider/src/main/java/io/opentelemetry/contrib/metrics/micrometer/MicrometerMeterProviderBuilder.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /** Builder utility class for creating instances of {@link MicrometerMeterProvider}. */
-public class MicrometerMeterProviderBuilder {
+public final class MicrometerMeterProviderBuilder {
   private final Supplier<MeterRegistry> meterRegistrySupplier;
   @Nullable private CallbackRegistrar callbackRegistrar;
 

--- a/noop-api/src/main/java/io/opentelemetry/contrib/noopapi/NoopContextStorageProvider.java
+++ b/noop-api/src/main/java/io/opentelemetry/contrib/noopapi/NoopContextStorageProvider.java
@@ -15,7 +15,7 @@ import javax.annotation.Nullable;
 /**
  * A {@link ContextStorageProvider} that returns a {@link ContextStorage} which is completely no-op.
  */
-public class NoopContextStorageProvider implements ContextStorageProvider {
+public final class NoopContextStorageProvider implements ContextStorageProvider {
 
   /** Returns a no-op context storage. */
   @Override

--- a/noop-api/src/main/java/io/opentelemetry/contrib/noopapi/NoopOpenTelemetry.java
+++ b/noop-api/src/main/java/io/opentelemetry/contrib/noopapi/NoopOpenTelemetry.java
@@ -42,7 +42,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
  * <p>The above will succeed both with the {@linkplain OpenTelemetry#noop() default implementation}
  * and this one, but with this implementation there will be no overhead at all.
  */
-public class NoopOpenTelemetry implements OpenTelemetry {
+public final class NoopOpenTelemetry implements OpenTelemetry {
 
   private static final OpenTelemetry INSTANCE = new NoopOpenTelemetry();
 

--- a/processors/src/main/java/io/opentelemetry/contrib/filter/FilteringLogRecordProcessor.java
+++ b/processors/src/main/java/io/opentelemetry/contrib/filter/FilteringLogRecordProcessor.java
@@ -11,10 +11,10 @@ import io.opentelemetry.sdk.logs.ReadWriteLogRecord;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import java.util.function.Predicate;
 
-public class FilteringLogRecordProcessor implements LogRecordProcessor {
+public final class FilteringLogRecordProcessor implements LogRecordProcessor {
 
-  public final LogRecordProcessor delegate;
-  public final Predicate<LogRecordData> predicate;
+  private final LogRecordProcessor delegate;
+  private final Predicate<LogRecordData> predicate;
 
   public FilteringLogRecordProcessor(
       LogRecordProcessor delegate, Predicate<LogRecordData> predicate) {

--- a/resource-providers/src/main/java/io/opentelemetry/contrib/resourceproviders/AppServerResourceDetector.java
+++ b/resource-providers/src/main/java/io/opentelemetry/contrib/resourceproviders/AppServerResourceDetector.java
@@ -12,7 +12,7 @@ import io.opentelemetry.sdk.resources.Resource;
 
 @SuppressWarnings("rawtypes")
 @AutoService(ComponentProvider.class)
-public class AppServerResourceDetector implements ComponentProvider<Resource> {
+public final class AppServerResourceDetector implements ComponentProvider<Resource> {
 
   @Override
   public Class<Resource> getType() {

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/LinksParentAlwaysOnSamplerProvider.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/LinksParentAlwaysOnSamplerProvider.java
@@ -9,7 +9,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSamplerProvider;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 
-public class LinksParentAlwaysOnSamplerProvider implements ConfigurableSamplerProvider {
+public final class LinksParentAlwaysOnSamplerProvider implements ConfigurableSamplerProvider {
   @Override
   public Sampler createSampler(ConfigProperties config) {
     return LinksBasedSampler.create(Sampler.parentBased(Sampler.alwaysOn()));


### PR DESCRIPTION
Applying the style guide section:

> Public non-internal classes should be declared `final` where possible.