### PR TITLE
Use assertj consistently everywhere

### DIFF
--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/IntegrationTest.java
@@ -6,9 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -168,20 +166,20 @@ class IntegrationTest {
   private <T> void assertExporter(FromDiskExporterImpl<T> exporter, Supplier<Integer> finishedItems)
       throws IOException {
     // Verify no data has been received in the original exporter until this point.
-    assertEquals(0, finishedItems.get());
+    assertThat(finishedItems.get()).isEqualTo(0);
 
     // Go to the future when we can read the stored items.
     fastForwardTimeByMillis(storageConfig.getMinFileAgeForReadMillis());
 
     // Read and send stored data.
-    assertTrue(exporter.exportStoredBatch(1, TimeUnit.SECONDS));
+    assertThat(exporter.exportStoredBatch(1, TimeUnit.SECONDS)).isTrue();
 
     // Now the data must have been delegated to the original exporter.
-    assertEquals(1, finishedItems.get());
+    assertThat(finishedItems.get()).isEqualTo(1);
 
     // Bonus: Try to read again, no more data should be available.
-    assertFalse(exporter.exportStoredBatch(1, TimeUnit.SECONDS));
-    assertEquals(1, finishedItems.get());
+    assertThat(exporter.exportStoredBatch(1, TimeUnit.SECONDS)).isFalse();
+    assertThat(finishedItems.get()).isEqualTo(1);
   }
 
   @SuppressWarnings("DirectInvocationOnMock")

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/LogRecordDataDeserializerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Severity;
@@ -39,16 +39,14 @@ class LogRecordDataDeserializerTest extends BaseSignalSerializerTest<LogRecordDa
 
   @Test
   void whenDecodingMalformedMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Test
   void whenDecodingTooShortMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Override

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/MetricDataDeserializerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.serializers.SignalSerializer;
 import io.opentelemetry.contrib.disk.buffering.testutils.BaseSignalSerializerTest;
@@ -17,16 +17,14 @@ class MetricDataDeserializerTest extends BaseSignalSerializerTest<MetricData> {
 
   @Test
   void whenDecodingMalformedMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Test
   void whenDecodingTooShortMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Override

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/deserializers/SpanDataDeserializerTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.deserializers;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
@@ -44,16 +44,14 @@ class SpanDataDeserializerTest extends BaseSignalSerializerTest<SpanData> {
 
   @Test
   void whenDecodingMalformedMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeMalformedSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Test
   void whenDecodingTooShortMessage_wrapIntoDeserializationException() {
-    assertThrows(
-        DeserializationException.class,
-        () -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()));
+    assertThatThrownBy(() -> getDeserializer().deserialize(TestData.makeTooShortSignalBinary()))
+        .isInstanceOf(DeserializationException.class);
   }
 
   @Override

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapperTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -28,7 +28,7 @@ class AttributesMapperTest {
 
     List<KeyValue> proto = mapToProto(attributes);
 
-    assertEquals(attributes, mapFromProto(proto));
+    assertThat(mapFromProto(proto)).isEqualTo(attributes);
   }
 
   @Test
@@ -45,7 +45,7 @@ class AttributesMapperTest {
 
     List<KeyValue> serialized = mapToProto(attributes);
 
-    assertEquals(attributes, mapFromProto(serialized));
+    assertThat(mapFromProto(serialized)).isEqualTo(attributes);
   }
 
   private static List<KeyValue> mapToProto(Attributes attributes) {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/ResourceMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/ResourceMapperTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
 import io.opentelemetry.proto.resource.v1.Resource;
@@ -17,7 +17,8 @@ class ResourceMapperTest {
   void verifyMapping() {
     Resource proto = mapToProto(TestData.RESOURCE_FULL);
 
-    assertEquals(TestData.RESOURCE_FULL, mapToSdk(proto, TestData.RESOURCE_FULL.getSchemaUrl()));
+    assertThat(mapToSdk(proto, TestData.RESOURCE_FULL.getSchemaUrl()))
+        .isEqualTo(TestData.RESOURCE_FULL);
   }
 
   private static Resource mapToProto(io.opentelemetry.sdk.resources.Resource sdkResource) {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/LogRecordDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/LogRecordDataMapperTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Severity;
@@ -38,9 +38,8 @@ class LogRecordDataMapperTest {
   void verifyMapping() {
     LogRecord proto = mapToProto(LOG_RECORD);
 
-    assertEquals(
-        LOG_RECORD,
-        mapToSdk(proto, LOG_RECORD.getResource(), LOG_RECORD.getInstrumentationScopeInfo()));
+    assertThat(mapToSdk(proto, LOG_RECORD.getResource(), LOG_RECORD.getInstrumentationScopeInfo()))
+        .isEqualTo(LOG_RECORD);
   }
 
   private static LogRecord mapToProto(LogRecordData data) {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/logs/ProtoLogsDataMapperTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.logs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.logs.Severity;
@@ -107,9 +106,9 @@ class ProtoLogsDataMapperTest {
     ExportLogsServiceRequest result = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = result.resource_logs;
-    assertEquals(1, resourceLogsList.size());
-    assertEquals(1, resourceLogsList.get(0).scope_logs.size());
-    assertEquals(1, resourceLogsList.get(0).scope_logs.get(0).log_records.size());
+    assertThat(resourceLogsList).hasSize(1);
+    assertThat(resourceLogsList.get(0).scope_logs).hasSize(1);
+    assertThat(resourceLogsList.get(0).scope_logs.get(0).log_records).hasSize(1);
 
     assertThat(mapFromProto(result)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -121,15 +120,15 @@ class ProtoLogsDataMapperTest {
     ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
-    assertEquals(1, resourceLogsList.size());
+    assertThat(resourceLogsList).hasSize(1);
     List<ScopeLogs> scopeLogsList = resourceLogsList.get(0).scope_logs;
-    assertEquals(1, scopeLogsList.size());
+    assertThat(scopeLogsList).hasSize(1);
     List<LogRecord> logRecords = scopeLogsList.get(0).log_records;
-    assertEquals(2, logRecords.size());
-    assertEquals("Log body", logRecords.get(0).body.string_value);
-    assertEquals("Other log body", logRecords.get(1).body.string_value);
+    assertThat(logRecords).hasSize(2);
+    assertThat(logRecords.get(0).body.string_value).isEqualTo("Log body");
+    assertThat(logRecords.get(1).body.string_value).isEqualTo("Other log body");
 
-    assertEquals(2, mapFromProto(proto).size());
+    assertThat(mapFromProto(proto)).hasSize(2);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -142,15 +141,15 @@ class ProtoLogsDataMapperTest {
     ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
-    assertEquals(1, resourceLogsList.size());
+    assertThat(resourceLogsList).hasSize(1);
     List<ScopeLogs> scopeLogsList = resourceLogsList.get(0).scope_logs;
-    assertEquals(2, scopeLogsList.size());
+    assertThat(scopeLogsList).hasSize(2);
     ScopeLogs firstScope = scopeLogsList.get(0);
     ScopeLogs secondScope = scopeLogsList.get(1);
     List<LogRecord> firstScopeLogs = firstScope.log_records;
     List<LogRecord> secondScopeLogs = secondScope.log_records;
-    assertEquals(1, firstScopeLogs.size());
-    assertEquals(1, secondScopeLogs.size());
+    assertThat(firstScopeLogs).hasSize(1);
+    assertThat(secondScopeLogs).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -162,19 +161,19 @@ class ProtoLogsDataMapperTest {
     ExportLogsServiceRequest proto = mapToProto(signals);
 
     List<ResourceLogs> resourceLogsList = proto.resource_logs;
-    assertEquals(2, resourceLogsList.size());
+    assertThat(resourceLogsList).hasSize(2);
     ResourceLogs firstResourceLogs = resourceLogsList.get(0);
     ResourceLogs secondResourceLogs = resourceLogsList.get(1);
     List<ScopeLogs> firstScopeLogsList = firstResourceLogs.scope_logs;
     List<ScopeLogs> secondScopeLogsList = secondResourceLogs.scope_logs;
-    assertEquals(1, firstScopeLogsList.size());
-    assertEquals(1, secondScopeLogsList.size());
+    assertThat(firstScopeLogsList).hasSize(1);
+    assertThat(secondScopeLogsList).hasSize(1);
     ScopeLogs firstScope = firstScopeLogsList.get(0);
     ScopeLogs secondScope = secondScopeLogsList.get(0);
     List<LogRecord> firstScopeLogs = firstScope.log_records;
     List<LogRecord> secondScopeLogs = secondScope.log_records;
-    assertEquals(1, firstScopeLogs.size());
-    assertEquals(1, secondScopeLogs.size());
+    assertThat(firstScopeLogs).hasSize(1);
+    assertThat(secondScopeLogs).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -188,7 +187,7 @@ class ProtoLogsDataMapperTest {
     List<ResourceLogs> resourceLogsList = result.resource_logs;
     LogRecord firstLog = resourceLogsList.get(0).scope_logs.get(0).log_records.get(0);
 
-    assertEquals("test.event.name", firstLog.event_name);
+    assertThat(firstLog.event_name).isEqualTo("test.event.name");
     assertThat(mapFromProto(result)).containsExactlyInAnyOrderElementsOf(signals);
   }
 

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/MetricDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/MetricDataMapperTest.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.contrib.disk.buffering.testutils.TestData.makeCon
 import static io.opentelemetry.contrib.disk.buffering.testutils.TestData.makeLongGauge;
 import static io.opentelemetry.contrib.disk.buffering.testutils.TestData.makeLongPointData;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -121,9 +120,10 @@ class MetricDataMapperTest {
 
     Metric proto = mapToProto(summaryMetric);
 
-    assertEquals(
-        summaryMetric,
-        mapToSdk(proto, summaryMetric.getResource(), summaryMetric.getInstrumentationScopeInfo()));
+    assertThat(
+            mapToSdk(
+                proto, summaryMetric.getResource(), summaryMetric.getInstrumentationScopeInfo()))
+        .isEqualTo(summaryMetric);
   }
 
   @Test

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/metrics/ProtoMetricsDataMapperTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.contrib.disk.buffering.testutils.TestData;
@@ -33,9 +32,9 @@ class ProtoMetricsDataMapperTest {
     ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
-    assertEquals(1, resourceMetrics.size());
-    assertEquals(1, resourceMetrics.get(0).scope_metrics.size());
-    assertEquals(1, resourceMetrics.get(0).scope_metrics.get(0).metrics.size());
+    assertThat(resourceMetrics).hasSize(1);
+    assertThat(resourceMetrics.get(0).scope_metrics).hasSize(1);
+    assertThat(resourceMetrics.get(0).scope_metrics.get(0).metrics).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(expectedSignals);
   }
@@ -52,11 +51,11 @@ class ProtoMetricsDataMapperTest {
     ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
-    assertEquals(1, resourceMetrics.size());
+    assertThat(resourceMetrics).hasSize(1);
     List<ScopeMetrics> scopeMetrics = resourceMetrics.get(0).scope_metrics;
-    assertEquals(1, scopeMetrics.size());
+    assertThat(scopeMetrics).hasSize(1);
     List<Metric> metrics = scopeMetrics.get(0).metrics;
-    assertEquals(2, metrics.size());
+    assertThat(metrics).hasSize(2);
 
     List<MetricData> result = mapFromProto(proto);
 
@@ -81,15 +80,15 @@ class ProtoMetricsDataMapperTest {
     ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
-    assertEquals(1, resourceMetrics.size());
+    assertThat(resourceMetrics).hasSize(1);
     List<ScopeMetrics> scopeMetrics = resourceMetrics.get(0).scope_metrics;
-    assertEquals(2, scopeMetrics.size());
+    assertThat(scopeMetrics).hasSize(2);
     ScopeMetrics firstScope = scopeMetrics.get(0);
     ScopeMetrics secondScope = scopeMetrics.get(1);
     List<Metric> firstScopeMetrics = firstScope.metrics;
     List<Metric> secondScopeMetrics = secondScope.metrics;
-    assertEquals(1, firstScopeMetrics.size());
-    assertEquals(1, secondScopeMetrics.size());
+    assertThat(firstScopeMetrics).hasSize(1);
+    assertThat(secondScopeMetrics).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(expectedSignals);
   }
@@ -116,19 +115,19 @@ class ProtoMetricsDataMapperTest {
     ExportMetricsServiceRequest proto = mapToProto(signals);
 
     List<ResourceMetrics> resourceMetrics = proto.resource_metrics;
-    assertEquals(2, resourceMetrics.size());
+    assertThat(resourceMetrics).hasSize(2);
     ResourceMetrics firstResourceMetrics = resourceMetrics.get(0);
     ResourceMetrics secondResourceMetrics = resourceMetrics.get(1);
     List<ScopeMetrics> firstScopeMetrics = firstResourceMetrics.scope_metrics;
     List<ScopeMetrics> secondScopeMetrics = secondResourceMetrics.scope_metrics;
-    assertEquals(1, firstScopeMetrics.size());
-    assertEquals(1, secondScopeMetrics.size());
+    assertThat(firstScopeMetrics).hasSize(1);
+    assertThat(secondScopeMetrics).hasSize(1);
     ScopeMetrics firstScope = firstScopeMetrics.get(0);
     ScopeMetrics secondScope = secondScopeMetrics.get(0);
     List<Metric> firstMetrics = firstScope.metrics;
     List<Metric> secondMetrics = secondScope.metrics;
-    assertEquals(1, firstMetrics.size());
-    assertEquals(1, secondMetrics.size());
+    assertThat(firstMetrics).hasSize(1);
+    assertThat(secondMetrics).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(expectedSignals);
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/ProtoSpansDataMapperTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
@@ -119,9 +118,9 @@ class ProtoSpansDataMapperTest {
     ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
-    assertEquals(1, resourceSpans.size());
-    assertEquals(1, resourceSpans.get(0).scope_spans.size());
-    assertEquals(1, resourceSpans.get(0).scope_spans.get(0).spans.size());
+    assertThat(resourceSpans).hasSize(1);
+    assertThat(resourceSpans.get(0).scope_spans).hasSize(1);
+    assertThat(resourceSpans.get(0).scope_spans.get(0).spans).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -133,11 +132,11 @@ class ProtoSpansDataMapperTest {
     ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
-    assertEquals(1, resourceSpans.size());
+    assertThat(resourceSpans).hasSize(1);
     List<ScopeSpans> scopeSpans = resourceSpans.get(0).scope_spans;
-    assertEquals(1, scopeSpans.size());
+    assertThat(scopeSpans).hasSize(1);
     List<Span> spans = scopeSpans.get(0).spans;
-    assertEquals(2, spans.size());
+    assertThat(spans).hasSize(2);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -149,15 +148,15 @@ class ProtoSpansDataMapperTest {
     ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
-    assertEquals(1, resourceSpans.size());
+    assertThat(resourceSpans).hasSize(1);
     List<ScopeSpans> scopeSpans = resourceSpans.get(0).scope_spans;
-    assertEquals(2, scopeSpans.size());
+    assertThat(scopeSpans).hasSize(2);
     ScopeSpans firstScope = scopeSpans.get(0);
     ScopeSpans secondScope = scopeSpans.get(1);
     List<Span> firstScopeSpans = firstScope.spans;
     List<Span> secondScopeSpans = secondScope.spans;
-    assertEquals(1, firstScopeSpans.size());
-    assertEquals(1, secondScopeSpans.size());
+    assertThat(firstScopeSpans).hasSize(1);
+    assertThat(secondScopeSpans).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }
@@ -169,19 +168,19 @@ class ProtoSpansDataMapperTest {
     ExportTraceServiceRequest proto = mapToProto(signals);
 
     List<ResourceSpans> resourceSpans = proto.resource_spans;
-    assertEquals(2, resourceSpans.size());
+    assertThat(resourceSpans).hasSize(2);
     ResourceSpans firstResourceSpans = resourceSpans.get(0);
     ResourceSpans secondResourceSpans = resourceSpans.get(1);
     List<ScopeSpans> firstScopeSpans = firstResourceSpans.scope_spans;
     List<ScopeSpans> secondScopeSpans = secondResourceSpans.scope_spans;
-    assertEquals(1, firstScopeSpans.size());
-    assertEquals(1, secondScopeSpans.size());
+    assertThat(firstScopeSpans).hasSize(1);
+    assertThat(secondScopeSpans).hasSize(1);
     ScopeSpans firstScope = firstScopeSpans.get(0);
     ScopeSpans secondScope = secondScopeSpans.get(0);
     List<Span> firstSpans = firstScope.spans;
     List<Span> secondSpans = secondScope.spans;
-    assertEquals(1, firstSpans.size());
-    assertEquals(1, secondSpans.size());
+    assertThat(firstSpans).hasSize(1);
+    assertThat(secondSpans).hasSize(1);
 
     assertThat(mapFromProto(proto)).containsExactlyInAnyOrderElementsOf(signals);
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/SpanDataMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/spans/SpanDataMapperTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.contrib.disk.buffering.internal.serialization.mapping.spans.models.SpanDataImpl;
@@ -74,21 +74,20 @@ class SpanDataMapperTest {
   void verifyMapping() {
     Span proto = mapToProto(SPAN_DATA);
 
-    assertEquals(
-        SPAN_DATA,
-        mapToSdk(proto, SPAN_DATA.getResource(), SPAN_DATA.getInstrumentationScopeInfo()));
+    assertThat(mapToSdk(proto, SPAN_DATA.getResource(), SPAN_DATA.getInstrumentationScopeInfo()))
+        .isEqualTo(SPAN_DATA);
   }
 
   @Test
   void verifyMappingWithTraceState() {
     Span proto = mapToProto(SPAN_DATA_WITH_TRACE_STATE);
 
-    assertEquals(
-        SPAN_DATA_WITH_TRACE_STATE,
-        mapToSdk(
-            proto,
-            SPAN_DATA_WITH_TRACE_STATE.getResource(),
-            SPAN_DATA_WITH_TRACE_STATE.getInstrumentationScopeInfo()));
+    assertThat(
+            mapToSdk(
+                proto,
+                SPAN_DATA_WITH_TRACE_STATE.getResource(),
+                SPAN_DATA_WITH_TRACE_STATE.getInstrumentationScopeInfo()))
+        .isEqualTo(SPAN_DATA_WITH_TRACE_STATE);
   }
 
   private static Span mapToProto(SpanData source) {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
@@ -9,12 +9,8 @@ import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.MAX_FILE_SIZE;
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.MIN_FILE_AGE_FOR_READ_MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +48,7 @@ class FolderManagerTest {
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(1000L));
     WritableFile file = folderManager.createWritableFile();
 
-    assertEquals("1000", file.getFile().getName());
+    assertThat(file.getFile().getName()).isEqualTo("1000");
   }
 
   @Test
@@ -69,12 +65,12 @@ class FolderManagerTest {
 
     WritableFile file = folderManager.createWritableFile();
 
-    assertNotEquals(existingFile1, file.getFile());
-    assertNotEquals(existingFile2, file.getFile());
-    assertNotEquals(existingFile3, file.getFile());
-    assertTrue(existingFile2.exists());
-    assertTrue(existingFile3.exists());
-    assertFalse(existingFile1.exists());
+    assertThat(file.getFile()).isNotEqualTo(existingFile1);
+    assertThat(file.getFile()).isNotEqualTo(existingFile2);
+    assertThat(file.getFile()).isNotEqualTo(existingFile3);
+    assertThat(existingFile2.exists()).isTrue();
+    assertThat(existingFile3.exists()).isTrue();
+    assertThat(existingFile1.exists()).isFalse();
   }
 
   @Test
@@ -91,8 +87,8 @@ class FolderManagerTest {
 
     ReadableFile readableFile = folderManager.getReadableFile();
 
-    assertEquals(writableFile.getFile(), readableFile.getFile());
-    assertTrue(writableFile.isClosed());
+    assertThat(readableFile.getFile()).isEqualTo(writableFile.getFile());
+    assertThat(writableFile.isClosed()).isTrue();
   }
 
   @Test
@@ -109,14 +105,14 @@ class FolderManagerTest {
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(1000L + MIN_FILE_AGE_FOR_READ_MILLIS));
 
     ReadableFile readableFile = folderManager.getReadableFile();
-    assertEquals(existingFile1, readableFile.getFile());
+    assertThat(readableFile.getFile()).isEqualTo(existingFile1);
 
     folderManager.createWritableFile();
 
-    assertTrue(existingFile2.exists());
-    assertTrue(existingFile3.exists());
-    assertFalse(existingFile1.exists());
-    assertTrue(readableFile.isClosed());
+    assertThat(existingFile2.exists()).isTrue();
+    assertThat(existingFile3.exists()).isTrue();
+    assertThat(existingFile1.exists()).isFalse();
+    assertThat(readableFile.isClosed()).isTrue();
   }
 
   @Test
@@ -133,12 +129,12 @@ class FolderManagerTest {
 
     WritableFile file = folderManager.createWritableFile();
 
-    assertNotEquals(existingFile1, file.getFile());
-    assertNotEquals(existingFile2, file.getFile());
-    assertNotEquals(existingFile3, file.getFile());
-    assertTrue(existingFile2.exists());
-    assertTrue(existingFile1.exists());
-    assertFalse(existingFile3.exists());
+    assertThat(file.getFile()).isNotEqualTo(existingFile1);
+    assertThat(file.getFile()).isNotEqualTo(existingFile2);
+    assertThat(file.getFile()).isNotEqualTo(existingFile3);
+    assertThat(existingFile2.exists()).isTrue();
+    assertThat(existingFile1.exists()).isTrue();
+    assertThat(existingFile3.exists()).isFalse();
   }
 
   @Test
@@ -152,9 +148,9 @@ class FolderManagerTest {
 
     WritableFile file = folderManager.createWritableFile();
 
-    assertFalse(expiredReadableFile.exists());
-    assertTrue(expiredWritableFile.exists());
-    assertNotEquals(expiredWritableFile, file.getFile());
+    assertThat(expiredReadableFile.exists()).isFalse();
+    assertThat(expiredWritableFile.exists()).isTrue();
+    assertThat(file.getFile()).isNotEqualTo(expiredWritableFile);
   }
 
   @Test
@@ -167,17 +163,17 @@ class FolderManagerTest {
 
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(900 + MIN_FILE_AGE_FOR_READ_MILLIS));
     ReadableFile readableFile = folderManager.getReadableFile();
-    assertEquals(expiredReadableFileBeingRead, readableFile.getFile());
+    assertThat(readableFile.getFile()).isEqualTo(expiredReadableFileBeingRead);
 
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(11_500L));
 
     WritableFile file = folderManager.createWritableFile();
 
-    assertFalse(expiredReadableFile.exists());
-    assertFalse(expiredReadableFileBeingRead.exists());
-    assertTrue(expiredWritableFile.exists());
-    assertNotEquals(expiredWritableFile, file.getFile());
-    assertTrue(readableFile.isClosed());
+    assertThat(expiredReadableFile.exists()).isFalse();
+    assertThat(expiredReadableFileBeingRead.exists()).isFalse();
+    assertThat(expiredWritableFile.exists()).isTrue();
+    assertThat(file.getFile()).isNotEqualTo(expiredWritableFile);
+    assertThat(readableFile.isClosed()).isTrue();
   }
 
   @Test
@@ -192,7 +188,7 @@ class FolderManagerTest {
 
     ReadableFile file = folderManager.getReadableFile();
 
-    assertEquals(readableFile, file.getFile());
+    assertThat(file.getFile()).isEqualTo(readableFile);
   }
 
   @Test
@@ -209,12 +205,12 @@ class FolderManagerTest {
 
     ReadableFile file = folderManager.getReadableFile();
 
-    assertEquals(readableFileOlder, file.getFile());
+    assertThat(file.getFile()).isEqualTo(readableFileOlder);
   }
 
   @Test
   void provideNullFileForRead_whenNoFilesAreAvailable() throws IOException {
-    assertNull(folderManager.getReadableFile());
+    assertThat(folderManager.getReadableFile()).isNull();
   }
 
   @Test
@@ -223,7 +219,7 @@ class FolderManagerTest {
     File writableFile = new File(rootDir, String.valueOf(currentTime));
     createFiles(writableFile);
 
-    assertNull(folderManager.getReadableFile());
+    assertThat(folderManager.getReadableFile()).isNull();
   }
 
   @Test
@@ -234,7 +230,7 @@ class FolderManagerTest {
     createFiles(expiredReadableFile1, expiredReadableFile2);
     when(clock.now()).thenReturn(creationReferenceTime + MAX_FILE_AGE_FOR_READ_MILLIS);
 
-    assertNull(folderManager.getReadableFile());
+    assertThat(folderManager.getReadableFile()).isNull();
   }
 
   private static void fillWithBytes(File file, int size) throws IOException {

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/StorageTest.java
@@ -6,9 +6,8 @@
 package io.opentelemetry.contrib.disk.buffering.internal.storage;
 
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.responses.ReadableResult.TRY_LATER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -58,7 +57,7 @@ class StorageTest {
   void whenReadingAndProcessingSuccessfully_returnSuccess() throws IOException {
     when(folderManager.getReadableFile()).thenReturn(readableFile);
 
-    assertEquals(ReadableResult.SUCCEEDED, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.SUCCEEDED);
 
     verify(readableFile).readAndProcess(processing);
   }
@@ -68,7 +67,7 @@ class StorageTest {
     when(folderManager.getReadableFile()).thenReturn(readableFile);
     when(readableFile.readAndProcess(processing)).thenReturn(TRY_LATER);
 
-    assertEquals(TRY_LATER, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(TRY_LATER);
 
     verify(readableFile).readAndProcess(processing);
   }
@@ -78,8 +77,8 @@ class StorageTest {
     ReadableFile anotherReadable = mock();
     when(folderManager.getReadableFile()).thenReturn(readableFile).thenReturn(anotherReadable);
 
-    assertEquals(ReadableResult.SUCCEEDED, storage.readAndProcess(processing));
-    assertEquals(ReadableResult.SUCCEEDED, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.SUCCEEDED);
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.SUCCEEDED);
 
     verify(readableFile, times(2)).readAndProcess(processing);
     verify(folderManager, times(1)).getReadableFile();
@@ -103,18 +102,18 @@ class StorageTest {
   @Test
   void whenAttemptingToReadAfterClosed_returnFailed() throws IOException {
     storage.close();
-    assertEquals(ReadableResult.FAILED, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.FAILED);
   }
 
   @Test
   void whenAttemptingToWriteAfterClosed_returnFalse() throws IOException {
     storage.close();
-    assertFalse(storage.write(new ByteArraySerializer(new byte[1])));
+    assertThat(storage.write(new ByteArraySerializer(new byte[1]))).isFalse();
   }
 
   @Test
   void whenNoFileAvailableForReading_returnFailed() throws IOException {
-    assertEquals(ReadableResult.FAILED, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.FAILED);
   }
 
   @Test
@@ -152,7 +151,7 @@ class StorageTest {
     when(folderManager.getReadableFile()).thenReturn(readableFile);
     when(readableFile.readAndProcess(processing)).thenReturn(ReadableResult.FAILED);
 
-    assertEquals(ReadableResult.FAILED, storage.readAndProcess(processing));
+    assertThat(storage.readAndProcess(processing)).isEqualTo(ReadableResult.FAILED);
 
     verify(folderManager, times(3)).getReadableFile();
   }
@@ -215,7 +214,7 @@ class StorageTest {
     when(folderManager.createWritableFile()).thenReturn(writableFile);
     when(writableFile.append(data)).thenReturn(WritableResult.FAILED);
 
-    assertFalse(storage.write(data));
+    assertThat(storage.write(data)).isFalse();
 
     verify(folderManager, times(3)).createWritableFile();
   }

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/WritableFileTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/files/WritableFileTest.java
@@ -8,9 +8,7 @@ package io.opentelemetry.contrib.disk.buffering.internal.storage.files;
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.MAX_FILE_AGE_FOR_WRITE_MILLIS;
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.MAX_FILE_SIZE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,14 +56,14 @@ class WritableFileTest {
   void hasNotExpired_whenWriteAgeHasNotExpired() {
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(1500L));
 
-    assertFalse(writableFile.hasExpired());
+    assertThat(writableFile.hasExpired()).isFalse();
   }
 
   @Test
   void hasExpired_whenWriteAgeHasExpired() {
     when(clock.now()).thenReturn(MILLISECONDS.toNanos(2000L));
 
-    assertTrue(writableFile.hasExpired());
+    assertThat(writableFile.hasExpired()).isTrue();
   }
 
   @Test
@@ -78,22 +76,22 @@ class WritableFileTest {
 
     List<String> lines = getWrittenLines();
 
-    assertEquals(2, lines.size());
-    assertEquals("First line", lines.get(0));
-    assertEquals("Second line", lines.get(1));
-    assertEquals(line1.length + line2.length, writableFile.getSize());
+    assertThat(lines).hasSize(2);
+    assertThat(lines.get(0)).isEqualTo("First line");
+    assertThat(lines.get(1)).isEqualTo("Second line");
+    assertThat(writableFile.getSize()).isEqualTo(line1.length + line2.length);
   }
 
   @Test
   void whenAppendingData_andNotEnoughSpaceIsAvailable_closeAndReturnFailed() throws IOException {
-    assertEquals(
-        WritableResult.SUCCEEDED,
-        writableFile.append(new ByteArraySerializer(new byte[MAX_FILE_SIZE])));
+    assertThat(writableFile.append(new ByteArraySerializer(new byte[MAX_FILE_SIZE])))
+        .isEqualTo(WritableResult.SUCCEEDED);
 
-    assertEquals(WritableResult.FAILED, writableFile.append(new ByteArraySerializer(new byte[1])));
+    assertThat(writableFile.append(new ByteArraySerializer(new byte[1])))
+        .isEqualTo(WritableResult.FAILED);
 
-    assertEquals(1, getWrittenLines().size());
-    assertEquals(MAX_FILE_SIZE, writableFile.getSize());
+    assertThat(getWrittenLines()).hasSize(1);
+    assertThat(writableFile.getSize()).isEqualTo(MAX_FILE_SIZE);
   }
 
   @Test
@@ -102,9 +100,10 @@ class WritableFileTest {
     when(clock.now())
         .thenReturn(MILLISECONDS.toNanos(CREATED_TIME_MILLIS + MAX_FILE_AGE_FOR_WRITE_MILLIS));
 
-    assertEquals(WritableResult.FAILED, writableFile.append(new ByteArraySerializer(new byte[1])));
+    assertThat(writableFile.append(new ByteArraySerializer(new byte[1])))
+        .isEqualTo(WritableResult.FAILED);
 
-    assertEquals(1, getWrittenLines().size());
+    assertThat(getWrittenLines()).hasSize(1);
   }
 
   @Test
@@ -112,7 +111,8 @@ class WritableFileTest {
     writableFile.append(new ByteArraySerializer(new byte[1]));
     writableFile.close();
 
-    assertEquals(WritableResult.FAILED, writableFile.append(new ByteArraySerializer(new byte[2])));
+    assertThat(writableFile.append(new ByteArraySerializer(new byte[2])))
+        .isEqualTo(WritableResult.FAILED);
   }
 
   private static byte[] getByteArrayLine(String line) {


### PR DESCRIPTION
Applying the [style guide](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/docs/style-guide.md#assertj) in preparation for enabling Copilot reviews.