### PR TITLE
Use assertj consistently everywhere

### DIFF
--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentProbabilityBasedSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentProbabilityBasedSamplerTest.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.sampler.consistent;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
@@ -63,8 +62,8 @@ class ConsistentProbabilityBasedSamplerTest {
                 .getUpdatedTraceState(TraceState.getDefault())
                 .get(OtelTraceState.TRACE_STATE_KEY);
         OtelTraceState traceState = OtelTraceState.parse(traceStateString);
-        assertTrue(traceState.hasValidR());
-        assertTrue(traceState.hasValidP());
+        assertThat(traceState.hasValidR()).isTrue();
+        assertThat(traceState.hasValidP()).isTrue();
         observedPvalues.merge(traceState.getP(), 1L, Long::sum);
       }
     }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentReservoirSamplingSpanProcessorTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentReservoirSamplingSpanProcessorTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -566,8 +565,8 @@ class ConsistentReservoirSamplingSpanProcessorTest {
         String traceStateString =
             spanData.getSpanContext().getTraceState().get(OtelTraceState.TRACE_STATE_KEY);
         OtelTraceState traceState = OtelTraceState.parse(traceStateString);
-        assertTrue(traceState.hasValidR());
-        assertTrue(traceState.hasValidP());
+        assertThat(traceState.hasValidR()).isTrue();
+        assertThat(traceState.hasValidP()).isTrue();
         observedPvalues.merge(traceState.getP(), 1L, Long::sum);
         totalAdjustedCount += 1L << traceState.getP();
         spanNameCounts.merge(spanData.getName(), 1L, Long::sum);

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/OtelTraceStateTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/OtelTraceStateTest.java
@@ -5,11 +5,10 @@
 
 package io.opentelemetry.contrib.sampler.consistent;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class OtelTraceStateTest {
@@ -21,59 +20,57 @@ class OtelTraceStateTest {
   @Test
   void test() {
 
-    Assertions.assertEquals("", OtelTraceState.parse("").serialize());
-    assertEquals("", OtelTraceState.parse("").serialize());
+    assertThat(OtelTraceState.parse("").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("").serialize()).isEqualTo("");
 
-    assertEquals("", OtelTraceState.parse("a").serialize());
-    assertEquals("", OtelTraceState.parse("#").serialize());
-    assertEquals("", OtelTraceState.parse(" ").serialize());
+    assertThat(OtelTraceState.parse("a").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("#").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse(" ").serialize()).isEqualTo("");
 
-    assertEquals("p:5", OtelTraceState.parse("p:5").serialize());
-    assertEquals("p:63", OtelTraceState.parse("p:63").serialize());
-    assertEquals("", OtelTraceState.parse("p:64").serialize());
-    assertEquals("", OtelTraceState.parse("p:5;").serialize());
-    assertEquals("", OtelTraceState.parse("p:99").serialize());
-    assertEquals("", OtelTraceState.parse("p:").serialize());
-    assertEquals("", OtelTraceState.parse("p:232").serialize());
-    assertEquals("", OtelTraceState.parse("x;p:5").serialize());
-    assertEquals("", OtelTraceState.parse("p:5;x").serialize());
-    assertEquals("p:5;x:3", OtelTraceState.parse("x:3;p:5").serialize());
-    assertEquals("p:5;x:3", OtelTraceState.parse("p:5;x:3").serialize());
-    assertEquals("", OtelTraceState.parse("p:5;x:3;").serialize());
-    assertEquals(
-        "p:5;a:" + getXString(246) + ";x:3",
-        OtelTraceState.parse("a:" + getXString(246) + ";p:5;x:3").serialize());
-    assertEquals("", OtelTraceState.parse("a:" + getXString(247) + ";p:5;x:3").serialize());
+    assertThat(OtelTraceState.parse("p:5").serialize()).isEqualTo("p:5");
+    assertThat(OtelTraceState.parse("p:63").serialize()).isEqualTo("p:63");
+    assertThat(OtelTraceState.parse("p:64").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p:5;").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p:99").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p:").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p:232").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("x;p:5").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p:5;x").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("x:3;p:5").serialize()).isEqualTo("p:5;x:3");
+    assertThat(OtelTraceState.parse("p:5;x:3").serialize()).isEqualTo("p:5;x:3");
+    assertThat(OtelTraceState.parse("p:5;x:3;").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("a:" + getXString(246) + ";p:5;x:3").serialize())
+        .isEqualTo("p:5;a:" + getXString(246) + ";x:3");
+    assertThat(OtelTraceState.parse("a:" + getXString(247) + ";p:5;x:3").serialize()).isEqualTo("");
 
-    assertEquals("r:5", OtelTraceState.parse("r:5").serialize());
-    assertEquals("r:62", OtelTraceState.parse("r:62").serialize());
-    assertEquals("", OtelTraceState.parse("r:63").serialize());
-    assertEquals("", OtelTraceState.parse("r:5;").serialize());
-    assertEquals("", OtelTraceState.parse("r:99").serialize());
-    assertEquals("", OtelTraceState.parse("r:").serialize());
-    assertEquals("", OtelTraceState.parse("r:232").serialize());
-    assertEquals("", OtelTraceState.parse("x;r:5").serialize());
-    assertEquals("", OtelTraceState.parse("r:5;x").serialize());
-    assertEquals("r:5;x:3", OtelTraceState.parse("x:3;r:5").serialize());
-    assertEquals("r:5;x:3", OtelTraceState.parse("r:5;x:3").serialize());
-    assertEquals("", OtelTraceState.parse("r:5;x:3;").serialize());
-    assertEquals(
-        "r:5;a:" + getXString(246) + ";x:3",
-        OtelTraceState.parse("a:" + getXString(246) + ";r:5;x:3").serialize());
-    assertEquals("", OtelTraceState.parse("a:" + getXString(247) + ";r:5;x:3").serialize());
+    assertThat(OtelTraceState.parse("r:5").serialize()).isEqualTo("r:5");
+    assertThat(OtelTraceState.parse("r:62").serialize()).isEqualTo("r:62");
+    assertThat(OtelTraceState.parse("r:63").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("r:5;").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("r:99").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("r:").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("r:232").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("x;r:5").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("r:5;x").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("x:3;r:5").serialize()).isEqualTo("r:5;x:3");
+    assertThat(OtelTraceState.parse("r:5;x:3").serialize()).isEqualTo("r:5;x:3");
+    assertThat(OtelTraceState.parse("r:5;x:3;").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("a:" + getXString(246) + ";r:5;x:3").serialize())
+        .isEqualTo("r:5;a:" + getXString(246) + ";x:3");
+    assertThat(OtelTraceState.parse("a:" + getXString(247) + ";r:5;x:3").serialize()).isEqualTo("");
 
-    assertEquals("p:7;r:5", OtelTraceState.parse("r:5;p:7").serialize());
-    assertEquals("p:4;r:5", OtelTraceState.parse("r:5;p:4").serialize());
-    assertEquals("p:7;r:5", OtelTraceState.parse("r:5;p:7").serialize());
-    assertEquals("p:4;r:5", OtelTraceState.parse("r:5;p:4").serialize());
+    assertThat(OtelTraceState.parse("r:5;p:7").serialize()).isEqualTo("p:7;r:5");
+    assertThat(OtelTraceState.parse("r:5;p:4").serialize()).isEqualTo("p:4;r:5");
+    assertThat(OtelTraceState.parse("r:5;p:7").serialize()).isEqualTo("p:7;r:5");
+    assertThat(OtelTraceState.parse("r:5;p:4").serialize()).isEqualTo("p:4;r:5");
 
-    assertEquals("r:6", OtelTraceState.parse("r:5;r:6").serialize());
-    assertEquals("p:6;r:10", OtelTraceState.parse("p:5;p:6;r:10").serialize());
-    assertEquals("", OtelTraceState.parse("p5;p:6;r:10").serialize());
-    assertEquals("p:6;r:10;p5:3", OtelTraceState.parse("p5:3;p:6;r:10").serialize());
-    assertEquals("", OtelTraceState.parse(":p:6;r:10").serialize());
-    assertEquals("", OtelTraceState.parse(";p:6;r:10").serialize());
-    assertEquals("", OtelTraceState.parse("_;p:6;r:10").serialize());
-    assertEquals("", OtelTraceState.parse("5;p:6;r:10").serialize());
+    assertThat(OtelTraceState.parse("r:5;r:6").serialize()).isEqualTo("r:6");
+    assertThat(OtelTraceState.parse("p:5;p:6;r:10").serialize()).isEqualTo("p:6;r:10");
+    assertThat(OtelTraceState.parse("p5;p:6;r:10").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("p5:3;p:6;r:10").serialize()).isEqualTo("p:6;r:10;p5:3");
+    assertThat(OtelTraceState.parse(":p:6;r:10").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse(";p:6;r:10").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("_;p:6;r:10").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("5;p:6;r:10").serialize()).isEqualTo("");
   }
 }

--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/OtelTraceStateTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent56/OtelTraceStateTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.contrib.sampler.consistent56;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -20,56 +20,64 @@ class OtelTraceStateTest {
   @Test
   void test() {
 
-    assertEquals("", OtelTraceState.parse("").serialize());
-    assertEquals("", OtelTraceState.parse("").serialize());
+    assertThat(OtelTraceState.parse("").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("").serialize()).isEqualTo("");
 
-    assertEquals("", OtelTraceState.parse("a").serialize());
-    assertEquals("", OtelTraceState.parse("#").serialize());
-    assertEquals("", OtelTraceState.parse(" ").serialize());
+    assertThat(OtelTraceState.parse("a").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("#").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse(" ").serialize()).isEqualTo("");
 
-    assertEquals("rv:1234567890abcd", OtelTraceState.parse("rv:1234567890abcd").serialize());
-    assertEquals("rv:01020304050607", OtelTraceState.parse("rv:01020304050607").serialize());
-    assertEquals("", OtelTraceState.parse("rv:1234567890abcde").serialize());
+    assertThat(OtelTraceState.parse("rv:1234567890abcd").serialize())
+        .isEqualTo("rv:1234567890abcd");
+    assertThat(OtelTraceState.parse("rv:01020304050607").serialize())
+        .isEqualTo("rv:01020304050607");
+    assertThat(OtelTraceState.parse("rv:1234567890abcde").serialize()).isEqualTo("");
 
-    assertEquals("th:1234567890abcd", OtelTraceState.parse("th:1234567890abcd").serialize());
-    assertEquals("th:01020304050607", OtelTraceState.parse("th:01020304050607").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10000000000000").serialize());
-    assertEquals("th:12345", OtelTraceState.parse("th:1234500000000").serialize());
-    assertEquals("th:0", OtelTraceState.parse("th:0").serialize()); // TODO
-    assertEquals("", OtelTraceState.parse("th:100000000000000").serialize());
-    assertEquals("", OtelTraceState.parse("th:1234567890abcde").serialize());
+    assertThat(OtelTraceState.parse("th:1234567890abcd").serialize())
+        .isEqualTo("th:1234567890abcd");
+    assertThat(OtelTraceState.parse("th:01020304050607").serialize())
+        .isEqualTo("th:01020304050607");
+    assertThat(OtelTraceState.parse("th:10000000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1234500000000").serialize()).isEqualTo("th:12345");
+    assertThat(OtelTraceState.parse("th:0").serialize()).isEqualTo("th:0"); // TODO
+    assertThat(OtelTraceState.parse("th:100000000000000").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("th:1234567890abcde").serialize()).isEqualTo("");
 
-    assertEquals(
-        "th:1234567890abcd;rv:1234567890abcd;a:" + getXString(214) + ";x:3",
-        OtelTraceState.parse("a:" + getXString(214) + ";rv:1234567890abcd;th:1234567890abcd;x:3")
-            .serialize());
-    assertEquals(
-        "",
-        OtelTraceState.parse("a:" + getXString(215) + ";rv:1234567890abcd;th:1234567890abcd;x:3")
-            .serialize());
+    assertThat(
+            OtelTraceState.parse(
+                    "a:" + getXString(214) + ";rv:1234567890abcd;th:1234567890abcd;x:3")
+                .serialize())
+        .isEqualTo("th:1234567890abcd;rv:1234567890abcd;a:" + getXString(214) + ";x:3");
+    assertThat(
+            OtelTraceState.parse(
+                    "a:" + getXString(215) + ";rv:1234567890abcd;th:1234567890abcd;x:3")
+                .serialize())
+        .isEqualTo("");
 
-    assertEquals("", OtelTraceState.parse("th:x").serialize());
-    assertEquals("", OtelTraceState.parse("th:100000000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10000000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:1000000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:100000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:1000000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:100000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:1000000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:100000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:1000").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:100").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:10").serialize());
-    assertEquals("th:1", OtelTraceState.parse("th:1").serialize());
+    assertThat(OtelTraceState.parse("th:x").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("th:100000000000000").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("th:10000000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1000000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:100000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:10000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1000000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:100000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:10000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1000000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:100000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:10000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1000").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:100").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:10").serialize()).isEqualTo("th:1");
+    assertThat(OtelTraceState.parse("th:1").serialize()).isEqualTo("th:1");
 
-    assertEquals("th:10000000000001", OtelTraceState.parse("th:10000000000001").serialize());
-    assertEquals("th:1000000000001", OtelTraceState.parse("th:10000000000010").serialize());
-    assertEquals("", OtelTraceState.parse("rv:x").serialize());
-    assertEquals("", OtelTraceState.parse("rv:100000000000000").serialize());
-    assertEquals("rv:10000000000000", OtelTraceState.parse("rv:10000000000000").serialize());
-    assertEquals("", OtelTraceState.parse("rv:1000000000000").serialize());
+    assertThat(OtelTraceState.parse("th:10000000000001").serialize())
+        .isEqualTo("th:10000000000001");
+    assertThat(OtelTraceState.parse("th:10000000000010").serialize()).isEqualTo("th:1000000000001");
+    assertThat(OtelTraceState.parse("rv:x").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("rv:100000000000000").serialize()).isEqualTo("");
+    assertThat(OtelTraceState.parse("rv:10000000000000").serialize())
+        .isEqualTo("rv:10000000000000");
+    assertThat(OtelTraceState.parse("rv:1000000000000").serialize()).isEqualTo("");
   }
 }


### PR DESCRIPTION
Applying the [style guide](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/docs/style-guide.md#assertj) in preparation for enabling Copilot reviews.