### PR TITLE
Use assertj consistently everywhere

### DIFF
--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -11,9 +11,7 @@ import static io.opentelemetry.contrib.gcp.auth.GcpAuthAutoConfigurationCustomiz
 import static io.opentelemetry.contrib.gcp.auth.GcpAuthAutoConfigurationCustomizerProvider.SIGNAL_TYPE_METRICS;
 import static io.opentelemetry.contrib.gcp.auth.GcpAuthAutoConfigurationCustomizerProvider.SIGNAL_TYPE_TRACES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -165,12 +163,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestSpan(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
 
       Mockito.verify(mockOtlpHttpSpanExporter, Mockito.times(1)).toBuilder();
       Mockito.verify(spyOtlpHttpSpanExporterBuilder, Mockito.times(1))
           .setHeaders(traceHeaderSupplierCaptor.capture());
-      assertEquals(2, traceHeaderSupplierCaptor.getValue().get().size());
+      assertThat(traceHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
       assertThat(authHeadersQuotaProjectIsPresent(traceHeaderSupplierCaptor.getValue().get()))
           .isTrue();
 
@@ -218,12 +216,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestSpan(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
 
       Mockito.verify(mockOtlpGrpcSpanExporter, Mockito.times(1)).toBuilder();
       Mockito.verify(spyOtlpGrpcSpanExporterBuilder, Mockito.times(1))
           .setHeaders(traceHeaderSupplierCaptor.capture());
-      assertEquals(2, traceHeaderSupplierCaptor.getValue().get().size());
+      assertThat(traceHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
       assertThat(authHeadersQuotaProjectIsPresent(traceHeaderSupplierCaptor.getValue().get()))
           .isTrue();
 
@@ -274,12 +272,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestMetric(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
 
       Mockito.verify(mockOtlpHttpMetricExporter, Mockito.times(1)).toBuilder();
       Mockito.verify(spyOtlpHttpMetricExporterBuilder, Mockito.times(1))
           .setHeaders(metricHeaderSupplierCaptor.capture());
-      assertEquals(2, metricHeaderSupplierCaptor.getValue().get().size());
+      assertThat(metricHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
       assertThat(authHeadersQuotaProjectIsPresent(metricHeaderSupplierCaptor.getValue().get()))
           .isTrue();
 
@@ -335,12 +333,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestMetric(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
 
       Mockito.verify(mockOtlpGrpcMetricExporter, Mockito.times(1)).toBuilder();
       Mockito.verify(spyOtlpGrpcMetricExporterBuilder, Mockito.times(1))
           .setHeaders(metricHeaderSupplierCaptor.capture());
-      assertEquals(2, metricHeaderSupplierCaptor.getValue().get().size());
+      assertThat(metricHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
       assertThat(authHeadersQuotaProjectIsPresent(metricHeaderSupplierCaptor.getValue().get()))
           .isTrue();
 
@@ -378,9 +376,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           .when(GoogleCredentials::getApplicationDefault)
           .thenReturn(mockedGoogleCredentials);
 
-      assertThrows(
-          ConfigurationException.class,
-          () -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter));
+      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter))
+          .isInstanceOf(ConfigurationException.class);
     }
   }
 
@@ -440,7 +437,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestSpan(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
       Mockito.verify(spyOtlpGrpcSpanExporterBuilder, Mockito.times(1))
           .setHeaders(traceHeaderSupplierCaptor.capture());
 
@@ -509,14 +506,14 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       generateTestSpan(sdk);
       CompletableResultCode code = sdk.shutdown();
       CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
-      assertTrue(joinResult.isSuccess());
+      assertThat(joinResult.isSuccess()).isTrue();
 
       // Check Traces modification conditions
       if (testCase.getExpectedIsTraceSignalModified()) {
         // If traces signal is expected to be modified, auth headers must be present
         Mockito.verify(spyOtlpGrpcSpanExporterBuilder, Mockito.times(1))
             .setHeaders(traceHeaderSupplierCaptor.capture());
-        assertEquals(2, traceHeaderSupplierCaptor.getValue().get().size());
+        assertThat(traceHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
         assertThat(authHeadersQuotaProjectIsPresent(traceHeaderSupplierCaptor.getValue().get()))
             .isTrue();
       } else {
@@ -530,7 +527,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         // If metrics signal is expected to be modified, auth headers must be present
         Mockito.verify(spyOtlpGrpcMetricExporterBuilder, Mockito.times(1))
             .setHeaders(metricHeaderSupplierCaptor.capture());
-        assertEquals(2, metricHeaderSupplierCaptor.getValue().get().size());
+        assertThat(metricHeaderSupplierCaptor.getValue().get().size()).isEqualTo(2);
         assertThat(authHeadersQuotaProjectIsPresent(metricHeaderSupplierCaptor.getValue().get()))
             .isTrue();
       } else {

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthExtensionEndToEndTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthExtensionEndToEndTest.java
@@ -7,9 +7,8 @@ package io.opentelemetry.contrib.gcp.auth;
 
 import static io.opentelemetry.contrib.gcp.auth.GcpAuthAutoConfigurationCustomizerProvider.GCP_USER_PROJECT_ID_KEY;
 import static io.opentelemetry.contrib.gcp.auth.GcpAuthAutoConfigurationCustomizerProvider.QUOTA_USER_PROJECT_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.stop.Stop.stopQuietly;
@@ -160,24 +159,22 @@ class GcpAuthExtensionEndToEndTest {
   private static void verifyResourceAttributes(List<ResourceSpans> extractedResourceSpans) {
     extractedResourceSpans.forEach(
         resourceSpan ->
-            assertTrue(
-                resourceSpan
-                    .getResource()
-                    .getAttributesList()
-                    .contains(
-                        KeyValue.newBuilder()
-                            .setKey(GCP_USER_PROJECT_ID_KEY)
-                            .setValue(AnyValue.newBuilder().setStringValue(DUMMY_GCP_PROJECT))
-                            .build())));
+            assertThat(resourceSpan.getResource().getAttributesList())
+                .contains(
+                    KeyValue.newBuilder()
+                        .setKey(GCP_USER_PROJECT_ID_KEY)
+                        .setValue(AnyValue.newBuilder().setStringValue(DUMMY_GCP_PROJECT))
+                        .build()));
   }
 
   private static void verifyRequestHeaders(List<Headers> extractedHeaders) {
-    assertFalse(extractedHeaders.isEmpty());
+    assertThat(extractedHeaders).isNotEmpty();
     // verify if extension added the required headers
     extractedHeaders.forEach(
         headers -> {
-          assertTrue(headers.containsEntry(QUOTA_USER_PROJECT_HEADER, DUMMY_GCP_QUOTA_PROJECT));
-          assertTrue(headers.containsEntry("Authorization", "Bearer fake.access_token"));
+          assertThat(headers.containsEntry(QUOTA_USER_PROJECT_HEADER, DUMMY_GCP_QUOTA_PROJECT))
+              .isTrue();
+          assertThat(headers.containsEntry("Authorization", "Bearer fake.access_token")).isTrue();
         });
   }
 

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.opamp.client.internal.request.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/WebSocketRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/WebSocketRequestServiceTest.java
@@ -6,7 +6,7 @@
 package io.opentelemetry.opamp.client.internal.request.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.inOrder;


### PR DESCRIPTION
Applying the [style guide](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/docs/style-guide.md#assertj) in preparation for enabling Copilot reviews.