### PR TITLE
Clearer link checking

### DIFF
--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -44,17 +44,15 @@ jobs:
                             | grep -E '^(\.github/config/lychee\.toml|mise\.toml)$' || true)
           if [ -n "$config_modified" ]; then
             echo "modified=true" >> $GITHUB_OUTPUT
-          else
-            echo "modified=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Link check - all links (modified files only)
-        if: github.event_name == 'pull_request' && steps.modified-files.outputs.files != ''
+      - name: Link check (modified files only)
+        if: github.event_name == 'pull_request' && steps.modified-files.outputs.files != '' && steps.config-check.outputs.modified != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: mise run lint-links ${{ steps.modified-files.outputs.files }}
 
-      - name: Link check - all links (all files)
+      - name: Link check (all files)
         if: github.event_name != 'pull_request' || steps.config-check.outputs.modified == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I got confused looking at https://github.com/open-telemetry/opentelemetry-java-contrib/actions/runs/17774366899/job/50518247172?pr=2266

thinking that it should run link check against all files since the PR updated the link check config

but I only saw it checking links against modified files

(it was a user error, because it failed there and didn't get to the next step, but this will hopefully avoid confusion in the future)