### PR TITLE
Empty attribute values in disk buffering

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapper.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapper.java
@@ -84,8 +84,13 @@ public final class AttributesMapper {
       builder.put(AttributeKey.doubleKey(key), value.double_value);
     } else if (value.array_value != null) {
       addArray(builder, key, value.array_value);
-    } else {
-      throw new UnsupportedOperationException();
+    }
+    else {
+      // Until we have complex attribute types that could potentially yield
+      // empty objects, we MUST assume here that the writer put an empty string
+      // into the value of the attribute. This will need to change later, when complex
+      // types arrive and the spec issue is resolved.
+      builder.put(AttributeKey.stringKey(key), "");
     }
   }
 

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapperTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/serialization/mapping/common/AttributesMapperTest.java
@@ -21,6 +21,7 @@ class AttributesMapperTest {
     Attributes attributes =
         Attributes.builder()
             .put(AttributeKey.stringKey("someString"), "someValue")
+            .put(AttributeKey.stringKey("emptyString"), "")
             .put(AttributeKey.booleanKey("someBool"), true)
             .put(AttributeKey.longKey("someLong"), 10L)
             .put(AttributeKey.doubleKey("someDouble"), 10.0)

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/TestData.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/testutils/TestData.java
@@ -37,6 +37,8 @@ public final class TestData {
           .put("conditions", false, true)
           .put("scores", 0L, 1L)
           .put("coins", 0.01, 0.05, 0.1)
+          .put("empty", "")
+          .put("blank", " ")
           .build();
 
   public static final Resource RESOURCE_FULL =


### PR DESCRIPTION
Fixes #2257.

I don't love this, but it's a way for us to work around this empty string Attribute issue until we can get some clarification around the spec. See https://github.com/open-telemetry/opentelemetry-specification/issues/4660.