### PR TITLE
opamp exponential backoff retries on http connection failures

### DIFF
--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -161,12 +161,14 @@ public final class HttpRequestService implements RequestService {
       }
     } catch (IOException | InterruptedException | TimeoutException e) {
       getCallback().onConnectionFailed(e);
+      connectionStatus.retryAfter(null);
     } catch (ExecutionException e) {
       if (e.getCause() != null) {
         getCallback().onConnectionFailed(e.getCause());
       } else {
         getCallback().onConnectionFailed(e);
       }
+      connectionStatus.retryAfter(null);
     }
   }
 


### PR DESCRIPTION
**Description:**

The other failures (including websocket connection failure and all request failures) do exponential backoff, but http connection failure doesn't, this remedies that

**Existing Issue(s):**

n/a

**Testing:**

manual testing

**Documentation:**

not needed

**Outstanding items:**

none