### PR TITLE
[opamp-client] Refactor opamp client callbacks api

### DIFF
--- a/opamp-client/README.md
+++ b/opamp-client/README.md
@@ -11,7 +11,6 @@ client [spec](https://github.com/open-telemetry/opamp-spec/blob/main/specificati
 
 ```java
 // Initializing it
-
 RequestService requestService = HttpRequestService.create(OkHttpSender.create("[OPAMP_SERVICE_URL]"));
 // RequestService requestService = WebSocketRequestService.create(OkHttpWebSocket.create("[OPAMP_SERVICE_URL]")); // Use this instead to connect to the server via WebSocket.
 OpampClient client =
@@ -19,8 +18,7 @@ OpampClient client =
         .putIdentifyingAttribute("service.name", "My service name")
         .enableRemoteConfig()
         .setRequestService(requestService)
-        .build(
-            new OpampClient.Callbacks() {
+        .build(cx -> new OpampClient.Callbacks() {
               @Override
               public void onConnect() {}
 
@@ -37,7 +35,7 @@ OpampClient client =
                   // A remote config was received
 
                   // After applying it...
-                  client.setRemoteConfigStatus(
+                  cx.setRemoteConfigStatus(
                       new RemoteConfigStatus.Builder()
                           .status(RemoteConfigStatuses.RemoteConfigStatuses_APPLIED)
                           .build());

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/OpampClient.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/OpampClient.java
@@ -35,6 +35,21 @@ public interface OpampClient extends Closeable {
    */
   void setRemoteConfigStatus(RemoteConfigStatus remoteConfigStatus);
 
+  Callbacks NOOP_CALLBACKS =
+      new Callbacks() {
+        @Override
+        public void onConnect() {}
+
+        @Override
+        public void onConnectFailed(@org.jetbrains.annotations.Nullable Throwable throwable) {}
+
+        @Override
+        public void onErrorResponse(ServerErrorResponse errorResponse) {}
+
+        @Override
+        public void onMessage(MessageData messageData) {}
+      };
+
   interface Callbacks {
     /**
      * Called when the connection is successfully established to the Server. For WebSocket clients

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/OpampClientBuilder.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/OpampClientBuilder.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import opamp.proto.AgentCapabilities;
 import opamp.proto.AgentDescription;
@@ -376,7 +377,7 @@ public final class OpampClientBuilder {
     return this;
   }
 
-  public OpampClient build(OpampClient.Callbacks callbacks) {
+  public OpampClient build(Function<OpampClient, OpampClient.Callbacks> callbacks) {
     List<KeyValue> protoIdentifyingAttributes = new ArrayList<>();
     List<KeyValue> protoNonIdentifyingAttributes = new ArrayList<>();
     identifyingAttributes.forEach(

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/impl/OpampClientImplTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/impl/OpampClientImplTest.java
@@ -395,7 +395,7 @@ class OpampClientImplTest {
     enqueueServerToAgentResponse(initialResponse);
 
     callbacks = spy(new TestCallbacks());
-    client = OpampClientImpl.create(requestService, state, callbacks);
+    client = OpampClientImpl.create(requestService, state, x -> callbacks);
 
     return takeRequest();
   }


### PR DESCRIPTION
Resolves #2250.

This is one approach that I thought was a reasonable compromise. The client implementation has a mutable/volatile `Callbacks` instance which is set in the `create()` factory method. Rather than passing a `Callbacks` instantly, the user passes a `Function` that accepts the client instance a returns a `Callbacks` instance.

In practice, I suspect that most users won't be creating anonymous `Callback` instances like in the `README.md` example, and that instead they will pass the client to the constructor of their concrete implementations. 