### PR TITLE
Use the same develocity rule as instrumentation repo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -155,9 +155,8 @@
     {
       groupName: 'develocity packages',
       matchPackageNames: [
-        'com.gradle.develocity',
-        'com.gradle:develocity-gradle-plugin',
-      ],
+        'com.gradle.develocity{/,}**',
+      ]
     },
     {
       groupName: 'bouncycastle packages',


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2283 and https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2285 should have been grouped