### PR TITLE
Update Renovate config to ignore JUnit 6 which requires Java 17+

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,16 @@
       enabled: false,
     },
     {
+      // junit 6+ requires Java 17+
+      matchPackageNames: [
+        'org.junit:**',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
+    },
+    {
       // junit-pioneer 2+ requires Java 11+
       matchPackageNames: [
         'org.junit-pioneer:junit-pioneer',


### PR DESCRIPTION
Port of https://github.com/open-telemetry/semantic-conventions-java/pull/310