### PR TITLE
Fix gradle deprecation warning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,13 @@ pluginManagement {
     id("com.gradleup.shadow") version "9.2.2"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("com.gradle.develocity") version "4.2.2"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   }
 }
 
 plugins {
   id("com.gradle.develocity")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Fixes

> Using toolchain 'Eclipse Temurin JDK 17 (17.0.16+8)' installed via auto-provisioning without toolchain repositories. This behavior has been deprecated. This will fail with an error in Gradle 10. Builds may fail when this toolchain is not available in other environments. Add toolchain repositories to this build. For more information, please refer to https://docs.gradle.org/9.1.0/userguide/toolchains.html#sub:download_repositories in the Gradle documentation.