### PR TITLE
chore: Added more project links to the pom.xml

### DIFF
--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -3,6 +3,8 @@ plugins {
   signing
 }
 
+val tagVersion: String by rootProject.extra
+
 publishing {
   publications {
     register<MavenPublication>("maven") {
@@ -55,7 +57,18 @@ publishing {
         scm {
           connection.set("scm:git:git@github.com:open-telemetry/opentelemetry-java-contrib.git")
           developerConnection.set("scm:git:git@github.com:open-telemetry/opentelemetry-java-contrib.git")
-          url.set("git@github.com:open-telemetry/opentelemetry-java-contrib.git")
+          tag.set(tagVersion)
+          url.set("https://github.com/open-telemetry/opentelemetry-java-contrib/tree/${tagVersion}")
+        }
+
+        issueManagement {
+          system.set("GitHub Issues")
+          url.set("https://github.com/open-telemetry/opentelemetry-java-contrib/issues")
+        }
+
+        ciManagement {
+          system.set("GitHub Actions")
+          url.set("https://github.com/open-telemetry/opentelemetry-java-contrib/actions")
         }
 
         withXml {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,6 @@
 val stableVersion = "1.52.0-SNAPSHOT"
 val alphaVersion = "1.52.0-alpha-SNAPSHOT"
+val tagVersion by extra { "v$stableVersion" }
 
 allprojects {
   if (findProperty("otel.stable") != "true") {


### PR DESCRIPTION
**Description:**

According to https://maven.apache.org/pom.html#SCM the `scm.url` should be a publicly browsable repository.
Replaced git URI with URL to project page on Github.

Added `issueManagement` and `ciManagement` information to the scm section.

Took inspiration from https://central.sonatype.com/artifact/org.apache.maven/maven/4.0.0-rc-4 and their [pom.xml](https://repo1.maven.org/maven2/org/apache/maven/maven/4.0.0-rc-4/maven-4.0.0-rc-4.pom).

<img width="482" height="222" alt="image" src="https://github.com/user-attachments/assets/3e9ba169-ffbc-4159-a798-a643d67f9742" />

The link on https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-cel-sampler/1.51.0-alpha ends up in a 404.

<img width="1622" height="633" alt="image" src="https://github.com/user-attachments/assets/ba32431f-fba8-40bd-a321-8dec1d2603b7" />

### Before the change

<img width="949" height="113" alt="image" src="https://github.com/user-attachments/assets/a6fe85b4-d923-4410-bf45-ae7a355abfab" />

### After the change

The new pom.xml would look like this. Generated with `./gradlew clean publishToMavenLocal`.
The `scm.url` points to the release version of the source code.

<img width="967" height="310" alt="image" src="https://github.com/user-attachments/assets/e81539ed-72ca-4a9a-a107-476cc4690dd0" />

