### PR TITLE
Auto-assign Copilot as a reviewer

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -20,6 +20,7 @@ private admin repo.
 
 ### Repository secrets
 
+- `COPILOT_ASSIGNING_PAT` - owned by [@trask](https://github.com/trask)
 - `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
 - `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
 - `NVD_API_KEY` - stored in OpenTelemetry-Java 1Password


### PR DESCRIPTION
We are hoping to have this option via CNCF / GitHub Copilot licensing agreement, but until then I'd like to try it out here since we've put in the work to create the [copilot-instructions.md](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/.github/copilot-instructions.md) already.