### PR TITLE
Narrow renovate dependency caps to specific modules where it makes sense

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,9 @@
     },
     {
       // disruptor 4+ requires Java 11+
+      matchFileNames: [
+        'inferred-spans/build.gradle.kts',
+      ],
       matchPackageNames: [
         'com.lmax:disruptor',
       ],
@@ -83,6 +86,9 @@
     },
     {
       // caffeine 3+ requires Java 11+
+      matchFileNames: [
+        'aws-xray/build.gradle.kts',
+      ],
       matchPackageNames: [
         'com.github.ben-manes.caffeine:caffeine',
       ],
@@ -113,6 +119,9 @@
     },
     {
       // agrona 1.23+ requires Java 17+
+      matchFileNames: [
+        'inferred-spans/build.gradle.kts',
+      ],
       matchPackageNames: [
         'org.agrona:agrona',
       ],
@@ -135,6 +144,9 @@
     },
     {
       // pinned version for compatibility
+      matchFileNames: [
+        'micrometer-meter-provider/build.gradle.kts',
+      ],
       matchPackageNames: [
         'io.micrometer:micrometer-core',
       ],
@@ -143,6 +155,9 @@
     },
     {
       // pinned version for compatibility
+      matchFileNames: [
+        'maven-extension/build.gradle.kts',
+      ],
       matchCurrentVersion: '3.5.0',
       enabled: false,
       matchPackageNames: [
@@ -189,6 +204,9 @@
     },
     {
       // pinned version for compatibility with java 8 JFR parsing
+      matchFileNames: [
+        'jfr-connection/build.gradle.kts',
+      ],
       matchUpdateTypes: [
         'major',
       ],

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -53,11 +53,9 @@ dependencies {
     api("org.skyscreamer:jsonassert:1.5.3")
     api("org.apache.kafka:kafka-clients:4.1.1")
     api("org.testcontainers:testcontainers-kafka:2.0.2")
-    api("com.lmax:disruptor:3.4.4")
     api("org.jctools:jctools-core:4.0.5")
     api("tools.profiler:async-profiler:4.2")
     api("com.blogspot.mydailyjava:weak-lock-free:0.18")
-    api("org.agrona:agrona:1.22.0")
     api("com.github.f4b6a3:uuid-creator:6.1.1")
   }
 }

--- a/inferred-spans/build.gradle.kts
+++ b/inferred-spans/build.gradle.kts
@@ -16,11 +16,11 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
   compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
-  implementation("com.lmax:disruptor")
+  implementation("com.lmax:disruptor:3.4.4")
   implementation("org.jctools:jctools-core")
   implementation("tools.profiler:async-profiler")
   implementation("com.blogspot.mydailyjava:weak-lock-free")
-  implementation("org.agrona:agrona")
+  implementation("org.agrona:agrona:1.22.0")
 
   testAnnotationProcessor("com.google.auto.service:auto-service")
   testCompileOnly("com.google.auto.service:auto-service-annotations")


### PR DESCRIPTION
So other modules don't accidentally inherit these limitations in the future, and for a bit of self-documentation.