### PR TITLE
Remove versions from maven test resources

### DIFF
--- a/maven-extension/src/test/resources/projects/jib_1/pom.xml
+++ b/maven-extension/src/test/resources/projects/jib_1/pom.xml
@@ -15,7 +15,6 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.4.6</version>
         <configuration>
           <to>
             <image>docker.io/john/${project.artifactId}:latest</image>

--- a/maven-extension/src/test/resources/projects/jib_2/pom.xml
+++ b/maven-extension/src/test/resources/projects/jib_2/pom.xml
@@ -15,7 +15,6 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.4.6</version>
         <configuration>
           <to>
             <image>gcr.io/my-gcp-project/my-app</image>

--- a/maven-extension/src/test/resources/projects/snyk_1/pom.xml
+++ b/maven-extension/src/test/resources/projects/snyk_1/pom.xml
@@ -15,7 +15,6 @@
       <plugin>
         <groupId>io.snyk</groupId>
         <artifactId>snyk-maven-plugin</artifactId>
-        <version>2.3.0</version>
         <configuration>
           <apiToken>${snyk.token}</apiToken>
           <args>

--- a/maven-extension/src/test/resources/projects/springboot_1/pom.xml
+++ b/maven-extension/src/test/resources/projects/springboot_1/pom.xml
@@ -6,7 +6,6 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>io.opentelemetry.contrib.maven.test</groupId>

--- a/maven-extension/src/test/resources/projects/springboot_2/pom.xml
+++ b/maven-extension/src/test/resources/projects/springboot_2/pom.xml
@@ -6,7 +6,6 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>io.opentelemetry.contrib.maven.test</groupId>


### PR DESCRIPTION
Although this might not work in real projects it seems to work for the tests. Without the versions renovate won't have anything to keep up to date in the test resources.