### PR TITLE
Remove scorecard experiment

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -24,18 +24,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        id: create-token
-        with:
-          # analyzing classic branch protections requires a token with admin read permissions
-          # see https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
-          # and https://github.com/open-telemetry/community/issues/2769
-          app-id: ${{ vars.OSSF_SCORECARD_APP_ID }}
-          private-key: ${{ secrets.OSSF_SCORECARD_PRIVATE_KEY }}
-
       - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
-          repo_token:  ${{ steps.create-token.outputs.token }}
           results_file: results.sarif
           results_format: sarif
           publish_results: true


### PR DESCRIPTION
This didn't end up being useful. And now we're moving to GitHub rulesets which scorecard can view without special permissions.