### PR TITLE
migrate jmx-scraper to the new JmxTelemetry API

### DIFF
--- a/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
+++ b/jmx-scraper/src/main/java/io/opentelemetry/contrib/jmxscraper/JmxScraper.java
@@ -252,9 +252,12 @@ public final class JmxScraper {
             system -> {
               try (InputStream input = config.getTargetSystemYaml(system)) {
                 Path tempFile = Files.createTempFile("jmx-scraper-" + system, ".yaml");
-                Files.copy(input, tempFile, StandardCopyOption.REPLACE_EXISTING);
-                builder.addCustomRules(tempFile);
-                Files.delete(tempFile);
+                try {
+                  Files.copy(input, tempFile, StandardCopyOption.REPLACE_EXISTING);
+                  builder.addCustomRules(tempFile);
+                } finally {
+                  Files.delete(tempFile);
+                }
               } catch (IOException e) {
                 throw new IllegalStateException(e);
               }


### PR DESCRIPTION
Following the introduction of `JmxTelemetry` / `JmxTelemetryBuilder` in the new JMX Insights API (in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15220), this PR migrates to the new API to prevent relying on internal implementation classes.

There is however a limitation in this new API that prevents loading the "legacy" definitions in jmx-scraper. A simple workaround has been implemented by loading metrics definitions through a temporary file, this will be removed once the limitation is removed in instrumentation with https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15413.
