### PR TITLE
Fix warnings from generate-release-contributors.sh

### DIFF
--- a/.github/scripts/generate-release-contributors.sh
+++ b/.github/scripts/generate-release-contributors.sh
@@ -72,7 +72,7 @@ query($q: String!, $endCursor: String) {
   }
 }
 ' --jq '.data.search.edges.[].node.body' \
-  | grep -oE "#[0-9]{3,}$|#[0-9]{3,}[^0-9<]|$GITHUB_REPOSITORY/issues/[0-9]{3,}" \
+  | grep -oE "#[0-9]{3,}$|#[0-9]{3,}[^0-9<&#;]|$GITHUB_REPOSITORY/issues/[0-9]{3,}" \
   | grep -oE "[0-9]{3,}" \
   | xargs -I{} gh issue view {} --json 'author,url' --jq '[.author.login,.url]' \
   | grep -v '/pull/' \
@@ -83,8 +83,11 @@ query($q: String!, $endCursor: String) {
 echo $contributors1 $contributors2 \
   | sed 's/ /\n/g' \
   | sort -uf \
-  | grep -v linux-foundation-easycla \
+  | grep -v copilot-pull-request-reviewer \
+  | grep -v copilot-swe-agent \
   | grep -v github-actions \
+  | grep -v github-advanced-security \
+  | grep -v linux-foundation-easycla \
   | grep -v renovate \
   | grep -v otelbot \
   | sed 's/^/@/'


### PR DESCRIPTION
Seems like it's working, but was logging a lot of warnings about PRs not found because the regex was picking up too much.

Also excluded more bots.