### PR TITLE
Fix snapshot publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
 
       - name: Build and publish snapshots
-        run: ./gradlew assemble publishToSonatype
+        # Disable parallel due to Sonatype's HTTP 429 rate limiting
+        run: ./gradlew assemble publishToSonatype --no-parallel
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}


### PR DESCRIPTION
Snapshot publishing has been failing for a couple of days.

This is just a guess based on the error messages, e.g.

```
Execution failed for task ':jmx-metrics:publishMavenPublicationToSonatypeRepository'.
> Failed to publish publication 'maven' to repository 'sonatype'
   > Could not PUT 'https://central.sonatype.com/repository/maven-snapshots/io/opentelemetry/contrib/opentelemetry-jmx-metrics/1.53.0-alpha-SNAPSHOT/opentelemetry-jmx-metrics-1.53.0-alpha-20251126.021504-11.jar.sha1'. Received status code 429 from server: Too Many Requests
```

https://github.com/open-telemetry/opentelemetry-java-contrib/actions/runs/19690230332/job/56404386346

Seems to be affecting java instrumentation too (haven't checked the others).

If this works, I'll port to other repos.

Also not sure if this is only an issue with snapshot repo or if it will be an issue with releases too.