### PR TITLE
Remove unnecessary code

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,3 @@ idiomatic_version_file_enable_tools = []
 windows_executable_extensions = ["sh"]
 windows_default_file_shell_args = "bash"
 use_file_shell_for_executable_tasks = true
-
-[tasks."lint:markdown"]
-file = ".mise/tasks/lint/markdown.sh"


### PR DESCRIPTION
Forgot that the mise task names are implicit based on their name under the .mise directory