### PR TITLE
Move snapshot publishing to daily build

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -20,6 +20,34 @@ jobs:
   link-check:
     uses: ./.github/workflows/reusable-link-check.yml
 
+  publish-snapshots:
+    needs:
+      - common
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java-contrib'
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
+
+      - name: Build and publish snapshots
+        # Disable parallel due to Sonatype's HTTP 429 rate limiting
+        run: ./gradlew assemble publishToSonatype --no-parallel
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+
   workflow-notification:
     permissions:
         contents: read
@@ -28,10 +56,12 @@ jobs:
     needs:
       - common
       - link-check
+      - publish-snapshots
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: >-
-        ${{
+        ${{{
           needs.common.result == 'success' &&
-          needs.link-check.result == 'success'
+          needs.link-check.result == 'success' &&
+          needs.publish-snapshots.result == 'success'
         }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,32 +19,3 @@ jobs:
   # Link check is disabled for push events to avoid unnecessary CI failures
   # (these failures will instead be captured by the daily scheduled run)
   # and for release branches to avoid unnecessary maintenance if external links break
-
-  publish-snapshots:
-    needs:
-      - common
-    runs-on: ubuntu-latest
-    # skipping release branches because the versions in those branches are not snapshots
-    if: github.ref_name == 'main' && github.repository == 'open-telemetry/opentelemetry-java-contrib'
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Set up JDK for running Gradle
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Set up gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-
-      - name: Build and publish snapshots
-        # Disable parallel due to Sonatype's HTTP 429 rate limiting
-        run: ./gradlew assemble publishToSonatype --no-parallel
-        env:
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I suspect daily snapshot publishing is fine, and this will trigger issue creation when snapshot publishing fails.