### PR TITLE
Use develocity build cache in PRs and local builds

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,24 +29,19 @@ val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
 
-// if develocity access key is not given and we are in CI, then we publish to scans.gradle.com
-val useScansGradleCom = isCI && develocityAccessKey.isEmpty()
-
 develocity {
-  if (useScansGradleCom) {
-    buildScan {
-      termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-      termsOfUseAgree = "yes"
-    }
-  } else {
+  if (develocityAccessKey.isNotEmpty()) {
     server = develocityServer
-    buildScan {
-      publishing.onlyIf { it.isAuthenticated }
-    }
   }
 
   buildScan {
-    uploadInBackground = !isCI
+    if (develocityAccessKey.isNotEmpty()) {
+    } else if (isCI) {
+      termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+      termsOfUseAgree = "yes"
+    } else {
+      publishing.onlyIf { false }
+    }
 
     capture {
       fileFingerprints = true
@@ -60,11 +55,10 @@ develocity {
   }
 }
 
-if (!useScansGradleCom) {
-  buildCache {
-    remote(develocity.buildCache) {
-      isPush = isCI && develocityAccessKey.isNotEmpty()
-    }
+buildCache {
+  remote(HttpBuildCache::class) {
+    url = uri("$develocityServer/cache/")
+    isPush = isCI && develocityAccessKey.isNotEmpty()
   }
 }
 


### PR DESCRIPTION
Ported from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15579
