### PR TITLE
Revert xray lambda name for declarative configuration

### DIFF
--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayLambdaComponentProvider.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsXrayLambdaComponentProvider.java
@@ -18,7 +18,7 @@ public class AwsXrayLambdaComponentProvider implements ComponentProvider {
 
   @Override
   public String getName() {
-    return "xray_lambda";
+    return "xray-lambda";
   }
 
   @Override

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
@@ -25,7 +25,7 @@ class AwsComponentProviderTest {
             + "propagator:\n"
             + "  composite:\n"
             + "    - xray:\n"
-            + "    - xray_lambda:\n";
+            + "    - xray-lambda:\n";
 
     OpenTelemetrySdk openTelemetrySdk =
         DeclarativeConfiguration.parseAndCreate(


### PR DESCRIPTION
I had changed this to underscore in #2423 for consistency with the other component providers, but this was a mistake. @tylerbenson pointed out that this is [defined in semconv](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/aws-lambda.md), so we should remain consistent with that.

<img width="1144" height="327" alt="image" src="https://github.com/user-attachments/assets/31759c81-2120-4893-98a0-6df3ff9e5421" />
