### PR TITLE
Skip running tests in build step

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -59,7 +59,7 @@ jobs:
           cache-read-only: ${{ inputs.cache-read-only }}
 
       - name: Build
-        run: ./gradlew build -x spotlessCheck -x test ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
+        run: ./gradlew build -x spotlessCheck -PskipTests=true ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,3 +35,11 @@ nexusPublishing {
 }
 
 description = "OpenTelemetry Contrib libraries and utilities for the JVM"
+
+if (project.findProperty("skipTests") as String? == "true") {
+  subprojects {
+    tasks.withType<Test>().configureEach {
+      enabled = false
+    }
+  }
+}


### PR DESCRIPTION
Tests are already run in separate test steps. `-x test` won't skip jvm test suites that are added with `dependsOn` to `check`. 