### PR TITLE
Group all GitHub Actions updates into a single weekly Renovate PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -241,6 +241,17 @@
         'org.springframework.boot:**',
       ],
     },
+    {
+      // group all GitHub Actions updates into a single weekly PR
+      // (Renovate applies packageRules in order and later rules win)
+      groupName: 'github actions',
+      matchManagers: [
+        'github-actions',
+      ],
+      schedule: [
+        'before 8am on Tuesday',
+      ],
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
E_TOO_MANY_RENOVATE_PRS

Security vulnerability fixes won't be affected by this grouping and will come in immediately ~once https://github.com/open-telemetry/admin/pull/578 is merged~.