### PR TITLE
Replace IllegalStateException with EOFException in readRawVarint32

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.disk.buffering.internal.utils;
 
 import com.squareup.wire.ProtoAdapter;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,7 +30,7 @@ public final class ProtobufTools {
     for (; offset < 32; offset += 7) {
       int b = input.read();
       if (b == -1) {
-        throw new IllegalStateException();
+        throw new EOFException();
       }
       result |= (b & 0x7f) << offset;
       if ((b & 0x80) == 0) {
@@ -40,13 +41,13 @@ public final class ProtobufTools {
     for (; offset < 64; offset += 7) {
       int b = input.read();
       if (b == -1) {
-        throw new IllegalStateException();
+        throw new EOFException();
       }
       if ((b & 0x80) == 0) {
         return result;
       }
     }
-    throw new IllegalStateException();
+    throw new IOException();
   }
 
   /**


### PR DESCRIPTION
- Replace unchecked IllegalStateException with checked EOFException and IOException
- Enables graceful handling of corrupted disk-buffered data

Fixes #2684

**Description:**


Replaces unchecked `IllegalStateException` with checked `EOFException` to enable graceful error handling for corrupted disk-buffered data.

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2684