### PR TITLE
Replace IllegalStateException with EOFException in readRawVarint32

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/utils/ProtobufTools.java
@@ -30,7 +30,7 @@ public final class ProtobufTools {
     for (; offset < 32; offset += 7) {
       int b = input.read();
       if (b == -1) {
-        throw new EOFException();
+        throw new EOFException("Unexpected end-of-stream while reading a varint32. Offset < 32");
       }
       result |= (b & 0x7f) << offset;
       if ((b & 0x80) == 0) {
@@ -41,13 +41,13 @@ public final class ProtobufTools {
     for (; offset < 64; offset += 7) {
       int b = input.read();
       if (b == -1) {
-        throw new EOFException();
+        throw new EOFException("Unexpected end-of-stream while reading a varint32. Offset < 64");
       }
       if ((b & 0x80) == 0) {
         return result;
       }
     }
-    throw new IOException();
+    throw new IOException("Malformed/overlong varint32");
   }
 
   /**


### PR DESCRIPTION
Replace unchecked IllegalStateException with checked EOFException and IOException
Enables graceful handling of corrupted disk-buffered data
Fixes https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2684

Description:

Replaces unchecked IllegalStateException with checked EOFException to enable graceful error handling for corrupted disk-buffered data.

Existing Issue(s):

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2684