### PR TITLE
Remove zeitlinger from disk-buffering component owners

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -39,7 +39,6 @@ components:
     - PeterF778
   disk-buffering:
     - LikeTheSalad
-    - zeitlinger
   gcp-resources:
     - jsuereth
     - psx95

--- a/disk-buffering/README.md
+++ b/disk-buffering/README.md
@@ -188,6 +188,5 @@ the reading and the writing actions are executed within the same application pro
 ## Component owners
 
 - [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
-- [Gregor Zeitlinger](https://github.com/zeitlinger), Grafana
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
Disk buffering is primarily a mobile observability component, which is outside my area of expertise. Stepping down as component owner so reviews get routed to people with the right context.

@LikeTheSalad remains as sole owner.