### PR TITLE
[dynamic control] refactor trace sampling into specific subpackage

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSampler.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSampler.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.sampler;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.policy;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 
 public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   public static final String TYPE = "trace-sampling";

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.policy;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
-import io.opentelemetry.contrib.dynamic.sampler.DelegatingSampler;
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Collections;
 import java.util.List;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.policy;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSamplerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSamplerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.sampler;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.policy;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.contrib.dynamic.sampler.DelegatingSampler;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.contrib.dynamic.policy;
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
**Description:**

refactor. Moving all the trace sampling related classes into a specific policy subpackage. Looking at other policies (there are likely to be a dozen, but very unlikely to ever be more than 30), it makes sense to have anything related to a specific policy (the policy itself, the validation, the implementors and any framework supporting the implementors) together, since any change to a policy will work on those together, and they work all together

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Tests also refactored

**Documentation:**

N/A

**Outstanding items:**

N/A