### PR TITLE
[dynamic control] add jsonkeyvalue source

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 /** Supported source formats and their parser dispatch. */
 public enum SourceFormat {
   KEYVALUE("keyvalue", KeyValueSourceWrapper::parse),
-  JSON("json", JsonSourceWrapper::parse),
+  JSON("json", JsonSourceWrapper::parse), // Will remove
   JSONKEYVALUE("jsonkeyvalue", JsonSourceWrapper::parse);
 
   private final String configValue;


### PR DESCRIPTION
**Description:**

first step to being more explicit about the current source support which rather than generic json with generic mapping (which is possible), is json key-value, like {"some-key": "some-value"}

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Effectively the current json tests

**Documentation:**

docs will be updated after migration is complete

**Outstanding items:**

several more PRs to come to migrate from json to jsonkeyvalue and refactor providers, I'm trying to keep the PRs as small as possible which means some duplication in the meantime until complete