### PR TITLE
[dynamic control] step 1 in transition to simpler validation

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyValidator.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.source.KeyValueSourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import javax.annotation.Nullable;
 
 public interface PolicyValidator {
@@ -17,6 +20,34 @@ public interface PolicyValidator {
    */
   @Nullable
   TelemetryPolicy validate(String json);
+
+  /**
+   * Validates a parsed policy configuration source.
+   *
+   * <p>This is a transitional API: by default it delegates to {@link #validate(String)} and/or
+   * {@link #validateAlias(String, String)} where possible.
+   *
+   * @param source parsed source wrapper containing the format and payload
+   * @return The validated {@link TelemetryPolicy}, or {@code null} if the source does not contain a
+   *     valid policy for this validator.
+   */
+  @Nullable
+  default TelemetryPolicy validate(SourceWrapper source) {
+    if (source == null) {
+      return null;
+    }
+    if (source instanceof JsonSourceWrapper) {
+      return validate(((JsonSourceWrapper) source).asJsonNode().toString());
+    }
+    if (source instanceof KeyValueSourceWrapper) {
+      KeyValueSourceWrapper kv = (KeyValueSourceWrapper) source;
+      String alias = getAlias();
+      if (alias != null && alias.equals(kv.getKey().trim())) {
+        return validateAlias(kv.getKey().trim(), kv.getValue());
+      }
+    }
+    return null;
+  }
 
   /**
    * Returns the type of the policy this validator handles.


### PR DESCRIPTION
**Description:**

first step in transitioning to to simpler validation

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Already present but will be simpler along with simpler validation

**Documentation:**

docs will be updated after migration is complete

**Outstanding items:**

several more PRs to come to migrate from json to jsonkeyvalue and refactor of providers to simplify validation, I'm trying to keep the PRs as small as possible which means some duplication in the meantime until complete