### PR TITLE
[dynamic control] Move to using SourceWrapper, simplifying parsing

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.source.KeyValueSourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import javax.annotation.Nullable;
+
+/** Base validator with common source-dispatch and parse helpers. */
+public abstract class AbstractSourcePolicyValidator implements PolicyValidator {
+
+  @Override
+  @Nullable
+  public final TelemetryPolicy validate(SourceWrapper source) {
+    if (source == null) {
+      return null;
+    }
+    SourceFormat format = source.getFormat();
+    switch (format) {
+      case JSON: // transitional: same payload shape as JSONKEYVALUE until JSON is removed
+      case JSONKEYVALUE:
+        return validateJsonSource(((JsonSourceWrapper) source).asJsonNode());
+      case KEYVALUE:
+        return validateKeyValueSource((KeyValueSourceWrapper) source);
+    }
+    return null;
+  }
+
+  @Nullable
+  private TelemetryPolicy validateJsonSource(JsonNode node) {
+    JsonNode valueNode = node.get(getPolicyType());
+    if (valueNode == null) {
+      return null;
+    }
+    return validateJsonValue(valueNode);
+  }
+
+  @Nullable
+  private TelemetryPolicy validateKeyValueSource(KeyValueSourceWrapper source) {
+    if (!getPolicyType().equals(source.getKey().trim())) {
+      return null;
+    }
+    return validateKeyValueValue(source.getValue());
+  }
+
+  @Nullable
+  protected abstract TelemetryPolicy validateJsonValue(JsonNode valueNode);
+
+  @Nullable
+  protected abstract TelemetryPolicy validateKeyValueValue(String value);
+
+  @Nullable
+  protected static Double parseDouble(JsonNode valueNode) {
+    if (valueNode.isNumber()) {
+      return valueNode.asDouble();
+    }
+    if (valueNode.isTextual()) {
+      return parseDouble(valueNode.asText());
+    }
+    return null;
+  }
+
+  @Nullable
+  protected static Double parseDouble(String value) {
+    try {
+      return Double.parseDouble(value.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  @Nullable
+  protected static Boolean parseBoolean(JsonNode valueNode) {
+    if (valueNode.isBoolean()) {
+      return valueNode.asBoolean();
+    }
+    if (valueNode.isTextual()) {
+      return parseBoolean(valueNode.asText());
+    }
+    return null;
+  }
+
+  @Nullable
+  protected static Boolean parseBoolean(String value) {
+    String normalized = value.trim();
+    if ("true".equalsIgnoreCase(normalized)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(normalized)) {
+      return false;
+    }
+    return null;
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,14 +20,13 @@ import java.util.stream.Stream;
  * A {@link PolicyProvider} that reads policies from a local file, where each line represents a
  * separate policy configuration.
  *
- * <p>The file format supports two types of lines:
+ * <p>The file format supports JSON and key-value lines:
  *
  * <ul>
  *   <li><b>JSON Objects:</b> Lines starting with <code>{</code> are treated as JSON objects and
  *       validated against the registered {@link PolicyValidator}s.
- *   <li><b>Key-Value Pairs:</b> Lines in the format <code>key=value</code> are treated as aliases,
- *       where the key matches a validator's {@link PolicyValidator#getAlias()} and the value is
- *       parsed accordingly.
+ *   <li><b>Key-Value:</b> Lines containing <code>=</code> are treated as key-value policy lines and
+ *       validated against the registered {@link PolicyValidator}s.
  * </ul>
  *
  * <p>Empty lines and lines starting with <code>#</code> are ignored.
@@ -57,47 +58,33 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
               return;
             }
 
-            TelemetryPolicy policy = null;
-
+            SourceFormat format;
             if (trimmedLine.startsWith("{")) {
-              for (PolicyValidator validator : validators) {
-                if (trimmedLine.contains("\"" + validator.getPolicyType() + "\"")) {
-                  policy = validator.validate(trimmedLine);
-                  if (policy != null) {
-                    break;
-                  }
-                }
-              }
+              format = SourceFormat.JSON;
+            } else if (trimmedLine.indexOf('=') >= 0) {
+              format = SourceFormat.KEYVALUE;
             } else {
-              int idx = trimmedLine.indexOf('=');
-              if (idx > 0) {
-                String key = trimmedLine.substring(0, idx).trim();
-                String valueStr = trimmedLine.substring(idx + 1).trim();
-
-                for (PolicyValidator validator : validators) {
-                  String alias = validator.getAlias();
-                  if (alias != null && alias.equals(key)) {
-                    try {
-                      policy = validator.validateAlias(key, valueStr);
-                    } catch (UnsupportedOperationException e) {
-                      logger.info(
-                          "Validator does not support alias validation: "
-                              + validator.getClass().getName());
-                      continue;
-                    }
-                    if (policy != null) {
-                      break;
-                    }
-                  }
-                }
-              }
+              logger.info("Unsupported policy line format: " + trimmedLine);
+              return;
+            }
+            List<SourceWrapper> parsedSources = format.parse(trimmedLine);
+            if (parsedSources == null || parsedSources.size() != 1) {
+              logger.info("Invalid " + format.configValue() + " policy line: " + trimmedLine);
+              return;
             }
 
+            SourceWrapper parsedSource = parsedSources.get(0);
+            TelemetryPolicy policy = null;
+            for (PolicyValidator validator : validators) {
+              policy = validator.validate(parsedSource);
+              if (policy != null) {
+                break;
+              }
+            }
             if (policy == null) {
               logger.info("Validator not found or rejected for line: " + trimmedLine);
               return;
             }
-
             policies.add(policy);
           });
     }


### PR DESCRIPTION
**Description:**

Continuing the transition to simpler validation and adding an abstract validator to include utility validation methods concrete subclasses can use

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Already present but will be simpler along with simpler validation

**Documentation:**

docs will be updated after migration is complete

**Outstanding items:**

several more PRs to come to migrate from json to jsonkeyvalue and refactor of providers to simplify validation, I'm trying to keep the PRs as small as possible which means some duplication in the meantime until complete

