### PR TITLE
Add jason as component owner to disk buffering

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -39,6 +39,7 @@ components:
     - PeterF778
   disk-buffering:
     - LikeTheSalad
+    - breedx-splk
   gcp-resources:
     - jsuereth
     - psx95

--- a/disk-buffering/README.md
+++ b/disk-buffering/README.md
@@ -188,5 +188,6 @@ the reading and the writing actions are executed within the same application pro
 ## Component owners
 
 - [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
+- [Jason Plumb](https://github.com/breedx-splk), Splunk
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
**Description:**

Follows #2696.

Disk buffering is looking for another component owner, so I'll offer to help out here. This is used by android and is relevant.