### PR TITLE
[dynamic control] Add policy store

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -33,11 +33,11 @@ public final class PolicyStore {
    */
   public synchronized boolean updatePolicies(List<TelemetryPolicy> newPolicies) {
     Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
-    List<TelemetryPolicy> normalized = new ArrayList<>(new LinkedHashSet<>(newPolicies));
-    if (new LinkedHashSet<>(policies).equals(new LinkedHashSet<>(normalized))) {
+    LinkedHashSet<TelemetryPolicy> newPolicySet = new LinkedHashSet<>(newPolicies);
+    if (new LinkedHashSet<>(policies).equals(newPolicySet)) {
       return false;
     }
-    policies = normalized;
+    policies = new ArrayList<>(newPolicySet);
     return true;
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -23,11 +23,11 @@ public final class PolicyStore {
    * Replaces the stored policies when the new snapshot is not equal to the current one.
    *
    * <p>Input lists are normalized to a set of distinct policies ({@link TelemetryPolicy#equals
-   * value equality}): duplicates are dropped and only the first occurrence of each policy is
-   * kept (insertion order). Change detection uses set equality, so list order does not matter.
-   * That matches telemetry policy semantics where the effective result does not depend on
-   * processing order (see the telemetry policy OTEP, commutativity / no user-defined ordering
-   * between policies).
+   * value equality}): duplicates are dropped and only the first occurrence of each policy is kept
+   * (insertion order). Change detection uses set equality, so list order does not matter. That
+   * matches telemetry policy semantics where the effective result does not depend on processing
+   * order (see the telemetry policy OTEP, commutativity / no user-defined ordering between
+   * policies).
    *
    * @return {@code true} if the store was updated, {@code false} if the snapshot was unchanged
    */

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.dynamic.policy;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,20 +17,27 @@ import java.util.Objects;
  */
 public final class PolicyStore {
 
-  private volatile List<TelemetryPolicy> policies = Collections.emptyList();
+  private List<TelemetryPolicy> policies = Collections.emptyList();
 
   /**
-   * Replaces the stored policies when the new list is not equal to the current snapshot.
+   * Replaces the stored policies when the new snapshot is not equal to the current one.
    *
-   * @return {@code true} if the store was updated, {@code false} if the list was equal
+   * <p>Input lists are normalized to a set of distinct policies ({@link TelemetryPolicy#equals
+   * value equality}): duplicates are dropped and only the first occurrence of each policy is
+   * kept (insertion order). Change detection uses set equality, so list order does not matter.
+   * That matches telemetry policy semantics where the effective result does not depend on
+   * processing order (see the telemetry policy OTEP, commutativity / no user-defined ordering
+   * between policies).
+   *
+   * @return {@code true} if the store was updated, {@code false} if the snapshot was unchanged
    */
   public synchronized boolean updatePolicies(List<TelemetryPolicy> newPolicies) {
     Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
-    List<TelemetryPolicy> copy = new ArrayList<>(newPolicies);
-    if (policies.equals(copy)) {
+    List<TelemetryPolicy> normalized = new ArrayList<>(new LinkedHashSet<>(newPolicies));
+    if (new LinkedHashSet<>(policies).equals(new LinkedHashSet<>(normalized))) {
       return false;
     }
-    policies = copy;
+    policies = normalized;
     return true;
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Holds the latest validated policy snapshot and reports whether an update changed effective
+ * configuration.
+ */
+public final class PolicyStore {
+
+  private volatile List<TelemetryPolicy> policies = Collections.emptyList();
+
+  /**
+   * Replaces the stored policies when the new list is not equal to the current snapshot.
+   *
+   * @return {@code true} if the store was updated, {@code false} if the list was equal
+   */
+  public synchronized boolean updatePolicies(List<TelemetryPolicy> newPolicies) {
+    Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
+    List<TelemetryPolicy> copy = new ArrayList<>(newPolicies);
+    if (policies.equals(copy)) {
+      return false;
+    }
+    policies = copy;
+    return true;
+  }
+
+  public synchronized List<TelemetryPolicy> getPolicies() {
+    return Collections.unmodifiableList(new ArrayList<>(policies));
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -50,4 +50,28 @@ public class TelemetryPolicy {
   public String getType() {
     return type;
   }
+
+  /**
+   * Type-only policies ({@link TelemetryPolicy} instances) do not equal typed subclasses that share
+   * the same {@link #getType() type} string.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof TelemetryPolicy)) {
+      return false;
+    }
+    TelemetryPolicy that = (TelemetryPolicy) obj;
+    if (that.getClass() != TelemetryPolicy.class || getClass() != TelemetryPolicy.class) {
+      return false;
+    }
+    return type.equals(that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type);
+  }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -21,6 +21,14 @@ import java.util.Objects;
  * <p>Direct instantiation of this base class is intentionally supported for type-only policy
  * signals (for example, to indicate policy removal/reset without policy-specific values).
  *
+ * <p><b>Subclasses:</b> {@link #equals(Object)} on this class returns {@code false} when either
+ * operand is a typed subclass (not {@code TelemetryPolicy} itself), so a type-only instance never
+ * equals a value-carrying subclass with the same {@link #getType() type}. Each concrete subclass
+ * <b>must</b> override both {@code equals} and {@code hashCode} consistently with its fields, and
+ * obey the {@code equals}/{@code hashCode} contract. That is required for consumers such as {@link
+ * io.opentelemetry.contrib.dynamic.policy.PolicyStore} that deduplicate and detect changes using
+ * {@link Object#equals(Object)}.
+ *
  * @see io.opentelemetry.contrib.dynamic.policy
  */
 public class TelemetryPolicy {
@@ -53,7 +61,8 @@ public class TelemetryPolicy {
 
   /**
    * Type-only policies ({@link TelemetryPolicy} instances) do not equal typed subclasses that share
-   * the same {@link #getType() type} string.
+   * the same {@link #getType() type} string. Subclasses must override {@code equals} (and {@code
+   * hashCode}) for value-based equality; see the class Javadoc.
    */
   @Override
   public boolean equals(Object obj) {
@@ -72,6 +81,6 @@ public class TelemetryPolicy {
 
   @Override
   public int hashCode() {
-    return Objects.hash(type);
+    return type.hashCode();
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
-import java.util.Objects;
 
 public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   public static final String POLICY_TYPE = "trace-sampling";
@@ -39,6 +38,6 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
 
   @Override
   public int hashCode() {
-    return Objects.hash(probability);
+    return Double.hashCode(probability);
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import java.util.Objects;
 
 public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   public static final String POLICY_TYPE = "trace-sampling";
@@ -22,5 +23,22 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
 
   public double getProbability() {
     return probability;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof TraceSamplingRatePolicy)) {
+      return false;
+    }
+    TraceSamplingRatePolicy that = (TraceSamplingRatePolicy) obj;
+    return Double.compare(probability, that.probability) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(probability);
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -41,7 +41,7 @@ class PolicyStoreTest {
   }
 
   @Test
-  void updatePoliciesDetectsListOrderChange() {
+  void updatePoliciesReturnsFalseWhenOnlyOrderDiffers() {
     PolicyStore store = new PolicyStore();
     List<TelemetryPolicy> first =
         Arrays.asList(new TraceSamplingRatePolicy(0.1), new TraceSamplingRatePolicy(0.2));
@@ -49,8 +49,17 @@ class PolicyStoreTest {
         Arrays.asList(new TraceSamplingRatePolicy(0.2), new TraceSamplingRatePolicy(0.1));
 
     assertThat(store.updatePolicies(first)).isTrue();
-    assertThat(store.updatePolicies(reordered)).isTrue();
-    assertThat(store.getPolicies()).isEqualTo(reordered);
+    assertThat(store.updatePolicies(reordered)).isFalse();
+    assertThat(store.getPolicies()).isEqualTo(first);
+  }
+
+  @Test
+  void updatePoliciesIgnoresDuplicatePoliciesInInput() {
+    PolicyStore store = new PolicyStore();
+    TraceSamplingRatePolicy p = new TraceSamplingRatePolicy(0.5);
+    assertThat(store.updatePolicies(Arrays.asList(p, new TraceSamplingRatePolicy(0.5)))).isTrue();
+    assertThat(store.getPolicies()).containsExactly(p);
+    assertThat(store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.5)))).isFalse();
   }
 
   @Test

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PolicyStoreTest {
+
+  @Test
+  void updatePoliciesReturnsTrueOnFirstSet() {
+    PolicyStore store = new PolicyStore();
+    List<TelemetryPolicy> policies = singletonList(new TraceSamplingRatePolicy(0.5));
+
+    assertThat(store.updatePolicies(policies)).isTrue();
+    assertThat(store.getPolicies()).isEqualTo(policies);
+  }
+
+  @Test
+  void updatePoliciesReturnsFalseWhenEqualContent() {
+    PolicyStore store = new PolicyStore();
+    assertThat(store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.5)))).isTrue();
+    assertThat(store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.5)))).isFalse();
+  }
+
+  @Test
+  void updatePoliciesReturnsTrueWhenProbabilityChanges() {
+    PolicyStore store = new PolicyStore();
+    assertThat(store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.25)))).isTrue();
+    assertThat(store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.75)))).isTrue();
+    assertThat(store.getPolicies()).containsExactly(new TraceSamplingRatePolicy(0.75));
+  }
+
+  @Test
+  void updatePoliciesDetectsListOrderChange() {
+    PolicyStore store = new PolicyStore();
+    List<TelemetryPolicy> first =
+        Arrays.asList(new TraceSamplingRatePolicy(0.1), new TraceSamplingRatePolicy(0.2));
+    List<TelemetryPolicy> reordered =
+        Arrays.asList(new TraceSamplingRatePolicy(0.2), new TraceSamplingRatePolicy(0.1));
+
+    assertThat(store.updatePolicies(first)).isTrue();
+    assertThat(store.updatePolicies(reordered)).isTrue();
+    assertThat(store.getPolicies()).isEqualTo(reordered);
+  }
+
+  @Test
+  void getPoliciesReturnsEmptyWhenNeverUpdated() {
+    assertThat(new PolicyStore().getPolicies()).isEqualTo(Collections.emptyList());
+  }
+}


### PR DESCRIPTION
**Description:**

The policy store will be used as a middle component between ingest and application of policies. The initial implementation is simply to avoid re-applying the latest set of policies that were applied, using a simple comparison. More sophisticated prioritization strategies will be applied when the OTEP has stabilized in that area. Because equality is used, equals is now required to be implemented for policies

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Included in this PR

**Documentation:**

Included in this PR

**Outstanding items:**

Hooking up the policy store to the policy pipeline is still to come, I am deliberately keeping PRs small for easier review