### PR TITLE
Use explicit Renovate Tuesday morning schedules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
         'patch',
       ],
       schedule: [
-        'before 8am on Tuesday',
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
     },
     {
@@ -38,7 +38,7 @@
         'major',
       ],
       schedule: [
-        'before 8am on Monday',
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
       matchPackageNames: [
         '!io.opentelemetry:**',
@@ -53,7 +53,7 @@
         'github-actions',
       ],
       schedule: [
-        'before 8am on Tuesday',
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
     },
 


### PR DESCRIPTION
This switches Renovate scheduling to an explicit Tuesday morning cron schedule:

`* 0-7 * * 2`

The goal is to preserve the existing weekly timing while moving away from deprecated older schedule syntax and reducing repeated same-day Renovate churn.

Ported from https://github.com/open-telemetry/semantic-conventions/pull/3576
