### PR TITLE
[dynamic control] Add policy config model classes (record-style structure)

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.registry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Top-level registry initialization model containing per-source mapping config. */
+public final class PolicyInitConfig {
+
+  private final List<PolicySourceConfig> sources;
+
+  public PolicyInitConfig(List<PolicySourceConfig> sources) {
+    List<PolicySourceConfig> sourceCopy =
+        new ArrayList<>(Objects.requireNonNull(sources, "sources cannot be null"));
+    for (PolicySourceConfig source : sourceCopy) {
+      Objects.requireNonNull(source, "sources cannot contain null elements");
+    }
+    this.sources = Collections.unmodifiableList(sourceCopy);
+  }
+
+  public List<PolicySourceConfig> getSources() {
+    return sources;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof PolicyInitConfig)) {
+      return false;
+    }
+    PolicyInitConfig that = (PolicyInitConfig) obj;
+    return sources.equals(that.sources);
+  }
+
+  @Override
+  public int hashCode() {
+    return sources.hashCode();
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.registry;
+
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** One configured policy source with source-local key-to-policy mappings. */
+public final class PolicySourceConfig {
+
+  private final SourceKind kind;
+  private final SourceFormat format;
+  @Nullable private final String location;
+  private final List<PolicySourceMappingConfig> mappings;
+
+  public PolicySourceConfig(
+      SourceKind kind,
+      SourceFormat format,
+      @Nullable String location,
+      List<PolicySourceMappingConfig> mappings) {
+    this.kind = Objects.requireNonNull(kind, "kind cannot be null");
+    this.format = Objects.requireNonNull(format, "format cannot be null");
+    this.location = location;
+    List<PolicySourceMappingConfig> mappingCopy =
+        new ArrayList<>(Objects.requireNonNull(mappings, "mappings cannot be null"));
+    for (PolicySourceMappingConfig mapping : mappingCopy) {
+      Objects.requireNonNull(mapping, "mappings cannot contain null elements");
+    }
+    this.mappings = Collections.unmodifiableList(mappingCopy);
+  }
+
+  public SourceKind getKind() {
+    return kind;
+  }
+
+  public SourceFormat getFormat() {
+    return format;
+  }
+
+  @Nullable
+  public String getLocation() {
+    return location;
+  }
+
+  public List<PolicySourceMappingConfig> getMappings() {
+    return mappings;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof PolicySourceConfig)) {
+      return false;
+    }
+    PolicySourceConfig that = (PolicySourceConfig) obj;
+    return kind == that.kind
+        && format == that.format
+        && Objects.equals(location, that.location)
+        && mappings.equals(that.mappings);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = kind.hashCode();
+    result = 31 * result + format.hashCode();
+    result = 31 * result + (location == null ? 0 : location.hashCode());
+    result = 31 * result + mappings.hashCode();
+    return result;
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceMappingConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceMappingConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.registry;
+
+import java.util.Objects;
+
+/** One source-local mapping from source key to target policy type. */
+public final class PolicySourceMappingConfig {
+
+  private final String sourceKey;
+  private final String policyType;
+
+  public PolicySourceMappingConfig(String sourceKey, String policyType) {
+    this.sourceKey = Objects.requireNonNull(sourceKey, "sourceKey cannot be null");
+    this.policyType = Objects.requireNonNull(policyType, "policyType cannot be null");
+  }
+
+  public String getSourceKey() {
+    return sourceKey;
+  }
+
+  public String getPolicyType() {
+    return policyType;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof PolicySourceMappingConfig)) {
+      return false;
+    }
+    PolicySourceMappingConfig that = (PolicySourceMappingConfig) obj;
+    return sourceKey.equals(that.sourceKey) && policyType.equals(that.policyType);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = sourceKey.hashCode();
+    result = 31 * result + policyType.hashCode();
+    return result;
+  }
+}


### PR DESCRIPTION
**Description:**

This PR adds three immutable, record-type model classes for config initialization

- PolicyInitConfig
   - sources: List<PolicySourceConfig>
- PolicySourceConfig
   - kind: SourceKind
   - format: SourceFormat
   - location: @Nullable String
   - mappings: List<PolicySourceMappingConfig>
- PolicySourceMappingConfig
   - sourceKey: String
   - policyType: String

Notes
- Classes are immutable (final fields, defensive copies, unmodifiable lists).
- Constructors enforce null-safety (including null-element checks for lists).
- Value semantics provided via equals/hashCode (manual hash implementations).

This would support initialization of the Policy pipeline for examples like the following json or yaml

```
{
  "sources": [
    {
      "kind": "opamp",
      "format": "jsonkeyvalue",
      "location": "vendor-specific",
      "mappings": [
        { "sourceKey": "sampling_rate", "policyType": "trace_sampling_rate_policy" },
        { "sourceKey": "send_logs", "policyType": "log_export_enabled_policy" }
      ]
    },
    {
      "kind": "file",
      "format": "keyvalue",
      "location": "/some/path/conf.file",
      "mappings": [
        { "sourceKey": "send_metrics", "policyType": "metric_export_enabled_policy" }
      ]
    }
  ]
}
```

```
sources:
  - kind: opamp
    format: jsonkeyvalue
    location: vendor-specific
    mappings:
      - sourceKey: sampling_rate
        policyType: trace_sampling_rate_policy
      - sourceKey: send_logs
        policyType: log_export_enabled_policy

  - kind: file
    format: keyvalue
    location: /some/path/conf.file
    mappings:
      - sourceKey: send_metrics
        policyType: metric_export_enabled_policy
```

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Not needed yet these are just record classes

**Documentation:**

not needed yet, will be added when specific format parsing is added (eg the above json and/or yaml examples)

**Outstanding items:**

The functionality to parse json and/or yaml files and create the policy pipeline based on that. Note that the yaml example is exactly what could go into declarative config under a policy pipeline node, so this would naturally migrate to declarative config when it the policy structure is stable and accepted