### PR TITLE
[dynamic control] add SourceFormat string to enum conversion

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.dynamic.policy.source;
 
 import com.google.errorprone.annotations.Immutable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -25,6 +26,27 @@ public enum SourceFormat {
 
   public String configValue() {
     return configValue;
+  }
+
+  /**
+   * Converts string value case independently to enum value. Leading and trailing whitespace is
+   * removed, then the remainder is matched case-insensitively against {@link #configValue()} for
+   * each format.
+   *
+   * @param value the string from config (e.g. {@code "keyvalue"}, {@code "JSONKEYVALUE"})
+   * @return the matching format
+   * @throws NullPointerException if value is null
+   * @throws IllegalArgumentException if no format matches the trimmed value
+   */
+  public static SourceFormat fromConfigValue(String value) {
+    Objects.requireNonNull(value, "value cannot be null");
+    String normalized = value.trim().toLowerCase(Locale.ROOT);
+    for (SourceFormat format : values()) {
+      if (format.configValue.equals(normalized)) {
+        return format;
+      }
+    }
+    throw new IllegalArgumentException("Unknown source format: " + value);
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -9,6 +9,7 @@ import com.google.errorprone.annotations.Immutable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Supported source formats and their parser dispatch. */
@@ -38,7 +39,7 @@ public enum SourceFormat {
    * @throws NullPointerException if value is null
    * @throws IllegalArgumentException if no format matches the trimmed value
    */
-  public static SourceFormat fromConfigValue(String value) {
+  public static SourceFormat fromConfigValue(@Nonnull String value) {
     Objects.requireNonNull(value, "value cannot be null");
     String normalized = value.trim().toLowerCase(Locale.ROOT);
     for (SourceFormat format : values()) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -46,7 +46,8 @@ public enum SourceFormat {
         return format;
       }
     }
-    throw new IllegalArgumentException("Unknown source format: " + value);
+    throw new IllegalArgumentException(
+        "Unknown source format (normalized): '" + normalized + "' (original: '" + value + "')");
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -29,7 +29,7 @@ public enum SourceFormat {
   }
 
   /**
-   * Converts string value case independently to enum value. Leading and trailing whitespace is
+   * Converts string value case insensitively to enum value. Leading and trailing whitespace is
    * removed, then the remainder is matched case-insensitively against {@link #configValue()} for
    * each format.
    *

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
@@ -20,6 +20,27 @@ class SourceFormatTest {
   }
 
   @Test
+  void fromConfigValueParsesCaseInsensitive() {
+    assertThat(SourceFormat.fromConfigValue("KEYVALUE")).isEqualTo(SourceFormat.KEYVALUE);
+    assertThat(SourceFormat.fromConfigValue("JsonKeyValue")).isEqualTo(SourceFormat.JSONKEYVALUE);
+  }
+
+  @Test
+  void fromConfigValueTrimsWhitespace() {
+    assertThat(SourceFormat.fromConfigValue("  keyvalue  ")).isEqualTo(SourceFormat.KEYVALUE);
+  }
+
+  @Test
+  void fromConfigValueRejectsNullAndUnknown() {
+    assertThatThrownBy(() -> SourceFormat.fromConfigValue(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("value cannot be null");
+    assertThatThrownBy(() -> SourceFormat.fromConfigValue("other"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unknown source format: other");
+  }
+
+  @Test
   void parseDelegatesToJsonParser() {
     List<SourceWrapper> parsed = SourceFormat.JSONKEYVALUE.parse("{\"trace-sampling\": 0.5}");
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
@@ -37,7 +37,7 @@ class SourceFormatTest {
         .hasMessage("value cannot be null");
     assertThatThrownBy(() -> SourceFormat.fromConfigValue("other"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Unknown source format: other");
+        .hasMessage("Unknown source format (normalized): 'other' (original: 'other')");
   }
 
   @Test


### PR DESCRIPTION
**Description:**

Just SourceFormat.fromConfigValue() method to convert from string to enum, needed for parsing config

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

added

**Documentation:**

added

**Outstanding items:**

the rest of the parsing is to come