### PR TITLE
feat: Add support for JFR contextual information

### DIFF
--- a/jfr-events/README.md
+++ b/jfr-events/README.md
@@ -8,7 +8,7 @@ Create JFR events that can be recorded and viewed in Java Mission Control (JMC).
   * The thread and stacktrace will be of the thread ending the span, which might
     be different from the thread creating the span.
   * Has the fields
-    * Operation Name
+    * Operation Name (`@Contextual`)
     * Trace ID
     * Parent Span ID
     * Span ID
@@ -16,7 +16,7 @@ Create JFR events that can be recorded and viewed in Java Mission Control (JMC).
   * Thread will match the thread the scope was active in and the stacktrace will be when scope was closed
   * Multiple scopes might be collected for a single span
   * Has the fields
-    * Trace ID
+    * Trace ID (`@Contextual`)
     * Span ID
 * Supports the Open Source version of JFR in Java 11.
   * Might support back port to OpenJDK 8, but not tested and classes are built with JDK 11 bytecode.

--- a/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/Contextual.java
+++ b/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/Contextual.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.jfrevent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import jdk.jfr.Label;
+import jdk.jfr.MetadataDefinition;
+import jdk.jfr.Name;
+
+/**
+ * Meta-annotation to support @Contextual without compiling against JDK 25.
+ *
+ * @see <a href="https://bugs.openjdk.org/browse/JDK-8356699">JDK-8356699</a>
+ */
+@MetadataDefinition
+@Label("Context")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@Name("jdk.jfr.Contextual")
+@interface Contextual {}

--- a/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/ScopeEvent.java
+++ b/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/ScopeEvent.java
@@ -20,7 +20,7 @@ import jdk.jfr.Name;
         + "in scope/active on this thread.")
 class ScopeEvent extends Event {
 
-  private final String traceId;
+  @Contextual private final String traceId;
   private final String spanId;
 
   ScopeEvent(SpanContext spanContext) {

--- a/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/SpanEvent.java
+++ b/jfr-events/src/main/java/io/opentelemetry/contrib/jfrevent/SpanEvent.java
@@ -18,7 +18,7 @@ import jdk.jfr.Name;
 @Description("Open Telemetry trace event corresponding to a span.")
 class SpanEvent extends Event {
 
-  private final String operationName;
+  @Contextual private final String operationName;
   private final String traceId;
   private final String spanId;
   private final String parentId;

--- a/jfr-events/src/test/java/io/opentelemetry/contrib/jfrevent/JfrSpanProcessorTest.java
+++ b/jfr-events/src/test/java/io/opentelemetry/contrib/jfrevent/JfrSpanProcessorTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
@@ -79,6 +80,14 @@ class JfrSpanProcessorTest {
       assertThat(events)
           .extracting(e -> e.getValue("operationName"))
           .containsExactly(OPERATION_NAME);
+      assertThat(events)
+          .extracting(
+              e ->
+                  e.getFields().stream()
+                      .filter(f -> f.getName().equals("operationName"))
+                      .map(d -> d.getAnnotation(Contextual.class))
+                      .collect(Collectors.toList()))
+          .doesNotContainNull();
     } finally {
       Files.delete(output);
     }
@@ -121,6 +130,15 @@ class JfrSpanProcessorTest {
           .filteredOn(e -> "Span".equals(e.getEventType().getLabel()))
           .extracting(e -> e.getValue("operationName"))
           .containsExactly(OPERATION_NAME);
+      assertThat(events)
+          .filteredOn(e -> "Scope".equals(e.getEventType().getLabel()))
+          .extracting(
+              e ->
+                  e.getFields().stream()
+                      .filter(f -> f.getName().equals("traceId"))
+                      .map(d -> d.getAnnotation(Contextual.class))
+                      .collect(Collectors.toList()))
+          .doesNotContainNull();
 
     } finally {
       Files.delete(output);


### PR DESCRIPTION
**Description:**

Feature addition
Annotate the operationName and traceID event fields with contextual so it shows up when using `jfr print`.

**Existing Issue(s):**

#2057

**Testing:**

Existing unit tests extended.

**Documentation:**

Attribute documentation in readme updated.

**Outstanding items:**

See discussion in #2057

> To avoid repetition in the presentation, it's probably best to annotate traceId only in a top-level event, such as the ScopeEvent or perhaps a new event that is even higher-level. SpanID is likely not that interesting either. If too much is annotated with @Contextual, it will be hard for humans to parse.
