### PR TITLE
[dynamic control] Create providers from SourceKind

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
@@ -5,8 +5,16 @@
 
 package io.opentelemetry.contrib.dynamic.policy.source;
 
+import com.google.errorprone.annotations.Immutable;
+import io.opentelemetry.contrib.dynamic.policy.OpampPolicyProvider;
+import io.opentelemetry.contrib.dynamic.policy.PolicyProvider;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceConfig;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Identifies where policy configuration is loaded from for registry initialization (e.g. local
@@ -15,21 +23,23 @@ import java.util.Objects;
  */
 public enum SourceKind {
   /** Policies loaded from a local file (e.g. line-per-policy file). */
-  FILE("file"),
+  FILE("file", SourceKind::createNoProvider),
 
   /** Policies delivered via OpAMP (remote management). */
-  OPAMP("opamp"),
+  OPAMP("opamp", SourceKind::createOpampProvider),
 
   /** Policies fetched from an HTTP/HTTPS endpoint. */
-  HTTP("http"),
+  HTTP("http", SourceKind::createNoProvider),
 
   /** User-defined or extension provider. */
-  CUSTOM("custom");
+  CUSTOM("custom", SourceKind::createNoProvider);
 
   private final String configValue;
+  private final ProviderCreator providerCreator;
 
-  SourceKind(String configValue) {
+  SourceKind(String configValue, ProviderCreator providerCreator) {
     this.configValue = configValue;
+    this.providerCreator = providerCreator;
   }
 
   /**
@@ -39,6 +49,46 @@ public enum SourceKind {
    */
   public String configValue() {
     return configValue;
+  }
+
+  /**
+   * Creates a runtime {@link PolicyProvider} for this source kind.
+   *
+   * <p>Provider creation is delegated to a per-kind method reference configured on each enum
+   * constant.
+   */
+  @Nullable
+  public PolicyProvider createProvider(
+      PolicySourceConfig source, ConfigProperties config, List<PolicyValidator> validators) {
+    Objects.requireNonNull(source, "source cannot be null");
+    Objects.requireNonNull(config, "config cannot be null");
+    Objects.requireNonNull(validators, "validators cannot be null");
+    return providerCreator.create(source, config, validators);
+  }
+
+  @Nullable
+  private static PolicyProvider createNoProvider(
+      PolicySourceConfig source, ConfigProperties config, List<PolicyValidator> validators) {
+    return null;
+  }
+
+  @Nullable
+  private static PolicyProvider createOpampProvider(
+      PolicySourceConfig source, ConfigProperties config, List<PolicyValidator> validators) {
+    String location = source.getLocation();
+    if (location == null || location.trim().isEmpty()) {
+      return null;
+    }
+    return new OpampPolicyProvider(
+        config, location, source.getFormat(), source.getMappings(), validators);
+  }
+
+  @Immutable
+  @FunctionalInterface
+  private interface ProviderCreator {
+    @Nullable
+    PolicyProvider create(
+        PolicySourceConfig source, ConfigProperties config, List<PolicyValidator> validators);
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
@@ -63,6 +63,11 @@ public enum SourceKind {
     Objects.requireNonNull(source, "source cannot be null");
     Objects.requireNonNull(config, "config cannot be null");
     Objects.requireNonNull(validators, "validators cannot be null");
+    SourceKind sourceKind = source.getKind();
+    if (sourceKind != this) {
+      throw new IllegalArgumentException(
+          "Source kind mismatch: expected " + this + " but was " + sourceKind);
+    }
     return providerCreator.create(source, config, validators);
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
@@ -14,6 +14,8 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -36,6 +38,7 @@ public enum SourceKind {
 
   private final String configValue;
   private final ProviderCreator providerCreator;
+  private static final Logger logger = Logger.getLogger(SourceKind.class.getName());
 
   SourceKind(String configValue, ProviderCreator providerCreator) {
     this.configValue = configValue;
@@ -79,8 +82,16 @@ public enum SourceKind {
     if (location == null || location.trim().isEmpty()) {
       return null;
     }
-    return new OpampPolicyProvider(
-        config, location, source.getFormat(), source.getMappings(), validators);
+    try {
+      return new OpampPolicyProvider(
+          config, location, source.getFormat(), source.getMappings(), validators);
+    } catch (IllegalArgumentException e) {
+      logger.log(
+          Level.FINE,
+          "Skipping OpAMP provider creation due to invalid/missing OpAMP configuration: {0}",
+          e.getMessage());
+      return null;
+    }
   }
 
   @Immutable

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
@@ -7,7 +7,15 @@ package io.opentelemetry.contrib.dynamic.policy.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.opentelemetry.contrib.dynamic.policy.PolicyProvider;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceConfig;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SourceKindTest {
@@ -43,5 +51,71 @@ class SourceKindTest {
     assertThatThrownBy(() -> SourceKind.fromConfigValue("unknown"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Unknown source kind: unknown");
+  }
+
+  @Test
+  void createProviderReturnsNullForKindsWithoutProviderCreator() {
+    PolicySourceConfig source = source(SourceKind.FILE, "ignored");
+    ConfigProperties config = opampConfig();
+    List<PolicyValidator> validators = Collections.emptyList();
+
+    assertThat(SourceKind.FILE.createProvider(source, config, validators)).isNull();
+    assertThat(
+            SourceKind.HTTP.createProvider(source(SourceKind.HTTP, "ignored"), config, validators))
+        .isNull();
+    assertThat(
+            SourceKind.CUSTOM.createProvider(
+                source(SourceKind.CUSTOM, "ignored"), config, validators))
+        .isNull();
+  }
+
+  @Test
+  void opampCreateProviderReturnsNullWhenLocationMissing() {
+    ConfigProperties config = opampConfig();
+    List<PolicyValidator> validators = Collections.emptyList();
+
+    assertThat(SourceKind.OPAMP.createProvider(source(SourceKind.OPAMP, null), config, validators))
+        .isNull();
+    assertThat(SourceKind.OPAMP.createProvider(source(SourceKind.OPAMP, "  "), config, validators))
+        .isNull();
+  }
+
+  @Test
+  void opampCreateProviderReturnsProviderWhenLocationPresent() {
+    PolicyProvider provider =
+        SourceKind.OPAMP.createProvider(
+            source(SourceKind.OPAMP, "vendor-specific"), opampConfig(), Collections.emptyList());
+
+    assertThat(provider).isNotNull();
+  }
+
+  @Test
+  void createProviderRejectsNullArguments() {
+    ConfigProperties config = opampConfig();
+    PolicySourceConfig source = source(SourceKind.OPAMP, "vendor-specific");
+    List<PolicyValidator> validators = Collections.emptyList();
+
+    assertThatThrownBy(() -> SourceKind.OPAMP.createProvider(null, config, validators))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("source cannot be null");
+    assertThatThrownBy(() -> SourceKind.OPAMP.createProvider(source, null, validators))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("config cannot be null");
+    assertThatThrownBy(() -> SourceKind.OPAMP.createProvider(source, config, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("validators cannot be null");
+  }
+
+  private static PolicySourceConfig source(SourceKind kind, String location) {
+    return new PolicySourceConfig(kind, SourceFormat.KEYVALUE, location, Collections.emptyList());
+  }
+
+  private static ConfigProperties opampConfig() {
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString("otel.opamp.service.url")).thenReturn("https://example.com");
+    when(config.getString("otel.service.name")).thenReturn("test-service");
+    when(config.getMap("otel.experimental.opamp.headers")).thenReturn(Collections.emptyMap());
+    when(config.getMap("otel.resource.attributes")).thenReturn(Collections.emptyMap());
+    return config;
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
@@ -90,6 +90,21 @@ class SourceKindTest {
   }
 
   @Test
+  void opampCreateProviderReturnsNullWhenRequiredConfigMissing() {
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString("otel.opamp.service.url")).thenReturn(null);
+    when(config.getString("otel.service.name")).thenReturn("test-service");
+    when(config.getMap("otel.experimental.opamp.headers")).thenReturn(Collections.emptyMap());
+    when(config.getMap("otel.resource.attributes")).thenReturn(Collections.emptyMap());
+
+    PolicyProvider provider =
+        SourceKind.OPAMP.createProvider(
+            source(SourceKind.OPAMP, "vendor-specific"), config, Collections.emptyList());
+
+    assertThat(provider).isNull();
+  }
+
+  @Test
   void createProviderRejectsNullArguments() {
     ConfigProperties config = opampConfig();
     PolicySourceConfig source = source(SourceKind.OPAMP, "vendor-specific");


### PR DESCRIPTION
**Description:**

This adds getting PolicyProviders of specific implementations from SourceKind

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Added

**Documentation:**

To be added

**Outstanding items:**

Wiring up the policy pipeline: 
- message -> provider -> policy -> policy handler -> implementer
- eg change sampling rate message -> OpampPolicyprovider -> TraceSamplingRatePolicy -> PolicyStore -> TraceSamplingRatePolicyImplementer

Steps needed for the wiring:
- providers reading policies, eg OpampPolicyprovider
- implementers applying policies, eg a TraceSamplingRatePolicyImplementer
- policy structures (eg TraceSamplingRatePolicy) that the provider converts messages into
- registering config to policy structures (eg "trace_sampling_rate_policy" registered to TraceSamplingRatePolicy)
- initializing policy classes (eg TraceSamplingRatePolicy needs to install a custom sampler)
- activate configured providers (eg start OpampPolicyprovider reading from it's source)
- register implementers for policies (eg a new TraceSamplingRatePolicy is applied by a TraceSamplingRatePolicyImplementer)
- link the provider to processing policies and applying implementers