### PR TITLE
[dynamic control] Add PolicyTypeInitializer interface for better readability

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
@@ -9,6 +9,8 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import javax.annotation.Nonnull;
 
 /**
+ * NOTE PolicyInit not yet added - remove this note when it is added
+ * 
  * Initializes one policy type and returns the implementer that applies that type at runtime.
  *
  * <p>This is used by {@code

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import javax.annotation.Nonnull;
+
+/**
+ * Initializes one policy type and returns the implementer that applies that type at runtime.
+ *
+ * <p>This is used by {@code
+ * io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit.registerPolicyType(...)} and is
+ * typically provided as a method reference, for example:
+ *
+ * <pre>{@code
+ * io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit.registerPolicyType(
+ *     TraceSamplingRatePolicy.POLICY_TYPE,
+ *     TraceSamplingRatePolicy.class,
+ *     TraceSamplingRatePolicy::initialize);
+ * }</pre>
+ */
+@FunctionalInterface
+public interface PolicyTypeInitializer {
+  /**
+   * Initializes policy runtime wiring for one policy type.
+   *
+   * @param autoConfiguration OpenTelemetry auto-configuration customizer
+   * @return non-null implementer for the policy type
+   */
+  @Nonnull
+  PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration);
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyTypeInitializer.java
@@ -10,8 +10,8 @@ import javax.annotation.Nonnull;
 
 /**
  * NOTE PolicyInit not yet added - remove this note when it is added
- * 
- * Initializes one policy type and returns the implementer that applies that type at runtime.
+ *
+ * <p>Initializes one policy type and returns the implementer that applies that type at runtime.
  *
  * <p>This is used by {@code
  * io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit.registerPolicyType(...)} and is


### PR DESCRIPTION
**Description:**

Adds a PolicyTypeInitializer to make initialization more readable, refers to `PolicyInit` class that is not yet implemented but is  planned

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

N/A

**Documentation:**

Added

**Outstanding items:**

When registering a policy type implementation, the implementation needs to be linked to the policy type name, it needs to be initialized only when the policy type is configured but not otherwise, and needs to be linked to the policy type implementer. Having PolicyTypeInitializer makes that straightforward and readable (I went through a bunch of unreadable Function and factories before settling on a nice simple choice)