### PR TITLE
feat(gcp-auth-extension): Support custom credentials via configuration properties

### DIFF
--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -56,16 +56,16 @@ enum ConfigurableOption {
 
   /**
    * Specifies the path to a Google Cloud service account JSON key file. The path can be either
-   * absolute or relative to the current working directory. Can be configured using the
-   * environment variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property
+   * absolute or relative to the current working directory. Can be configured using the environment
+   * variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property
    * `google.cloud.credentials.path`.
    */
   GOOGLE_CLOUD_CREDENTIALS_PATH("Google Cloud Credentials Path"),
 
   /**
    * Specifies the raw JSON content of a Google Cloud service account key. This is useful when
-   * credentials are not stored in a file but are available as a string. Can be configured using
-   * the environment variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property
+   * credentials are not stored in a file but are available as a string. Can be configured using the
+   * environment variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property
    * `google.cloud.credentials.json`.
    */
   GOOGLE_CLOUD_CREDENTIALS_JSON("Google Cloud Credentials JSON String");

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -52,7 +52,19 @@ enum ConfigurableOption {
    * configured using the environment variable `GOOGLE_OTEL_AUTH_TARGET_SIGNALS` or the system
    * property `google.otel.auth.target.signals`.
    */
-  GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Authentication Extension");
+  GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Authentication Extension"),
+
+  /**
+   * Represents the Google Cloud Credentials Path option. Can be configured using the environment
+   * variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property `google.cloud.credentials.path`.
+   */
+  GOOGLE_CLOUD_CREDENTIALS_PATH("Google Cloud Credentials Path"),
+
+  /**
+   * Represents the Google Cloud Credentials JSON option. Can be configured using the environment
+   * variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property `google.cloud.credentials.json`.
+   */
+  GOOGLE_CLOUD_CREDENTIALS_JSON("Google Cloud Credentials JSON String");
 
   private final String userReadableName;
   private final String environmentVariableName;

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -56,13 +56,15 @@ enum ConfigurableOption {
 
   /**
    * Represents the Google Cloud Credentials Path option. Can be configured using the environment
-   * variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property `google.cloud.credentials.path`.
+   * variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property
+   * `google.cloud.credentials.path`.
    */
   GOOGLE_CLOUD_CREDENTIALS_PATH("Google Cloud Credentials Path"),
 
   /**
    * Represents the Google Cloud Credentials JSON option. Can be configured using the environment
-   * variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property `google.cloud.credentials.json`.
+   * variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property
+   * `google.cloud.credentials.json`.
    */
   GOOGLE_CLOUD_CREDENTIALS_JSON("Google Cloud Credentials JSON String");
 

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -55,15 +55,17 @@ enum ConfigurableOption {
   GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Authentication Extension"),
 
   /**
-   * Represents the Google Cloud Credentials Path option. Can be configured using the environment
-   * variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property
+   * Specifies the path to a Google Cloud service account JSON key file. The path can be either
+   * absolute or relative to the current working directory. Can be configured using the
+   * environment variable `GOOGLE_CLOUD_CREDENTIALS_PATH` or the system property
    * `google.cloud.credentials.path`.
    */
   GOOGLE_CLOUD_CREDENTIALS_PATH("Google Cloud Credentials Path"),
 
   /**
-   * Represents the Google Cloud Credentials JSON option. Can be configured using the environment
-   * variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property
+   * Specifies the raw JSON content of a Google Cloud service account key. This is useful when
+   * credentials are not stored in a file but are available as a string. Can be configured using
+   * the environment variable `GOOGLE_CLOUD_CREDENTIALS_JSON` or the system property
    * `google.cloud.credentials.json`.
    */
   GOOGLE_CLOUD_CREDENTIALS_JSON("Google Cloud Credentials JSON String");

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -123,38 +123,46 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   private static GoogleCredentials resolveCredentials(ConfigProperties configProperties) {
-    return credentialsCache.computeIfAbsent(
-        configProperties,
-        props -> {
-          Optional<String> credsPath =
-              ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(props);
-          if (credsPath.isPresent()) {
-            try (FileInputStream fis = new FileInputStream(credsPath.get())) {
-              return GoogleCredentials.fromStream(fis);
-            } catch (IOException e) {
-              throw new ConfigurationException(
-                  "Failed to load credentials from file: " + new File(credsPath.get()).getName(),
-                  e);
-            }
-          }
+    synchronized (credentialsCache) {
+      GoogleCredentials cachedCredentials = credentialsCache.get(configProperties);
+      if (cachedCredentials != null) {
+        return cachedCredentials;
+      }
 
-          Optional<String> credsJson =
-              ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(props);
-          if (credsJson.isPresent()) {
-            try (ByteArrayInputStream bais =
-                new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
-              return GoogleCredentials.fromStream(bais);
-            } catch (IOException e) {
-              throw new ConfigurationException("Failed to load credentials from JSON string", e);
-            }
-          }
+      GoogleCredentials resolvedCredentials = loadCredentials(configProperties);
+      credentialsCache.put(configProperties, resolvedCredentials);
+      return resolvedCredentials;
+    }
+  }
 
-          try {
-            return GoogleCredentials.getApplicationDefault();
-          } catch (IOException e) {
-            throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-          }
-        });
+  private static GoogleCredentials loadCredentials(ConfigProperties props) {
+    Optional<String> credsPath =
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(props);
+    if (credsPath.isPresent()) {
+      try (FileInputStream fis = new FileInputStream(credsPath.get())) {
+        return GoogleCredentials.fromStream(fis);
+      } catch (IOException e) {
+        throw new ConfigurationException(
+            "Failed to load credentials from file: " + new File(credsPath.get()).getName(), e);
+      }
+    }
+
+    Optional<String> credsJson =
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(props);
+    if (credsJson.isPresent()) {
+      try (ByteArrayInputStream bais =
+          new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
+        return GoogleCredentials.fromStream(bais);
+      } catch (IOException e) {
+        throw new ConfigurationException("Failed to load credentials from JSON string", e);
+      }
+    }
+
+    try {
+      return GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+    }
   }
 
   @Override

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -11,6 +11,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.contrib.gcp.auth.GoogleAuthException.Reason;
@@ -49,8 +50,9 @@ import javax.annotation.Nonnull;
  * integration.
  *
  * <p>This class is registered as a service provider using {@link AutoService} and is responsible
- * for customizing the OpenTelemetry configuration for GCP specific behavior. It retrieves Google
- * Application Default Credentials (ADC) and adds them as authorization headers to the configured
+ * for customizing the OpenTelemetry configuration for GCP specific behavior. It retrieves
+ * credentials (either explicit service account keys from configuration or falling back to
+ * Application Default Credentials (ADC)) and adds them as authorization headers to the configured
  * {@link SpanExporter}. It also sets default properties and resource attributes for GCP
  * integration.
  *
@@ -83,8 +85,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    * Customizes the provided {@link AutoConfigurationCustomizer} such that authenticated exports to
    * GCP Telemetry API are possible from the configured OTLP exporter.
    *
-   * <p>This method attempts to retrieve Google Application Default Credentials (ADC) and performs
-   * the following:
+   * <p>This method attempts to retrieve credentials (either from user-specified configuration or
+   * falling back to ADC) and performs the following:
    *
    * <ul>
    *   <li>Verifies whether the configured OTLP endpoint (base or signal specific) is a known GCP
@@ -135,26 +137,29 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     }
   }
 
-  private static GoogleCredentials loadCredentials(ConfigProperties props) {
+  private static GoogleCredentials loadCredentials(ConfigProperties configProperties) {
     Optional<String> credsPath =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(props);
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(configProperties);
     if (credsPath.isPresent()) {
-      try (FileInputStream fis = new FileInputStream(credsPath.get())) {
-        return GoogleCredentials.fromStream(fis);
+      File file = new File(credsPath.get());
+      if (!file.exists()) {
+        throw new ConfigurationException("Credentials file not found: " + file.getName());
+      }
+      try (FileInputStream fis = new FileInputStream(file)) {
+        return ServiceAccountCredentials.fromStream(fis);
       } catch (IOException e) {
-        throw new ConfigurationException(
-            "Failed to load credentials from file: " + new File(credsPath.get()).getName(), e);
+        throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }
     }
 
     Optional<String> credsJson =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(props);
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(configProperties);
     if (credsJson.isPresent()) {
       try (ByteArrayInputStream bais =
           new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
-        return GoogleCredentials.fromStream(bais);
+        return ServiceAccountCredentials.fromStream(bais);
       } catch (IOException e) {
-        throw new ConfigurationException("Failed to load credentials from JSON string", e);
+        throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }
     }
 

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -29,7 +29,10 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -99,22 +102,47 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    */
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
-    GoogleCredentials credentials;
-    try {
-      credentials = GoogleCredentials.getApplicationDefault();
-    } catch (IOException e) {
-      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-    }
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
-                customizeSpanExporter(spanExporter, credentials, configProperties))
+                customizeSpanExporter(spanExporter, resolveCredentials(configProperties), configProperties))
         .addMetricExporterCustomizer(
             (metricExporter, configProperties) ->
-                customizeMetricExporter(metricExporter, credentials, configProperties))
+                customizeMetricExporter(metricExporter, resolveCredentials(configProperties), configProperties))
         .addResourceCustomizer(
             (resource, configProperties) ->
-                customizeResource(resource, credentials, configProperties));
+                customizeResource(resource, resolveCredentials(configProperties), configProperties));
+  }
+
+  private static GoogleCredentials resolveCredentials(ConfigProperties configProperties) {
+    Optional<String> credsPath =
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(
+            configProperties);
+    if (credsPath.isPresent()) {
+      try (FileInputStream fis = new FileInputStream(credsPath.get())) {
+        return GoogleCredentials.fromStream(fis);
+      } catch (IOException e) {
+        throw new ConfigurationException("Failed to load credentials from file: " + credsPath.get(), e);
+      }
+    }
+
+    Optional<String> credsJson =
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(
+            configProperties);
+    if (credsJson.isPresent()) {
+      try (ByteArrayInputStream bais =
+          new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
+        return GoogleCredentials.fromStream(bais);
+      } catch (IOException e) {
+        throw new ConfigurationException("Failed to load credentials from JSON string", e);
+      }
+    }
+
+    try {
+      return GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+    }
   }
 
   @Override

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -139,7 +139,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static GoogleCredentials loadCredentials(ConfigProperties configProperties) {
     Optional<String> credsPath =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(configProperties);
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(
+            configProperties);
     if (credsPath.isPresent()) {
       File file = new File(credsPath.get());
       if (!file.exists()) {
@@ -153,7 +154,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     }
 
     Optional<String> credsJson =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(configProperties);
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(
+            configProperties);
     if (credsJson.isPresent()) {
       try (ByteArrayInputStream bais =
           new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -148,7 +148,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       }
       try (FileInputStream fis = new FileInputStream(file)) {
         return ServiceAccountCredentials.fromStream(fis)
-            .createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
+            .createScoped(
+                Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
       } catch (IOException e) {
         throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }
@@ -161,7 +162,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       try (ByteArrayInputStream bais =
           new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
         return ServiceAccountCredentials.fromStream(bais)
-            .createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
+            .createScoped(
+                Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
       } catch (IOException e) {
         throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -30,13 +30,16 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -60,6 +63,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static final Logger logger =
       Logger.getLogger(GcpAuthAutoConfigurationCustomizerProvider.class.getName());
+  private static final Map<ConfigProperties, GoogleCredentials> credentialsCache =
+      Collections.synchronizedMap(new WeakHashMap<>());
   private static final String SIGNAL_TARGET_WARNING_FIX_SUGGESTION =
       String.format(
           "You may safely ignore this warning if it is intentional, otherwise please configure the '%s' by exporting valid values to environment variable: %s or by setting valid values in system property: %s.",
@@ -105,44 +110,51 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
-                customizeSpanExporter(spanExporter, resolveCredentials(configProperties), configProperties))
+                customizeSpanExporter(
+                    spanExporter, resolveCredentials(configProperties), configProperties))
         .addMetricExporterCustomizer(
             (metricExporter, configProperties) ->
-                customizeMetricExporter(metricExporter, resolveCredentials(configProperties), configProperties))
+                customizeMetricExporter(
+                    metricExporter, resolveCredentials(configProperties), configProperties))
         .addResourceCustomizer(
             (resource, configProperties) ->
-                customizeResource(resource, resolveCredentials(configProperties), configProperties));
+                customizeResource(
+                    resource, resolveCredentials(configProperties), configProperties));
   }
 
   private static GoogleCredentials resolveCredentials(ConfigProperties configProperties) {
-    Optional<String> credsPath =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(
-            configProperties);
-    if (credsPath.isPresent()) {
-      try (FileInputStream fis = new FileInputStream(credsPath.get())) {
-        return GoogleCredentials.fromStream(fis);
-      } catch (IOException e) {
-        throw new ConfigurationException("Failed to load credentials from file: " + credsPath.get(), e);
-      }
-    }
+    return credentialsCache.computeIfAbsent(
+        configProperties,
+        props -> {
+          Optional<String> credsPath =
+              ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getConfiguredValueAsOptional(props);
+          if (credsPath.isPresent()) {
+            try (FileInputStream fis = new FileInputStream(credsPath.get())) {
+              return GoogleCredentials.fromStream(fis);
+            } catch (IOException e) {
+              throw new ConfigurationException(
+                  "Failed to load credentials from file: " + new File(credsPath.get()).getName(),
+                  e);
+            }
+          }
 
-    Optional<String> credsJson =
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(
-            configProperties);
-    if (credsJson.isPresent()) {
-      try (ByteArrayInputStream bais =
-          new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
-        return GoogleCredentials.fromStream(bais);
-      } catch (IOException e) {
-        throw new ConfigurationException("Failed to load credentials from JSON string", e);
-      }
-    }
+          Optional<String> credsJson =
+              ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getConfiguredValueAsOptional(props);
+          if (credsJson.isPresent()) {
+            try (ByteArrayInputStream bais =
+                new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
+              return GoogleCredentials.fromStream(bais);
+            } catch (IOException e) {
+              throw new ConfigurationException("Failed to load credentials from JSON string", e);
+            }
+          }
 
-    try {
-      return GoogleCredentials.getApplicationDefault();
-    } catch (IOException e) {
-      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-    }
+          try {
+            return GoogleCredentials.getApplicationDefault();
+          } catch (IOException e) {
+            throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+          }
+        });
   }
 
   @Override

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -147,7 +147,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
         throw new ConfigurationException("Credentials file not found: " + file.getName());
       }
       try (FileInputStream fis = new FileInputStream(file)) {
-        return ServiceAccountCredentials.fromStream(fis);
+        return ServiceAccountCredentials.fromStream(fis)
+            .createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
       } catch (IOException e) {
         throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }
@@ -159,7 +160,8 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     if (credsJson.isPresent()) {
       try (ByteArrayInputStream bais =
           new ByteArrayInputStream(credsJson.get().getBytes(StandardCharsets.UTF_8))) {
-        return ServiceAccountCredentials.fromStream(bais);
+        return ServiceAccountCredentials.fromStream(bais)
+            .createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
       } catch (IOException e) {
         throw new GoogleAuthException(Reason.FAILED_CREDENTIAL_CREATION, e);
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GoogleAuthException.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GoogleAuthException.java
@@ -29,7 +29,9 @@ public class GoogleAuthException extends RuntimeException {
     /** Indicates a failure to retrieve Google Application Default Credentials. */
     FAILED_ADC_RETRIEVAL("Unable to retrieve Google Application Default Credentials."),
     /** Indicates a failure to retrieve Google Application Default Credentials. */
-    FAILED_ADC_REFRESH("Unable to refresh Google Application Default Credentials.");
+    FAILED_ADC_REFRESH("Unable to refresh Google Application Default Credentials."),
+    /** Indicates a failure to create credentials from provided source. */
+    FAILED_CREDENTIAL_CREATION("Unable to create credentials from provided source.");
 
     private final String message;
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -51,7 +51,12 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
@@ -240,6 +245,103 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
                 assertThat(spanData.getAttributes().asMap())
                     .containsKey(AttributeKey.longKey("work_loop"));
               });
+    }
+  }
+
+  @Test
+  void testCredentialsLoadedFromFilePath() throws IOException {
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    
+    File tempFile = File.createTempFile("gcp-creds", ".json");
+    tempFile.deleteOnExit();
+    try (Writer writer = Files.newBufferedWriter(tempFile.toPath(), StandardCharsets.UTF_8)) {
+        writer.write("{}");
+    }
+    
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(), tempFile.getAbsolutePath());
+
+    prepareMockBehaviorForGoogleCredentials();
+    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+        Mockito.spy(OtlpGrpcSpanExporter.builder());
+    List<SpanData> exportedSpans = new ArrayList<>();
+    configureGrpcMockSpanExporter(
+        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+          .thenReturn(mockedGoogleCredentials);
+
+      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+      
+      googleCredentialsMockedStatic.verify(() -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+    } finally {
+        System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
+    }
+  }
+
+  @Test
+  void testCredentialsLoadedFromJsonString() throws IOException {
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty(), "{}");
+
+    prepareMockBehaviorForGoogleCredentials();
+    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+        Mockito.spy(OtlpGrpcSpanExporter.builder());
+    List<SpanData> exportedSpans = new ArrayList<>();
+    configureGrpcMockSpanExporter(
+        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+          .thenReturn(mockedGoogleCredentials);
+
+      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+      
+      googleCredentialsMockedStatic.verify(() -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+    } finally {
+        System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
+    }
+  }
+
+  @Test
+  void testFallbackToApplicationDefaultCredentials() throws IOException {
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    
+    prepareMockBehaviorForGoogleCredentials();
+    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+        Mockito.spy(OtlpGrpcSpanExporter.builder());
+    List<SpanData> exportedSpans = new ArrayList<>();
+    configureGrpcMockSpanExporter(
+        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockedGoogleCredentials);
+
+      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+      
+      googleCredentialsMockedStatic.verify(GoogleCredentials::getApplicationDefault, Mockito.atLeastOnce());
     }
   }
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -283,7 +283,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
         serviceAccountCredentialsMockedStatic.verify(
-            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)),
+            Mockito.atLeastOnce());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
@@ -318,7 +319,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
         serviceAccountCredentialsMockedStatic.verify(
-            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)),
+            Mockito.atLeastOnce());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
@@ -344,10 +346,10 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
       try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class);
-           MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
-          Mockito.mockStatic(ServiceAccountCredentials.class)) {
-        
+              Mockito.mockStatic(GoogleCredentials.class);
+          MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+              Mockito.mockStatic(ServiceAccountCredentials.class)) {
+
         googleCredentialsMockedStatic
             .when(GoogleCredentials::getApplicationDefault)
             .thenReturn(mockedGoogleCredentials);
@@ -392,10 +394,10 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
       try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class);
-           MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
-          Mockito.mockStatic(ServiceAccountCredentials.class)) {
-        
+              Mockito.mockStatic(GoogleCredentials.class);
+          MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+              Mockito.mockStatic(ServiceAccountCredentials.class)) {
+
         serviceAccountCredentialsMockedStatic
             .when(() -> ServiceAccountCredentials.fromStream(any(InputStream.class)))
             .thenReturn(mockedGoogleCredentials);
@@ -403,7 +405,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
         serviceAccountCredentialsMockedStatic.verify(
-            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)),
+            Mockito.atLeastOnce());
         googleCredentialsMockedStatic.verify(
             GoogleCredentials::getApplicationDefault, Mockito.never());
       }
@@ -422,11 +425,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
     System.setProperty(
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
     System.setProperty(
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(), "/non/existent/path.json");
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(),
+        "/non/existent/path.json");
 
     try {
       OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-      
+
       assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter))
           .isInstanceOf(ConfigurationException.class)
           .hasMessageContaining("Credentials file not found");
@@ -448,7 +452,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
     try {
       OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-      
+
       try (MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
           Mockito.mockStatic(ServiceAccountCredentials.class)) {
         serviceAccountCredentialsMockedStatic
@@ -457,7 +461,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
         assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter))
             .isInstanceOf(GoogleAuthException.class)
-            .hasMessageContaining(GoogleAuthException.Reason.FAILED_CREDENTIAL_CREATION.getMessage());
+            .hasMessageContaining(
+                GoogleAuthException.Reason.FAILED_CREDENTIAL_CREATION.getMessage());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -250,39 +250,44 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
   @Test
   void testCredentialsLoadedFromFilePath() throws IOException {
+    File tempFile = File.createTempFile("gcp-creds", ".json");
+    tempFile.deleteOnExit();
+    try (Writer writer = Files.newBufferedWriter(tempFile.toPath(), StandardCharsets.UTF_8)) {
+      writer.write("{}");
+    }
+
     System.setProperty(
         ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
     System.setProperty(
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
-    
-    File tempFile = File.createTempFile("gcp-creds", ".json");
-    tempFile.deleteOnExit();
-    try (Writer writer = Files.newBufferedWriter(tempFile.toPath(), StandardCharsets.UTF_8)) {
-        writer.write("{}");
-    }
-    
     System.setProperty(
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(), tempFile.getAbsolutePath());
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(),
+        tempFile.getAbsolutePath());
 
-    prepareMockBehaviorForGoogleCredentials();
-    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
-        Mockito.spy(OtlpGrpcSpanExporter.builder());
-    List<SpanData> exportedSpans = new ArrayList<>();
-    configureGrpcMockSpanExporter(
-        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+    try {
+      prepareMockBehaviorForGoogleCredentials();
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+          Mockito.spy(OtlpGrpcSpanExporter.builder());
+      List<SpanData> exportedSpans = new ArrayList<>();
+      configureGrpcMockSpanExporter(
+          mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-        Mockito.mockStatic(GoogleCredentials.class)) {
-      googleCredentialsMockedStatic
-          .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
-          .thenReturn(mockedGoogleCredentials);
+      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+          Mockito.mockStatic(GoogleCredentials.class)) {
+        googleCredentialsMockedStatic
+            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+            .thenReturn(mockedGoogleCredentials);
 
-      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
-      
-      googleCredentialsMockedStatic.verify(() -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+
+        googleCredentialsMockedStatic.verify(
+            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+      }
     } finally {
-        System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
     }
   }
 
@@ -292,29 +297,32 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
     System.setProperty(
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
-    
-    System.setProperty(
-        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty(), "{}");
+    System.setProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty(), "{}");
 
-    prepareMockBehaviorForGoogleCredentials();
-    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
-        Mockito.spy(OtlpGrpcSpanExporter.builder());
-    List<SpanData> exportedSpans = new ArrayList<>();
-    configureGrpcMockSpanExporter(
-        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+    try {
+      prepareMockBehaviorForGoogleCredentials();
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+          Mockito.spy(OtlpGrpcSpanExporter.builder());
+      List<SpanData> exportedSpans = new ArrayList<>();
+      configureGrpcMockSpanExporter(
+          mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-        Mockito.mockStatic(GoogleCredentials.class)) {
-      googleCredentialsMockedStatic
-          .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
-          .thenReturn(mockedGoogleCredentials);
+      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+          Mockito.mockStatic(GoogleCredentials.class)) {
+        googleCredentialsMockedStatic
+            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+            .thenReturn(mockedGoogleCredentials);
 
-      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
-      
-      googleCredentialsMockedStatic.verify(() -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+
+        googleCredentialsMockedStatic.verify(
+            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+      }
     } finally {
-        System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
     }
   }
 
@@ -324,24 +332,79 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
     System.setProperty(
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
-    
-    prepareMockBehaviorForGoogleCredentials();
-    OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
-    OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
-        Mockito.spy(OtlpGrpcSpanExporter.builder());
-    List<SpanData> exportedSpans = new ArrayList<>();
-    configureGrpcMockSpanExporter(
-        mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-        Mockito.mockStatic(GoogleCredentials.class)) {
-      googleCredentialsMockedStatic
-          .when(GoogleCredentials::getApplicationDefault)
-          .thenReturn(mockedGoogleCredentials);
+    try {
+      prepareMockBehaviorForGoogleCredentials();
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+          Mockito.spy(OtlpGrpcSpanExporter.builder());
+      List<SpanData> exportedSpans = new ArrayList<>();
+      configureGrpcMockSpanExporter(
+          mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-      buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
-      
-      googleCredentialsMockedStatic.verify(GoogleCredentials::getApplicationDefault, Mockito.atLeastOnce());
+      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+          Mockito.mockStatic(GoogleCredentials.class)) {
+        googleCredentialsMockedStatic
+            .when(GoogleCredentials::getApplicationDefault)
+            .thenReturn(mockedGoogleCredentials);
+
+        buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+
+        googleCredentialsMockedStatic.verify(
+            GoogleCredentials::getApplicationDefault, Mockito.atLeastOnce());
+        googleCredentialsMockedStatic.verify(
+            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.never());
+      }
+    } finally {
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
+    }
+  }
+
+  @Test
+  void testCredentialsPathTakesPrecedenceOverJson() throws IOException {
+    File tempFile = File.createTempFile("gcp-creds", ".json");
+    tempFile.deleteOnExit();
+    try (Writer writer = Files.newBufferedWriter(tempFile.toPath(), StandardCharsets.UTF_8)) {
+      writer.write("{}");
+    }
+
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(),
+        tempFile.getAbsolutePath());
+    System.setProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty(), "{}");
+
+    try {
+      prepareMockBehaviorForGoogleCredentials();
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      OtlpGrpcSpanExporterBuilder spyOtlpGrpcSpanExporterBuilder =
+          Mockito.spy(OtlpGrpcSpanExporter.builder());
+      List<SpanData> exportedSpans = new ArrayList<>();
+      configureGrpcMockSpanExporter(
+          mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
+
+      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+          Mockito.mockStatic(GoogleCredentials.class)) {
+        googleCredentialsMockedStatic
+            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+            .thenReturn(mockedGoogleCredentials);
+
+        buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
+
+        googleCredentialsMockedStatic.verify(
+            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        googleCredentialsMockedStatic.verify(
+            GoogleCredentials::getApplicationDefault, Mockito.never());
+      }
+    } finally {
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
     }
   }
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.common.AttributeKey;
@@ -96,7 +97,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   private static final String DUMMY_GCP_QUOTA_PROJECT_ID = "my-gcp-quota-project-id";
   private static final Random TEST_RANDOM = new Random();
 
-  @Mock private GoogleCredentials mockedGoogleCredentials;
+  @Mock private ServiceAccountCredentials mockedGoogleCredentials;
 
   @Captor private ArgumentCaptor<Supplier<Map<String, String>>> traceHeaderSupplierCaptor;
   @Captor private ArgumentCaptor<Supplier<Map<String, String>>> metricHeaderSupplierCaptor;
@@ -273,16 +274,16 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       configureGrpcMockSpanExporter(
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class)) {
-        googleCredentialsMockedStatic
-            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+      try (MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+          Mockito.mockStatic(ServiceAccountCredentials.class)) {
+        serviceAccountCredentialsMockedStatic
+            .when(() -> ServiceAccountCredentials.fromStream(any(InputStream.class)))
             .thenReturn(mockedGoogleCredentials);
 
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
-        googleCredentialsMockedStatic.verify(
-            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        serviceAccountCredentialsMockedStatic.verify(
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
@@ -308,16 +309,16 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       configureGrpcMockSpanExporter(
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
-      try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class)) {
-        googleCredentialsMockedStatic
-            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+      try (MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+          Mockito.mockStatic(ServiceAccountCredentials.class)) {
+        serviceAccountCredentialsMockedStatic
+            .when(() -> ServiceAccountCredentials.fromStream(any(InputStream.class)))
             .thenReturn(mockedGoogleCredentials);
 
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
-        googleCredentialsMockedStatic.verify(
-            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        serviceAccountCredentialsMockedStatic.verify(
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
@@ -343,7 +344,10 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
       try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class)) {
+          Mockito.mockStatic(GoogleCredentials.class);
+           MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+          Mockito.mockStatic(ServiceAccountCredentials.class)) {
+        
         googleCredentialsMockedStatic
             .when(GoogleCredentials::getApplicationDefault)
             .thenReturn(mockedGoogleCredentials);
@@ -352,8 +356,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
         googleCredentialsMockedStatic.verify(
             GoogleCredentials::getApplicationDefault, Mockito.atLeastOnce());
-        googleCredentialsMockedStatic.verify(
-            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.never());
+        serviceAccountCredentialsMockedStatic.verify(
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.never());
       }
     } finally {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
@@ -388,15 +392,18 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           mockOtlpGrpcSpanExporter, spyOtlpGrpcSpanExporterBuilder, exportedSpans);
 
       try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-          Mockito.mockStatic(GoogleCredentials.class)) {
-        googleCredentialsMockedStatic
-            .when(() -> GoogleCredentials.fromStream(any(InputStream.class)))
+          Mockito.mockStatic(GoogleCredentials.class);
+           MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+          Mockito.mockStatic(ServiceAccountCredentials.class)) {
+        
+        serviceAccountCredentialsMockedStatic
+            .when(() -> ServiceAccountCredentials.fromStream(any(InputStream.class)))
             .thenReturn(mockedGoogleCredentials);
 
         buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter);
 
-        googleCredentialsMockedStatic.verify(
-            () -> GoogleCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
+        serviceAccountCredentialsMockedStatic.verify(
+            () -> ServiceAccountCredentials.fromStream(any(InputStream.class)), Mockito.atLeastOnce());
         googleCredentialsMockedStatic.verify(
             GoogleCredentials::getApplicationDefault, Mockito.never());
       }
@@ -404,6 +411,57 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
       System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
+    }
+  }
+
+  @Test
+  void testCredentialsFileNodeFoundThrowsConfigurationException() {
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty(), "/non/existent/path.json");
+
+    try {
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      
+      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter))
+          .isInstanceOf(ConfigurationException.class)
+          .hasMessageContaining("Credentials file not found");
+    } finally {
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_PATH.getSystemProperty());
+    }
+  }
+
+  @Test
+  void testMalformedCredentialsJsonThrowsGoogleAuthException() {
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty(), DUMMY_GCP_RESOURCE_PROJECT_ID);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty(), SIGNAL_TYPE_ALL);
+    System.setProperty(
+        ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty(), "malformed_json");
+
+    try {
+      OtlpGrpcSpanExporter mockOtlpGrpcSpanExporter = Mockito.mock(OtlpGrpcSpanExporter.class);
+      
+      try (MockedStatic<ServiceAccountCredentials> serviceAccountCredentialsMockedStatic =
+          Mockito.mockStatic(ServiceAccountCredentials.class)) {
+        serviceAccountCredentialsMockedStatic
+            .when(() -> ServiceAccountCredentials.fromStream(any(InputStream.class)))
+            .thenThrow(new IOException("Malformed JSON"));
+
+        assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpGrpcSpanExporter))
+            .isInstanceOf(GoogleAuthException.class)
+            .hasMessageContaining(GoogleAuthException.Reason.FAILED_CREDENTIAL_CREATION.getMessage());
+      }
+    } finally {
+      System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_PROJECT.getSystemProperty());
+      System.clearProperty(ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getSystemProperty());
       System.clearProperty(ConfigurableOption.GOOGLE_CLOUD_CREDENTIALS_JSON.getSystemProperty());
     }
   }


### PR DESCRIPTION
# feat(gcp-auth-extension): Support custom credentials via configuration properties

## Description
Currently, `gcp-auth-extension` is hardcoded to use Application Default Credentials (ADC). This PR adds support for specifying custom Service Account credentials via configuration properties (file path or JSON string), while maintaining backward compatibility by falling back to ADC.

## Key Changes

### `gcp-auth-extension`

*   **New Properties:** Added `google.cloud.credentials.path` and `google.cloud.credentials.json` options in `ConfigurableOption.java`.
*   **Lazy & Cached Resolution:** Moved credentials resolution to be lazy and cached per `ConfigProperties` instance in `GcpAuthAutoConfigurationCustomizerProvider.java` to avoid redundant I/O.
*   **Type-Safe Loading:** Uses `ServiceAccountCredentials.fromStream` instead of the obsolete generic `GoogleCredentials.fromStream` to address security concerns.
*   **Improved Error Handling:** Distinguishes between a missing file (`ConfigurationException`) and a failure to create credentials (`GoogleAuthException`).
*   **Tests:** Added unit tests for file path, JSON string, precedence rules, missing files, and malformed JSON.
*   **Docs:** Updated Javadoc to clarify that both relative and absolute paths are supported, and to reflect the new capabilities.

## Verification Results
*   Executed unit tests: `./gradlew :gcp-auth-extension:test` -> **BUILD SUCCESSFUL**
