### PR TITLE
Correct attribute name in readme

### DIFF
--- a/azure-resources/README.md
+++ b/azure-resources/README.md
@@ -6,9 +6,9 @@ The following OpenTelemetry semantic conventions will be detected:
 
 | Resource attribute          | VM       | Functions       | App Service       | Containers           |
 |-----------------------------|----------|-----------------|-------------------|----------------------|
-| cloud.platform              | azure_vm | azure_functions | azure_app_service | azure_container_apps |
+| cloud.platform              | azure.vm | azure.functions | azure.app_service | azure.container_apps |
 | cloud.provider              | azure    | azure           | azure             | azure                |
-| cloud.resource.id           | auto     |                 | auto              |                      |
+| cloud.resource_id           | auto     |                 | auto              |                      |
 | cloud.region                | auto     | auto            | auto              |                      |
 | deployment.environment.name |          |                 | auto              |                      |
 | host.id                     | auto     |                 | auto              |                      |
@@ -25,7 +25,7 @@ The following OpenTelemetry semantic conventions will be detected:
 | faas.name                   |          | auto            |                   |                      |
 | faas.version                |          | auto            |                   |                      |
 | faas.instance               |          | auto            |                   |                      |
-| faas.faas.max_memory        |          | auto            |                   |                      |
+| faas.max_memory             |          | auto            |                   |                      |
 
 ## Component Owners
 

--- a/azure-resources/README.md
+++ b/azure-resources/README.md
@@ -4,28 +4,28 @@ This module provides Azure resource detectors for OpenTelemetry.
 
 The following OpenTelemetry semantic conventions will be detected:
 
-| Resource attribute      | VM       | Functions       | App Service       | Containers           |
-|-------------------------|----------|-----------------|-------------------|----------------------|
-| cloud.platform          | azure_vm | azure_functions | azure_app_service | azure_container_apps |
-| cloud.provider          | azure    | azure           | azure             | azure                |
-| cloud.resource.id       | auto     |                 | auto              |                      |
-| cloud.region            | auto     | auto            | auto              |                      |
-| deployment.environment  |          |                 | auto              |                      |
-| host.id                 | auto     |                 | auto              |                      |
-| host.name               | auto     |                 |                   |                      |
-| host.type               | auto     |                 |                   |                      |
-| os.type                 | auto     |                 |                   |                      |
-| os.version              | auto     |                 |                   |                      |
-| azure.vm.scaleset.name  | auto     |                 |                   |                      |
-| azure.vm.sku            | auto     |                 |                   |                      |
-| service.name            |          |                 | auto              | auto                 |
-| service.version         |          |                 |                   | auto                 |
-| service.instance.id     |          |                 | auto              | auto                 |
-| azure.app.service.stamp |          |                 | auto              |                      |
-| faas.name               |          | auto            |                   |                      |
-| faas.version            |          | auto            |                   |                      |
-| faas.instance           |          | auto            |                   |                      |
-| faas.faas.max_memory    |          | auto            |                   |                      |
+| Resource attribute          | VM       | Functions       | App Service       | Containers           |
+|-----------------------------|----------|-----------------|-------------------|----------------------|
+| cloud.platform              | azure_vm | azure_functions | azure_app_service | azure_container_apps |
+| cloud.provider              | azure    | azure           | azure             | azure                |
+| cloud.resource.id           | auto     |                 | auto              |                      |
+| cloud.region                | auto     | auto            | auto              |                      |
+| deployment.environment.name |          |                 | auto              |                      |
+| host.id                     | auto     |                 | auto              |                      |
+| host.name                   | auto     |                 |                   |                      |
+| host.type                   | auto     |                 |                   |                      |
+| os.type                     | auto     |                 |                   |                      |
+| os.version                  | auto     |                 |                   |                      |
+| azure.vm.scaleset.name      | auto     |                 |                   |                      |
+| azure.vm.sku                | auto     |                 |                   |                      |
+| service.name                |          |                 | auto              | auto                 |
+| service.version             |          |                 |                   | auto                 |
+| service.instance.id         |          |                 | auto              | auto                 |
+| azure.app.service.stamp     |          |                 | auto              |                      |
+| faas.name                   |          | auto            |                   |                      |
+| faas.version                |          | auto            |                   |                      |
+| faas.instance               |          | auto            |                   |                      |
+| faas.faas.max_memory        |          | auto            |                   |                      |
 
 ## Component Owners
 

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.azure.resource;
 
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CloudPlatformIncubatingValues.AZURE_CONTAINER_APPS;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
@@ -54,8 +55,7 @@ public final class AzureContainersResourceProvider extends CloudResourceProvider
       return Attributes.empty();
     }
 
-    AttributesBuilder builder =
-        AzureVmResourceProvider.azureAttributeBuilder("azure_container_apps");
+    AttributesBuilder builder = AzureVmResourceProvider.azureAttributeBuilder(AZURE_CONTAINER_APPS);
 
     AzureEnvVarPlatform.addAttributesFromEnv(ENV_VAR_MAPPING, env, builder);
 

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/IncubatingAttributes.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/IncubatingAttributes.java
@@ -24,6 +24,7 @@ final class IncubatingAttributes {
     public static final String AZURE_AKS = "azure.aks";
     public static final String AZURE_FUNCTIONS = "azure.functions";
     public static final String AZURE_APP_SERVICE = "azure.app_service";
+    public static final String AZURE_CONTAINER_APPS = "azure.container_apps";
 
     private CloudPlatformIncubatingValues() {}
   }

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureContainersResourceProviderTest.java
@@ -11,6 +11,7 @@ import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PLATFORM;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PROVIDER;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CloudPlatformIncubatingValues.AZURE_CONTAINER_APPS;
 
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.sdk.testing.assertj.AttributesAssert;
@@ -34,7 +35,7 @@ class AzureContainersResourceProviderTest {
   void defaultValues() {
     createResource(DEFAULT_ENV_VARS)
         .containsEntry(CLOUD_PROVIDER, "azure")
-        .containsEntry(CLOUD_PLATFORM, "azure_container_apps")
+        .containsEntry(CLOUD_PLATFORM, AZURE_CONTAINER_APPS)
         .containsEntry(SERVICE_NAME, TEST_APP_NAME)
         .containsEntry(SERVICE_INSTANCE_ID, TEST_REPLICA_NAME)
         .containsEntry(SERVICE_VERSION, TEST_REVISION);


### PR DESCRIPTION
Code uses `deployment.environment.name` not `deployment.environment`. Other changes where pointed out by copilot.