### PR TITLE
[opamp] Improve error handling

### DIFF
--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -154,8 +154,8 @@ public final class HttpRequestService implements RequestService {
     try (HttpSender.Response response = future.get(30, TimeUnit.SECONDS)) {
       getCallback().onConnectionSuccess();
       if (isSuccessful(response)) {
-        handleHttpSuccess(
-            Response.create(ServerToAgent.ADAPTER.decode(response.bodyInputStream())));
+        ServerToAgent serverToAgent = ServerToAgent.ADAPTER.decode(response.bodyInputStream());
+        handleHttpSuccess(Response.create(serverToAgent));
       } else {
         handleHttpError(response);
       }

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -153,8 +153,8 @@ public final class HttpRequestService implements RequestService {
         requestSender.send(outputStream -> outputStream.write(data), data.length);
     try (HttpSender.Response response = future.get(30, TimeUnit.SECONDS)) {
       if (isSuccessful(response)) {
-        getCallback().onConnectionSuccess();
         ServerToAgent serverToAgent = ServerToAgent.ADAPTER.decode(response.bodyInputStream());
+        getCallback().onConnectionSuccess();
         handleHttpSuccess(Response.create(serverToAgent));
       } else {
         handleHttpError(response);

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -159,9 +159,6 @@ public final class HttpRequestService implements RequestService {
       } else {
         handleHttpError(response);
       }
-    } catch (IllegalStateException e) {
-      getCallback().onRequestFailed(e);
-      connectionStatus.retryAfter(null);
     } catch (IOException | InterruptedException | TimeoutException e) {
       getCallback().onConnectionFailed(e);
       connectionStatus.retryAfter(null);
@@ -171,6 +168,9 @@ public final class HttpRequestService implements RequestService {
       } else {
         getCallback().onConnectionFailed(e);
       }
+      connectionStatus.retryAfter(null);
+    } catch (RuntimeException e) {
+      getCallback().onRequestFailed(e);
       connectionStatus.retryAfter(null);
     }
   }

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -152,8 +152,8 @@ public final class HttpRequestService implements RequestService {
     CompletableFuture<HttpSender.Response> future =
         requestSender.send(outputStream -> outputStream.write(data), data.length);
     try (HttpSender.Response response = future.get(30, TimeUnit.SECONDS)) {
-      getCallback().onConnectionSuccess();
       if (isSuccessful(response)) {
+        getCallback().onConnectionSuccess();
         ServerToAgent serverToAgent = ServerToAgent.ADAPTER.decode(response.bodyInputStream());
         handleHttpSuccess(Response.create(serverToAgent));
       } else {

--- a/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
+++ b/opamp-client/src/main/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestService.java
@@ -159,6 +159,9 @@ public final class HttpRequestService implements RequestService {
       } else {
         handleHttpError(response);
       }
+    } catch (IllegalStateException e) {
+      getCallback().onRequestFailed(e);
+      connectionStatus.retryAfter(null);
     } catch (IOException | InterruptedException | TimeoutException e) {
       getCallback().onConnectionFailed(e);
       connectionStatus.retryAfter(null);

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -25,8 +25,10 @@ import io.opentelemetry.opamp.client.internal.request.delay.PeriodicDelay;
 import io.opentelemetry.opamp.client.internal.response.Response;
 import io.opentelemetry.opamp.client.request.service.RequestService;
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -133,8 +135,9 @@ class HttpRequestServiceTest {
   }
 
   @Test
-  void verifySuccessWithInvalidBodyIsConsideredFailure() {
+  void verifySuccessWithInvalidBodyIsConsideredConnectionFailure() {
     ServerToAgent serverToAgent = new ServerToAgent.Builder().build();
+    // This will generate an EOFException
     byte[] responseBody = "kablooey!!!".getBytes(UTF_8);
     HttpSender.Response httpResponse = createFailedResponse(200, responseBody, null);
     requestSender.enqueueResponse(httpResponse);
@@ -145,7 +148,25 @@ class HttpRequestServiceTest {
     verify(callback, never()).onRequestSuccess(Response.create(serverToAgent));
     verify(callback, never()).onRequestFailed(any());
     verify(callback, never()).onConnectionSuccess();
-    verify(callback).onConnectionFailed(any());
+    verify(callback).onConnectionFailed(any(EOFException.class));
+  }
+
+  @Test
+  void verifyIllegalStateExceptionInParsingIsConsideredRequestFailure() {
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().build();
+    byte[] responseBody = new byte[9024];
+    // This will generate an IllegalStateException
+    Arrays.fill(responseBody, (byte) 0x11);
+    HttpSender.Response httpResponse = createFailedResponse(200, responseBody, null);
+    requestSender.enqueueResponse(httpResponse);
+
+    httpRequestService.sendRequest();
+
+    verifySingleRequestSent();
+    verify(callback, never()).onRequestSuccess(Response.create(serverToAgent));
+    verify(callback, never()).onConnectionSuccess();
+    verify(callback, never()).onConnectionFailed(any());
+    verify(callback).onRequestFailed(any(IllegalStateException.class));
   }
 
   @Test

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -114,6 +115,20 @@ class HttpRequestServiceTest {
     verifySingleRequestSent();
     verifyRequestSuccessCallback(serverToAgent);
     verify(callback).onConnectionSuccess();
+  }
+
+  @Test
+  void verifySendingRequest_successNotCalledForNon200() {
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().build();
+    HttpSender.Response httpResponse = createFailedResponse(403);
+    requestSender.enqueueResponse(httpResponse);
+
+    httpRequestService.sendRequest();
+
+    verifySingleRequestSent();
+    verify(callback, never()).onRequestSuccess(Response.create(serverToAgent));
+    verify(callback, never()).onConnectionSuccess();
+    verifyRequestFailedCallback(403);
   }
 
   @Test

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.opamp.client.internal.request.service;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -129,6 +130,22 @@ class HttpRequestServiceTest {
     verify(callback, never()).onRequestSuccess(Response.create(serverToAgent));
     verify(callback, never()).onConnectionSuccess();
     verifyRequestFailedCallback(403);
+  }
+
+  @Test
+  void verifySuccessWithInvalidBodyIsConsideredFailure() {
+    ServerToAgent serverToAgent = new ServerToAgent.Builder().build();
+    byte[] responseBody = "kablooey!!!".getBytes(UTF_8);
+    HttpSender.Response httpResponse = createFailedResponse(200, responseBody, null);
+    requestSender.enqueueResponse(httpResponse);
+
+    httpRequestService.sendRequest();
+
+    verifySingleRequestSent();
+    verify(callback, never()).onRequestSuccess(Response.create(serverToAgent));
+    verify(callback, never()).onRequestFailed(any());
+    verify(callback, never()).onConnectionSuccess();
+    verify(callback).onConnectionFailed(any());
   }
 
   @Test
@@ -333,9 +350,23 @@ class HttpRequestServiceTest {
   }
 
   private static HttpSender.Response createFailedResponse(int statusCode) {
+    return createFailedResponse(statusCode, "".getBytes(UTF_8));
+  }
+
+  private static HttpSender.Response createFailedResponse(int statusCode, byte[] body) {
+    return createFailedResponse(statusCode, body, "Error message");
+  }
+
+  private static HttpSender.Response createFailedResponse(
+      int statusCode, byte[] body, String status) {
     HttpSender.Response response = mock();
     when(response.statusCode()).thenReturn(statusCode);
-    when(response.statusMessage()).thenReturn("Error message");
+    if (status != null) {
+      when(response.statusMessage()).thenReturn(status);
+    }
+    if (body.length > 0) {
+      when(response.bodyInputStream()).thenReturn(new ByteArrayInputStream(body));
+    }
     return response;
   }
 

--- a/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
+++ b/opamp-client/src/test/java/io/opentelemetry/opamp/client/internal/request/service/HttpRequestServiceTest.java
@@ -379,11 +379,11 @@ class HttpRequestServiceTest {
   }
 
   private static HttpSender.Response createFailedResponse(
-      int statusCode, byte[] body, String status) {
+      int statusCode, byte[] body, String statusMessage) {
     HttpSender.Response response = mock();
     when(response.statusCode()).thenReturn(statusCode);
-    if (status != null) {
-      when(response.statusMessage()).thenReturn(status);
+    if (statusMessage != null) {
+      when(response.statusMessage()).thenReturn(statusMessage);
     }
     if (body.length > 0) {
       when(response.bodyInputStream()).thenReturn(new ByteArrayInputStream(body));


### PR DESCRIPTION
Related to #2777, but probably does not resolve it.

There are two main ideas here, the main one is that the `onConnectionSuccess()` is moved into the `isSuccessful()` check and is also moved under the decoding of the server proto. With this, if the response is non-200 we don't consider this a successful connection, and if the server's response is invalid, we also do not consider this a valid connection.

There's another situation where the response body parsing can generate an ISE in the protobuf libs, and we turn that into a request failure.

There should be sufficient test coverage to handle these oddities. The semantics here are admittedly tricky/confusing, so I appreciate another set of eyes. 