### PR TITLE
ci: exclude generated markdown from flint

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -1,2 +1,9 @@
+[settings]
+exclude = [
+    ".github/pull_request_template.md",
+    "CHANGELOG.md",
+    "ibm-mq-metrics/docs/metrics.md",
+]
+
 [checks.lychee]
 check_all_local = true


### PR DESCRIPTION
## Summary

Follow-up for grafana/flint#213 baseline audit.

- exclude generated markdown from flint markdown lint baseline
- keep the fix scoped to the generated-file baseline failure

## Validation

- patched full flint audit passed locally:
  `mise x -- /home/gregor/source/flint/target/debug/flint run --full --short`
