### PR TITLE
Pin bouncycastle to 1.84 to fix CVE-2026-0636, CVE-2026-5588, CVE-2026-5598

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
     api("org.assertj:assertj-core:3.27.7")
     api("org.awaitility:awaitility:4.3.0")
     api("org.bouncycastle:bcpkix-jdk15on:1.70")
+    api("org.bouncycastle:bcpkix-jdk18on:1.84")
+    api("org.bouncycastle:bcprov-jdk18on:1.84")
     api("org.junit-pioneer:junit-pioneer:1.9.1")
     api("org.skyscreamer:jsonassert:1.5.3")
     api("org.apache.kafka:kafka-clients:4.2.0")

--- a/jmx-scraper/build.gradle.kts
+++ b/jmx-scraper/build.gradle.kts
@@ -39,8 +39,8 @@ testing {
         implementation("com.linecorp.armeria:armeria-junit5")
         implementation("com.linecorp.armeria:armeria-grpc")
         implementation("io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha")
-        implementation("org.bouncycastle:bcprov-jdk18on:1.84")
-        implementation("org.bouncycastle:bcpkix-jdk18on:1.84")
+        implementation("org.bouncycastle:bcprov-jdk18on")
+        implementation("org.bouncycastle:bcpkix-jdk18on")
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2768