### PR TITLE
use file_format: '1.0' now that declarative config is GA

### DIFF
--- a/aws-resources/src/test/resources/declarative-config.yaml
+++ b/aws-resources/src/test/resources/declarative-config.yaml
@@ -1,4 +1,4 @@
-file_format: "1.0-rc.1"
+file_format: "1.0"
 resource:
   detection/development:
     detectors:

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
@@ -21,7 +21,7 @@ class AwsComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "propagator:\n"
             + "  composite:\n"
             + "    - xray:\n"

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/internal/AwsComponentProviderTest.java
@@ -21,7 +21,7 @@ class AwsComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "propagator:\n"
             + "  composite:\n"
             + "    - xray:\n"

--- a/azure-resources/src/test/resources/declarative-config.yaml
+++ b/azure-resources/src/test/resources/declarative-config.yaml
@@ -1,4 +1,4 @@
-file_format: "1.0-rc.1"
+file_format: "1.0"
 resource:
   detection/development:
     detectors:

--- a/baggage-processor/README.md
+++ b/baggage-processor/README.md
@@ -32,7 +32,7 @@ You can configure the baggage span and log record processors using declarative Y
 For the tracer provider (span processor):
 
 ```yaml
-file_format: 1.0
+file_format: '1.0'
 tracer_provider:
   processors:
     - baggage:
@@ -43,7 +43,7 @@ tracer_provider:
 For the logger provider (log record processor):
 
 ```yaml
-file_format: 1.0
+file_format: '1.0'
 logger_provider:
   processors:
     - baggage:

--- a/baggage-processor/README.md
+++ b/baggage-processor/README.md
@@ -32,7 +32,7 @@ You can configure the baggage span and log record processors using declarative Y
 For the tracer provider (span processor):
 
 ```yaml
-file_format: 1.0-rc.1
+file_format: 1.0
 tracer_provider:
   processors:
     - baggage:
@@ -43,7 +43,7 @@ tracer_provider:
 For the logger provider (log record processor):
 
 ```yaml
-file_format: 1.0-rc.1
+file_format: 1.0
 logger_provider:
   processors:
     - baggage:

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
@@ -18,7 +18,7 @@ class BaggageLogRecordComponentProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - baggage:\n"

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
@@ -18,7 +18,7 @@ class BaggageLogRecordComponentProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - baggage:\n"

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
@@ -18,7 +18,7 @@ class BaggageSpanComponentProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - baggage:\n"

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
@@ -18,7 +18,7 @@ class BaggageSpanComponentProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - baggage:\n"

--- a/cel-sampler/src/test/resources/cel-sampler-config.yaml
+++ b/cel-sampler/src/test/resources/cel-sampler-config.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://github.com/open-telemetry/opentelemetry-configuration/raw/refs/tags/v1.0.0-rc.2/schema/opentelemetry_configuration.json
-file_format: 1.0
+file_format: "1.0"
 tracer_provider:
   sampler:
     parent_based:

--- a/cel-sampler/src/test/resources/cel-sampler-config.yaml
+++ b/cel-sampler/src/test/resources/cel-sampler-config.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://github.com/open-telemetry/opentelemetry-configuration/raw/refs/tags/v1.0.0-rc.2/schema/opentelemetry_configuration.json
-file_format: 1.0-rc.2
+file_format: 1.0
 tracer_provider:
   sampler:
     parent_based:

--- a/cel-sampler/src/test/resources/cel-sampler-config.yaml
+++ b/cel-sampler/src/test/resources/cel-sampler-config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://github.com/open-telemetry/opentelemetry-configuration/raw/refs/tags/v1.0.0-rc.2/schema/opentelemetry_configuration.json
+# yaml-language-server: $schema=https://github.com/open-telemetry/opentelemetry-configuration/raw/refs/tags/v1.0.0/schema/opentelemetry_configuration.json
 file_format: "1.0"
 tracer_provider:
   sampler:

--- a/cloudfoundry-resources/src/test/resources/declarative-config.yaml
+++ b/cloudfoundry-resources/src/test/resources/declarative-config.yaml
@@ -1,4 +1,4 @@
-file_format: "1.0-rc.1"
+file_format: "1.0"
 resource:
   detection/development:
     detectors:

--- a/inferred-spans/README.md
+++ b/inferred-spans/README.md
@@ -49,7 +49,7 @@ You can configure the inferred spans processor using declarative YAML configurat
 OpenTelemetry SDK. For example:
 
 ```yaml
-file_format: 1.0
+file_format: '1.0'
 tracer_provider:
   processors:
     - inferred_spans/development:

--- a/inferred-spans/README.md
+++ b/inferred-spans/README.md
@@ -49,7 +49,7 @@ You can configure the inferred spans processor using declarative YAML configurat
 OpenTelemetry SDK. For example:
 
 ```yaml
-file_format: 1.0-rc.1
+file_format: 1.0
 tracer_provider:
   processors:
     - inferred_spans/development:

--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/InferredSpansSpanProcessorProviderTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/InferredSpansSpanProcessorProviderTest.java
@@ -38,7 +38,7 @@ class InferredSpansSpanProcessorProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - inferred_spans/development:\n"
@@ -63,7 +63,7 @@ class InferredSpansSpanProcessorProviderTest {
   @Test
   void declarativeConfigDisabled() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - inferred_spans/development:\n"

--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/InferredSpansSpanProcessorProviderTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/InferredSpansSpanProcessorProviderTest.java
@@ -38,7 +38,7 @@ class InferredSpansSpanProcessorProviderTest {
   @Test
   void declarativeConfig() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - inferred_spans/development:\n"
@@ -63,7 +63,7 @@ class InferredSpansSpanProcessorProviderTest {
   @Test
   void declarativeConfigDisabled() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - inferred_spans/development:\n"

--- a/maven-extension/src/test/resources/declarative-config.yaml
+++ b/maven-extension/src/test/resources/declarative-config.yaml
@@ -1,4 +1,4 @@
-file_format: "1.0-rc.1"
+file_format: "1.0"
 resource:
   detection/development:
     detectors:

--- a/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
@@ -18,7 +18,7 @@ class EventToSpanBridgeComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - event_to_span_event_bridge:\n";

--- a/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
+++ b/processors/src/test/java/io/opentelemetry/contrib/eventbridge/internal/EventToSpanBridgeComponentProviderTest.java
@@ -18,7 +18,7 @@ class EventToSpanBridgeComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "logger_provider:\n"
             + "  processors:\n"
             + "    - event_to_span_event_bridge:\n";

--- a/samplers/src/test/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProviderTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProviderTest.java
@@ -37,7 +37,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "tracer_provider:\n"
             + "  sampler:\n"
             + "    parent_based:\n"

--- a/samplers/src/test/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProviderTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/sampler/internal/RuleBasedRoutingSamplerComponentProviderTest.java
@@ -37,7 +37,7 @@ class RuleBasedRoutingSamplerComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "tracer_provider:\n"
             + "  sampler:\n"
             + "    parent_based:\n"

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -29,7 +29,7 @@ SDK when included in the application runtime dependencies.
 You can enable the stacktrace span processor using declarative YAML configuration with the OpenTelemetry SDK. For example:
 
 ```yaml
-file_format: 1.0-rc.1
+file_format: 1.0
 tracer_provider:
   processors:
     - stacktrace/development:

--- a/span-stacktrace/README.md
+++ b/span-stacktrace/README.md
@@ -29,7 +29,7 @@ SDK when included in the application runtime dependencies.
 You can enable the stacktrace span processor using declarative YAML configuration with the OpenTelemetry SDK. For example:
 
 ```yaml
-file_format: 1.0
+file_format: '1.0'
 tracer_provider:
   processors:
     - stacktrace/development:

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceComponentProviderTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceComponentProviderTest.java
@@ -19,7 +19,7 @@ class StackTraceComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0-rc.1\n"
+        "file_format: 1.0\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - stacktrace/development: \n"

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceComponentProviderTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceComponentProviderTest.java
@@ -19,7 +19,7 @@ class StackTraceComponentProviderTest {
   @Test
   void endToEnd() {
     String yaml =
-        "file_format: 1.0\n"
+        "file_format: '1.0'\n"
             + "tracer_provider:\n"
             + "  processors:\n"
             + "    - stacktrace/development: \n"


### PR DESCRIPTION
Declarative configuration is now GA with version 1.0.

We have plenty of references to the release-candidates versions in examples and in tests, to avoid any confusion this PR replaces those with 1.0.