### PR TITLE
add toString implementation in the baggage processor

### DIFF
--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
@@ -49,6 +49,5 @@ public final class BaggageLogRecordProcessor implements LogRecordProcessor {
 
   @Override
   public String toString() {
-    return "BaggageLogRecordProcessor{" + "baggageKeyPredicate=" + baggageKeyPredicate + '}';
-  }
+    return "BaggageLogRecordProcessor{baggageKeyPredicate=" + baggageKeyPredicate + '}';}
 }

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
@@ -46,4 +46,9 @@ public final class BaggageLogRecordProcessor implements LogRecordProcessor {
               }
             });
   }
+
+  @Override
+  public String toString() {
+    return "BaggageLogRecordProcessor{" + "baggageKeyPredicate=" + baggageKeyPredicate + '}';
+  }
 }

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordProcessor.java
@@ -49,5 +49,6 @@ public final class BaggageLogRecordProcessor implements LogRecordProcessor {
 
   @Override
   public String toString() {
-    return "BaggageLogRecordProcessor{baggageKeyPredicate=" + baggageKeyPredicate + '}';}
+    return "BaggageLogRecordProcessor{baggageKeyPredicate=" + baggageKeyPredicate + '}';
+  }
 }

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
@@ -58,4 +58,9 @@ public final class BaggageSpanProcessor implements SpanProcessor {
   public boolean isEndRequired() {
     return false;
   }
+
+  @Override
+  public String toString() {
+    return "BaggageSpanProcessor{" + "baggageKeyPredicate=" + baggageKeyPredicate + '}';
+  }
 }

--- a/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
+++ b/baggage-processor/src/main/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanProcessor.java
@@ -61,6 +61,6 @@ public final class BaggageSpanProcessor implements SpanProcessor {
 
   @Override
   public String toString() {
-    return "BaggageSpanProcessor{" + "baggageKeyPredicate=" + baggageKeyPredicate + '}';
+    return "BaggageSpanProcessor{baggageKeyPredicate=" + baggageKeyPredicate + '}';
   }
 }

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
@@ -30,6 +30,9 @@ class BaggageLogRecordComponentProviderTest {
                 new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)))
             .getSdk();
 
-    assertThat(sdk).asString().contains("BaggageLogRecordProcessor");
+    assertThat(sdk)
+        .asString()
+        .contains("BaggageLogRecordProcessor")
+        .containsPattern("IncludeExcludePredicate.*, included=\\[foo], excluded=\\[bar]");
   }
 }

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageLogRecordComponentProviderTest.java
@@ -33,6 +33,7 @@ class BaggageLogRecordComponentProviderTest {
     assertThat(sdk)
         .asString()
         .contains("BaggageLogRecordProcessor")
-        .containsPattern("IncludeExcludePredicate.*, included=\\[foo], excluded=\\[bar]");
+        .contains("included=[foo]")
+        .contains("excluded=[bar]");
   }
 }

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
@@ -33,6 +33,7 @@ class BaggageSpanComponentProviderTest {
     assertThat(sdk)
         .asString()
         .contains("BaggageSpanProcessor")
-        .containsPattern("IncludeExcludePredicate.*, included=\\[foo], excluded=\\[bar]");
+        .contains("included=[foo]")
+        .contains("excluded=[bar]");
   }
 }

--- a/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
+++ b/baggage-processor/src/test/java/io/opentelemetry/contrib/baggage/processor/BaggageSpanComponentProviderTest.java
@@ -30,6 +30,9 @@ class BaggageSpanComponentProviderTest {
                 new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)))
             .getSdk();
 
-    assertThat(sdk).asString().contains("BaggageSpanProcessor");
+    assertThat(sdk)
+        .asString()
+        .contains("BaggageSpanProcessor")
+        .containsPattern("IncludeExcludePredicate.*, included=\\[foo], excluded=\\[bar]");
   }
 }


### PR DESCRIPTION
The current implementation of `BaggageLogRecordProcessor` and `BaggageSpanProcessor` do not implement `toString` which makes testing and debugging configuration harder, in particular when using declarative configuration.

This PR adds a simple implementation that delegates to the underlying `IncludeExcludePredicate` so we get the include/exclude patterns used in the `toString` result.