### PR TITLE
make span stacktrace ignore inferred spans by default

### DIFF
--- a/span-stacktrace/build.gradle.kts
+++ b/span-stacktrace/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
@@ -30,4 +29,7 @@ dependencies {
   testCompileOnly("com.google.auto.service:auto-service-annotations")
 
   testImplementation("io.opentelemetry:opentelemetry-exporter-logging")
+
+  // allows to test inferred spans that should be filtered-out
+  testCompileOnly(project(":inferred-spans"))
 }

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -59,6 +59,17 @@ public class StackTraceSpanProcessor implements ExtendedSpanProcessor {
     if (!filterPredicate.test(span)) {
       return;
     }
+
+    // inferred spans are generated from sampling, thus the span processor is not actually called
+    // on when the span is active, so the stack trace collection should be skipped.
+    //
+    // we only get such spans when inferred spans processor executes before this span processor
+    // which may be considered to be a configuration error.
+    boolean isInferred = span.getInstrumentationScopeInfo().getName().equals("inferred-spans");
+    if (isInferred) {
+      return;
+    }
+
     span.setAttribute(CodeAttributes.CODE_STACKTRACE, generateSpanEndStacktrace());
   }
 

--- a/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
+++ b/span-stacktrace/src/main/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessor.java
@@ -60,11 +60,11 @@ public class StackTraceSpanProcessor implements ExtendedSpanProcessor {
       return;
     }
 
-    // inferred spans are generated from sampling, thus the span processor is not actually called
-    // on when the span is active, so the stack trace collection should be skipped.
+    // Inferred spans are generated from sampling, so this span processor is not actually called
+    // when the span is active, and stack trace collection should be skipped.
     //
-    // we only get such spans when inferred spans processor executes before this span processor
-    // which may be considered to be a configuration error.
+    // We only get such spans when the inferred spans processor executes before this span
+    // processor, which may be considered a configuration error.
     boolean isInferred = span.getInstrumentationScopeInfo().getName().equals("inferred-spans");
     if (isInferred) {
       return;

--- a/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
+++ b/span-stacktrace/src/test/java/io/opentelemetry/contrib/stacktrace/StackTraceSpanProcessorTest.java
@@ -12,6 +12,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.contrib.inferredspans.InferredSpansProcessor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
@@ -49,10 +50,10 @@ class StackTraceSpanProcessorTest {
     // over duration threshold
     checkSpanWithStackTrace("1ms", msToNs(2));
     // under duration threshold
-    checkSpanWithoutStackTrace(YesPredicate.class, "2ms", msToNs(1));
+    checkSpanWithoutStackTrace(YesPredicate.class, "2ms", msToNs(1), "test");
 
     // filtering out span
-    checkSpanWithoutStackTrace(NoPredicate.class, "1ms", msToNs(20));
+    checkSpanWithoutStackTrace(NoPredicate.class, "1ms", msToNs(20), "test");
   }
 
   public static class YesPredicate implements Predicate<ReadableSpan> {
@@ -75,12 +76,12 @@ class StackTraceSpanProcessorTest {
     long expectedDefault = msToNs(5);
     checkSpanWithStackTrace(null, expectedDefault);
     checkSpanWithStackTrace(null, expectedDefault + 1);
-    checkSpanWithoutStackTrace(YesPredicate.class, null, expectedDefault - 1);
+    checkSpanWithoutStackTrace(YesPredicate.class, null, expectedDefault - 1, "test");
   }
 
   @Test
   void disabledConfig() {
-    checkSpanWithoutStackTrace(YesPredicate.class, "-1", 5);
+    checkSpanWithoutStackTrace(YesPredicate.class, "-1", 5, "test");
   }
 
   @Test
@@ -90,7 +91,13 @@ class StackTraceSpanProcessorTest {
         "1ms",
         Duration.ofMillis(1).toNanos(),
         sb -> sb.setAttribute(CodeAttributes.CODE_STACKTRACE, "hello"),
-        stacktrace -> assertThat(stacktrace).isEqualTo("hello"));
+        stacktrace -> assertThat(stacktrace).isEqualTo("hello"),
+        "test");
+  }
+
+  @Test
+  void spanFromInferredSpansIgnored() {
+    checkSpanWithoutStackTrace(null, "1ms", msToNs(1), InferredSpansProcessor.TRACER_NAME);
   }
 
   private static void checkSpanWithStackTrace(String minDurationString, long spanDurationNanos) {
@@ -102,19 +109,22 @@ class StackTraceSpanProcessorTest {
         (stackTrace) ->
             assertThat(stackTrace)
                 .describedAs("span stack trace should contain caller class name")
-                .contains(StackTraceSpanProcessorTest.class.getCanonicalName()));
+                .contains(StackTraceSpanProcessorTest.class.getCanonicalName()),
+        "test");
   }
 
   private static void checkSpanWithoutStackTrace(
       Class<? extends Predicate<?>> predicateClass,
       String minDurationString,
-      long spanDurationNanos) {
+      long spanDurationNanos,
+      String scopeName) {
     checkSpan(
         predicateClass,
         minDurationString,
         spanDurationNanos,
         Function.identity(),
-        (stackTrace) -> assertThat(stackTrace).describedAs("no stack trace expected").isNull());
+        (stackTrace) -> assertThat(stackTrace).describedAs("no stack trace expected").isNull(),
+        scopeName);
   }
 
   private static void checkSpan(
@@ -122,7 +132,8 @@ class StackTraceSpanProcessorTest {
       String minDurationString,
       long spanDurationNanos,
       Function<SpanBuilder, SpanBuilder> customizeSpanBuilder,
-      Consumer<String> stackTraceCheck) {
+      Consumer<String> stackTraceCheck,
+      String scopeName) {
 
     // must be re-created on every test as exporter is shut down on span processor close
     InMemorySpanExporter spansExporter = InMemorySpanExporter.create();
@@ -153,7 +164,7 @@ class StackTraceSpanProcessorTest {
 
     try (OpenTelemetrySdk sdk = sdkBuilder.build().getOpenTelemetrySdk()) {
 
-      Tracer tracer = sdk.getTracer("test");
+      Tracer tracer = sdk.getTracer(scopeName);
 
       Instant start = Instant.now();
       Instant end = start.plusNanos(spanDurationNanos);


### PR DESCRIPTION
The span stacktrace span processor captures the current thread stack trace when the span ends.

However, the inferred spans span processor produces spans that are not executed when the span is active as they are artificially generated from sampling data.

When the span stacktrace span processor is executed before the inferred spans, the inferred spans are naturally excluded, however when the stacktrace span processor is after then we have to explicitly exclude such spans. We can argue that this may be a mis-configuration in the span processor pipeline, but this creates an extra burden on user.

This is why the span stacktrace processor was created with the ability to provide a custom filter. The only known usage and filter implementation in that I'm aware of is in the Elastic (EDOT) distribution which is using the `is_inferred` span attribute to filter inferred spans.

With this change:
- inferred-spans are ignored by default for span stacktraces, hence making it easier for users
- we remove the need to use the `is_inferred` span attribute to detect span attributes, we can rely on the scope name (in a sense we trade one implementation detail to another)
- this exclusion is being tested in unit tests

Possible follow-up tasks
- remove the `is_inferred` span attribute in inferred spans: it is not part of semconv and should not be used by anyone after this change is effective
- deprecate the `filter` option in span stacktrace span processor.