### PR TITLE
[ibm-mq] Add expired message metric for IBM MQ queues

### DIFF
--- a/ibm-mq-metrics/config.yml
+++ b/ibm-mq-metrics/config.yml
@@ -142,6 +142,8 @@ metrics:
     enabled: true
   "ibm.mq.queue.depth.low.event":  # The number of low queue events
     enabled: true
+  "ibm.mq.expired.messages":  # Number of expired messages
+    enabled: true
   "ibm.mq.uncommitted.messages":  # Number of uncommitted messages
     enabled: true
   "ibm.mq.oldest.msg.age":  # Queue message oldest age

--- a/ibm-mq-metrics/docs/metrics.md
+++ b/ibm-mq-metrics/docs/metrics.md
@@ -351,9 +351,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [9] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [10] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[9] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[10] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -370,9 +370,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [10] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [11] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[10] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[11] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -389,9 +389,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [11] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [12] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[11] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[12] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -408,9 +408,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [12] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [13] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[12] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[13] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -427,9 +427,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [13] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [14] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[13] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[14] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -446,9 +446,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [14] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [15] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[14] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[15] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -465,9 +465,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [15] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [16] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[15] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[16] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -484,9 +484,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [16] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [17] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[16] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[17] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -548,9 +548,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [17] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [18] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[17] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[18] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -567,9 +567,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [18] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [19] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[18] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[19] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -586,9 +586,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [19] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [20] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[19] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[20] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -745,9 +745,9 @@
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [20] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [21] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[20] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[21] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -763,9 +763,9 @@
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [21] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [22] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[21] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[22] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -797,12 +797,12 @@
 | Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `service.name` | string | Logical name of the service. [22] | `Wordle`; `JMSService` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `user.name` | string | Short name or login/username of the user. [23] | `foo`; `root` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `service.name` | string | Logical name of the service. [23] | `Wordle`; `JMSService` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `user.name` | string | Short name or login/username of the user. [24] | `foo`; `root` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[22] `service.name`:** This is duplicated from otel semantic-conventions.
+**[23] `service.name`:** This is duplicated from otel semantic-conventions.
 
-**[23] `user.name`:** This is duplicated from otel semantic-conventions.
+**[24] `user.name`:** This is duplicated from otel semantic-conventions.
 
 
 
@@ -834,3 +834,5 @@
 |---|---|---|---|---|---|
 | `error.code` | string | The reason code associated with an error | `2038`; `2543`; `2009` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+

--- a/ibm-mq-metrics/docs/metrics.md
+++ b/ibm-mq-metrics/docs/metrics.md
@@ -834,5 +834,3 @@
 |---|---|---|---|---|---|
 | `error.code` | string | The reason code associated with an error | `2038`; `2543`; `2009` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-
-

--- a/ibm-mq-metrics/docs/metrics.md
+++ b/ibm-mq-metrics/docs/metrics.md
@@ -300,6 +300,25 @@
 
 
 
+## Metric `ibm.mq.expired.messages`
+
+| Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
+| -------- | --------------- | ----------- | -------------- | --------- |
+| `ibm.mq.expired.messages` | Gauge | `{message}` | Number of expired messages | ![Development](https://img.shields.io/badge/-development-blue) |
+
+
+### `ibm.mq.expired.messages` Attributes
+
+| Attribute  | Type | Description  | Examples  | [Requirement Level](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/) | Stability |
+|---|---|---|---|---|---|
+| `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [8] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+
+**[8] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+
+
+
 ## Metric `ibm.mq.uncommitted.messages`
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
@@ -313,9 +332,9 @@
 |---|---|---|---|---|---|
 | `ibm.mq.queue.manager` | string | The name of the IBM queue manager | `MQ1` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 | `ibm.mq.queue.type` | string | The queue type | `local-normal` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
-| `messaging.destination.name` | string | The system-specific name of the messaging operation. [8] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
+| `messaging.destination.name` | string | The system-specific name of the messaging operation. [9] | `dev/` | `Required` | ![Development](https://img.shields.io/badge/-development-blue) |
 
-**[8] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
+**[9] `messaging.destination.name`:** This is duplicated from otel semantic-conventions.
 
 
 

--- a/ibm-mq-metrics/model/metrics.yaml
+++ b/ibm-mq-metrics/model/metrics.yaml
@@ -249,6 +249,20 @@ groups:
         requirement_level: required
       - ref: messaging.destination.name
         requirement_level: required
+  - id: ibm.mq.expired.messages
+    type: metric
+    metric_name: ibm.mq.expired.messages
+    stability: development
+    brief: "Number of expired messages"
+    instrument: gauge
+    unit: "{message}"
+    attributes:
+      - ref: ibm.mq.queue.manager
+        requirement_level: required
+      - ref: messaging.destination.name
+        requirement_level: required
+      - ref: ibm.mq.queue.type
+        requirement_level: required
   - id: ibm.mq.uncommitted.messages
     type: metric
     metric_name: ibm.mq.uncommitted.messages

--- a/ibm-mq-metrics/src/integrationTest/resources/conf/test-config.yml
+++ b/ibm-mq-metrics/src/integrationTest/resources/conf/test-config.yml
@@ -122,6 +122,8 @@ metrics:
     enabled: true
   "ibm.mq.queue.depth.low.event":  # The number of low queue events
     enabled: true
+  "ibm.mq.expired.messages":  # Number of expired messages
+    enabled: true
   "ibm.mq.uncommitted.messages":  # Number of uncommitted messages
     enabled: true
   "ibm.mq.oldest.msg.age":  # Queue message oldest age

--- a/ibm-mq-metrics/src/integrationTest/resources/conf/test-queuemgr-config.yml
+++ b/ibm-mq-metrics/src/integrationTest/resources/conf/test-queuemgr-config.yml
@@ -94,6 +94,8 @@ metrics:
     enabled: true
   "ibm.mq.queue.depth.low.event":  # The number of low queue events
     enabled: true
+  "ibm.mq.expired.messages":  # Number of expired messages
+    enabled: true
   "ibm.mq.uncommitted.messages":  # Number of uncommitted messages
     enabled: true
   "ibm.mq.oldest.msg.age":  # Queue message oldest age

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/Metrics.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/Metrics.java
@@ -159,6 +159,15 @@ public final class Metrics {
         .build();
   }
 
+  public static LongGauge createIbmMqExpiredMessages(Meter meter) {
+    return meter
+        .gaugeBuilder("ibm.mq.expired.messages")
+        .ofLongs()
+        .setUnit("{message}")
+        .setDescription("Number of expired messages")
+        .build();
+  }
+
   public static LongGauge createIbmMqUncommittedMessages(Meter meter) {
     return meter
         .gaugeBuilder("ibm.mq.uncommitted.messages")

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/MetricsConfig.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/MetricsConfig.java
@@ -83,6 +83,10 @@ public final class MetricsConfig {
     return isEnabled("ibm.mq.queue.depth.low.event");
   }
 
+  public boolean isIbmMqExpiredMessagesEnabled() {
+    return isEnabled("ibm.mq.expired.messages");
+  }
+
   public boolean isIbmMqUncommittedMessagesEnabled() {
     return isEnabled("ibm.mq.uncommitted.messages");
   }

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/InquireQStatusCmdCollector.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/InquireQStatusCmdCollector.java
@@ -39,6 +39,7 @@ final class InquireQStatusCmdCollector implements Consumer<MetricsCollectorConte
         CMQCFC.MQIACF_CUR_MAX_FILE_SIZE,
         CMQCFC.MQIACF_OLDEST_MSG_AGE,
         CMQCFC.MQIACF_UNCOMMITTED_MSGS,
+        CMQCFC.MQIACF_EXPIRY_Q_COUNT,
         CMQCFC.MQIACF_Q_TIME_INDICATOR,
         CMQC.MQIA_CURRENT_Q_DEPTH,
       };

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/QueueCollectionBuddy.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metricscollector/QueueCollectionBuddy.java
@@ -109,6 +109,11 @@ final class QueueCollectionBuddy {
             Metrics.createIbmMqUncommittedMessages(meter),
             MetricsConfig::isIbmMqUncommittedMessagesEnabled));
     gauges.put(
+        CMQCFC.MQIACF_EXPIRY_Q_COUNT,
+        createAllowedGauge(
+            Metrics.createIbmMqExpiredMessages(meter),
+            MetricsConfig::isIbmMqExpiredMessagesEnabled));
+    gauges.put(
         CMQC.MQIA_MSG_DEQ_COUNT,
         createAllowedGauge(
             Metrics.createIbmMqMessageDeqCount(meter),

--- a/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/metricscollector/QueueCollectionBuddyTest.java
+++ b/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/metricscollector/QueueCollectionBuddyTest.java
@@ -72,6 +72,7 @@ class QueueCollectionBuddyTest {
                 "DEV.DEAD.LETTER.QUEUE",
                 new HashMap<>(
                     ImmutableMap.of(
+                        "ibm.mq.expired.messages", 2L,
                         "ibm.mq.oldest.msg.age", -1L,
                         "ibm.mq.uncommitted.messages", 0L,
                         "ibm.mq.onqtime.short_period", -1L,
@@ -80,6 +81,7 @@ class QueueCollectionBuddyTest {
                 "DEV.QUEUE.1",
                 new HashMap<>(
                     ImmutableMap.of(
+                        "ibm.mq.expired.messages", 3L,
                         "ibm.mq.oldest.msg.age", -1L,
                         "ibm.mq.uncommitted.messages", 10L,
                         "ibm.mq.onqtime.short_period", -1L,
@@ -166,41 +168,44 @@ class QueueCollectionBuddyTest {
       PCFMessage:
       MQCFH [type: 1, strucLength: 36, version: 1, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
       MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-      MQCFIL [type: 5, strucLength: 32, parameter: 1026 (MQIACF_Q_STATUS_ATTRS), count: 4, values: {2016, 1226, 1227, 1027}]
+      MQCFIL [type: 5, strucLength: 36, parameter: 1026 (MQIACF_Q_STATUS_ATTRS), count: 5, values: {2016, 1226, 1227, 1116, 1027}]
   */
   private static PCFMessage createPCFRequestForInquireQStatusCmd() {
     PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_STATUS);
     request.addParameter(CMQC.MQCA_Q_NAME, "*");
-    request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, new int[] {2016, 1226, 1227, 1027});
+    request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, new int[] {2016, 1226, 1227, 1116, 1027});
     return request;
   }
 
   /*
       0 = {PCFMessage@6026} "PCFMessage:
-      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 7]
       MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: AMQ.5AF1608820C7D76E                            ]
       MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
       MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 12]
       MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
       MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1116 (MQIACF_EXPIRY_Q_COUNT), value: 0]
       MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
 
       1 = {PCFMessage@6029} "PCFMessage:
-      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 7]
       MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
       MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
       MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
       MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
       MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1116 (MQIACF_EXPIRY_Q_COUNT), value: 2]
       MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
 
       2 = {PCFMessage@6030} "PCFMessage:
-      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 7]
       MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.QUEUE.1                                     ]
       MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
       MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 1]
       MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
       MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1116 (MQIACF_EXPIRY_Q_COUNT), value: 3]
       MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
   */
   private static PCFMessage[] createPCFResponseForInquireQStatusCmd() {
@@ -210,6 +215,7 @@ class QueueCollectionBuddyTest {
     response1.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 12);
     response1.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
     response1.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response1.addParameter(CMQCFC.MQIACF_EXPIRY_Q_COUNT, 0);
     response1.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
 
     PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 2, false);
@@ -218,6 +224,7 @@ class QueueCollectionBuddyTest {
     response2.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 0);
     response2.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
     response2.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response2.addParameter(CMQCFC.MQIACF_EXPIRY_Q_COUNT, 2);
     response2.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
 
     PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 1, false);
@@ -226,6 +233,7 @@ class QueueCollectionBuddyTest {
     response3.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 1);
     response3.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
     response3.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response3.addParameter(CMQCFC.MQIACF_EXPIRY_Q_COUNT, 3);
     response3.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 10);
 
     return new PCFMessage[] {response1, response2, response3};

--- a/ibm-mq-metrics/src/test/resources/conf/config.yml
+++ b/ibm-mq-metrics/src/test/resources/conf/config.yml
@@ -134,6 +134,8 @@ metrics:
     enabled: true
   "ibm.mq.queue.depth.low.event":  # The number of low queue events
     enabled: true
+  "ibm.mq.expired.messages":  # Number of expired messages
+    enabled: true
   "ibm.mq.uncommitted.messages":  # Number of uncommitted messages
     enabled: true
   "ibm.mq.oldest.msg.age":  # Queue message oldest age


### PR DESCRIPTION
Resolves #2788. Slopvomited with codex.

I don't love that the metric type is gauge, but it's consistent with `ibm.mq.uncommitted.messages` as mentioned in the original issue. We should also probably give some follow-up consideration to the metric names, since `committed` and `uncommitted` could (in concept) just be attributes/dimensions on some `ibm.mq.messages` counter...but let's leave data model redesign for a follow-up PR effort, as demand calls for it.


