### PR TITLE
Use sonatype guide dependency audit

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -22,8 +22,7 @@ private admin repo.
 
 - `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password
 - `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
-- `SONATYPE_OSS_INDEX_USER` - owned by [@trask](https://github.com/trask)
-- `SONATYPE_OSS_INDEX_PASSWORD` - owned by [@trask](https://github.com/trask)
+- `SONATYPE_GUIDE_PAT` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_KEY` - owned by [@trask](https://github.com/trask)
 - `SONATYPE_USER` - owned by [@trask](https://github.com/trask)
 

--- a/.github/workflows/oss-index-audit-daily.yml
+++ b/.github/workflows/oss-index-audit-daily.yml
@@ -29,8 +29,7 @@ jobs:
         run: ./gradlew ossIndexAudit --no-configuration-cache --no-parallel
         continue-on-error: true
         env:
-          SONATYPE_OSS_INDEX_USER: ${{ secrets.SONATYPE_OSS_INDEX_USER }}
-          SONATYPE_OSS_INDEX_PASSWORD: ${{ secrets.SONATYPE_OSS_INDEX_PASSWORD }}
+          SONATYPE_GUIDE_PAT: ${{ secrets.SONATYPE_GUIDE_PAT }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Print vulnerability report

--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -1,6 +1,6 @@
 # the benefit of this over renovate is that this also analyzes transitive dependencies
 # while renovate (at least currently) only analyzes top-level dependencies
-name: OSS Index dependency audit (daily)
+name: Sonatype Guide dependency audit (daily)
 
 on:
   schedule:
@@ -35,7 +35,7 @@ jobs:
       - name: Print vulnerability report
         if: steps.audit.outcome == 'failure'
         run: |
-          echo "=== OSS Index Vulnerability Report ==="
+          echo "=== Sonatype Guide Vulnerability Report ==="
           find . -name "oss-index-cyclonedx-bom.json" | xargs cat
           exit 1
 

--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -221,6 +221,7 @@ ossIndexAudit {
   isExcludeCompileOnly = true
   outputFormat = org.sonatype.gradle.plugins.scan.ossindex.OutputFormat.JSON_CYCLONE_DX_1_4
 
-  username = System.getenv("SONATYPE_OSS_INDEX_USER")
-  password = System.getenv("SONATYPE_OSS_INDEX_PASSWORD")
+  // Guide PAT authentication ignores this, but the scan plugin requires it.
+  username = "unused"
+  password = System.getenv("SONATYPE_GUIDE_PAT") ?: ""
 }


### PR DESCRIPTION
OSS Index got renamed to Guide, and the tokens stopped working along the way...

Port of

- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18515
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/18522
