### PR TITLE
Fix jfr-events tests

### DIFF
--- a/jfr-events/build.gradle.kts
+++ b/jfr-events/build.gradle.kts
@@ -23,7 +23,7 @@ tasks {
 
     // Disabled due to https://bugs.openjdk.java.net/browse/JDK-8245283
     configure<JacocoTaskExtension> {
-      enabled = false
+      isEnabled = false
     }
   }
 }

--- a/jfr-events/src/test/java/io/opentelemetry/contrib/jfrevent/JfrSpanProcessorTest.java
+++ b/jfr-events/src/test/java/io/opentelemetry/contrib/jfrevent/JfrSpanProcessorTest.java
@@ -72,11 +72,13 @@ class JfrSpanProcessorTest {
       assertThat(events).hasSize(1);
       assertThat(events)
           .extracting(e -> e.getValue("traceId"))
-          .isEqualTo(span.getSpanContext().getTraceId());
+          .containsExactly(span.getSpanContext().getTraceId());
       assertThat(events)
           .extracting(e -> e.getValue("spanId"))
-          .isEqualTo(span.getSpanContext().getSpanId());
-      assertThat(events).extracting(e -> e.getValue("operationName")).isEqualTo(OPERATION_NAME);
+          .containsExactly(span.getSpanContext().getSpanId());
+      assertThat(events)
+          .extracting(e -> e.getValue("operationName"))
+          .containsExactly(OPERATION_NAME);
     } finally {
       Files.delete(output);
     }
@@ -111,14 +113,14 @@ class JfrSpanProcessorTest {
       assertThat(events).hasSize(2);
       assertThat(events)
           .extracting(e -> e.getValue("traceId"))
-          .isEqualTo(span.getSpanContext().getTraceId());
+          .containsOnly(span.getSpanContext().getTraceId());
       assertThat(events)
           .extracting(e -> e.getValue("spanId"))
-          .isEqualTo(span.getSpanContext().getSpanId());
+          .containsOnly(span.getSpanContext().getSpanId());
       assertThat(events)
           .filteredOn(e -> "Span".equals(e.getEventType().getLabel()))
           .extracting(e -> e.getValue("operationName"))
-          .isEqualTo(OPERATION_NAME);
+          .containsExactly(OPERATION_NAME);
 
     } finally {
       Files.delete(output);


### PR DESCRIPTION
While reviewing #2739 i was trying to run the tests locally and they were not working due to a bug in the gradle config beacuse Kotlin DSL requires the is-prefixed form for boolean properties.

Once the tests were fixed to run, they were failing, so i updated the assertions accordingly