### PR TITLE
Add mvnrepository badge for GCP components

### DIFF
--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -1,5 +1,7 @@
 # Google Cloud Authentication Extension
 
+[![Maven](https://badges.mvnrepository.com/badge/io.opentelemetry.contrib/opentelemetry-gcp-auth-extension/badge.svg?label=Maven&color=orange)](https://mvnrepository.com/artifact/io.opentelemetry.contrib/opentelemetry-gcp-auth-extension)
+
 The Google Cloud Auth Extension allows users to export telemetry from their
 applications to Google Cloud using the built-in OTLP exporters.
 The extension takes care of the configuration required to authenticate to GCP

--- a/gcp-resources/README.md
+++ b/gcp-resources/README.md
@@ -1,5 +1,7 @@
 # GCP Resource Detectors for OpenTelemetry
 
+[![Maven](https://badges.mvnrepository.com/badge/io.opentelemetry.contrib/opentelemetry-gcp-resources/badge.svg?label=Maven&color=orange)](https://mvnrepository.com/artifact/io.opentelemetry.contrib/opentelemetry-gcp-resources)
+
 This module provides GCP resource detectors for OpenTelemetry.
 
 The following OpenTelemetry semantic conventions will be detected:


### PR DESCRIPTION
The badge link allows to quickly go to the maven repository link which shows the latest version along with stubs for importing the dependency.