### PR TITLE
Bump gummy bears version

### DIFF
--- a/buildSrc/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.animalsniffer-conventions.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-  signature("com.toasttab.android:gummy-bears-api-23:0.13.0:coreLib@signature")
+  signature("com.toasttab.android:gummy-bears-api-23:0.14.0:coreLib2@signature")
 }
 
 animalsniffer {

--- a/dynamic-control/build.gradle.kts
+++ b/dynamic-control/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   id("otel.java-conventions")
   id("otel.publish-conventions")
-  id("otel.animalsniffer-conventions")
 }
 
 description = "Dynamic control of some specific features of the agent"


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2790

- Updates Animal Sniffer's Android signature file.
- Removes Android support checks from the `dynamic-control`module.