### PR TITLE
[dynamic control] Add policy pipeline initializing manager

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -337,7 +337,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
   }
 
   /** Resets shared provider test state, including polling interval and active provider tracking. */
-  static void resetForTest() {
+  public static void resetForTest() {
     setGlobalPollingInterval(DEFAULT_POLLING_INTERVAL);
     ACTIVE_PROVIDERS.clear();
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -337,6 +337,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
   }
 
   /** Resets shared provider test state, including polling interval and active provider tracking. */
+  // TODO: refactor/rescope to make this not public at some point
   public static void resetForTest() {
     setGlobalPollingInterval(DEFAULT_POLLING_INTERVAL);
     ACTIVE_PROVIDERS.clear();

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -226,6 +226,7 @@ public final class PolicyInit {
     try {
       PolicyImplementer implementer = policyTypeInitializer.initialize(autoConfiguration);
       initializedImplementers.put(policyClass, implementer);
+      // TODO: register implementer with policyStore, not yet implemented
       // policyStore.registerImplementer(implementer);
       logger.log(Level.INFO, "Initialized policy class ''{0}''", policyClass.getName());
     } catch (RuntimeException e) {
@@ -266,10 +267,11 @@ public final class PolicyInit {
         updatePoliciesForSource(provider, initialPolicies);
       } catch (Exception e) {
         logger.log(
-            Level.INFO,
-            "Failed to fetch initial policies for provider source ''{0}''",
-            source.getLocation());
-      }
+             Level.WARNING,
+             "Failed to fetch initial policies for provider source ''"
+                 + source.getLocation()
+                 + "''",
+             e);      }
       Closeable watch =
           provider.startWatching(
               policies -> {
@@ -352,10 +354,14 @@ public final class PolicyInit {
   }
 
   /**
-   * Shuts down active policy sources and clears runtime registry state.
+   * Shuts down active policy sources and clears source-activation runtime state.
    *
    * <p>This closes all currently active source watches and allows a subsequent {@link #init}
    * invocation to activate sources again.
+   *
+   * <p>This does <strong>not</strong> clear global policy type registrations ({@link
+   * #registerPolicyType(String, Class, PolicyTypeInitializer)}) and does not replace the static
+   * {@link PolicyStore} instance.
    */
   public static void shutdown() {
     for (Closeable watch : activeSourceWatches) {
@@ -372,7 +378,7 @@ public final class PolicyInit {
   }
 
   /**
-   * Resets static registry state used by tests.
+   * Resets source-activation runtime state used by tests.
    *
    * <p>Example usage:
    *

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -267,11 +267,10 @@ public final class PolicyInit {
         updatePoliciesForSource(provider, initialPolicies);
       } catch (Exception e) {
         logger.log(
-             Level.WARNING,
-             "Failed to fetch initial policies for provider source ''"
-                 + source.getLocation()
-                 + "''",
-             e);      }
+            Level.WARNING,
+            "Failed to fetch initial policies for provider source ''" + source.getLocation() + "''",
+            e);
+      }
       Closeable watch =
           provider.startWatching(
               policies -> {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.registry;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.contrib.dynamic.policy.OpampPolicyProvider;
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.PolicyProvider;
+import io.opentelemetry.contrib.dynamic.policy.PolicyStore;
+import io.opentelemetry.contrib.dynamic.policy.PolicyTypeInitializer;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Central registry bootstrap for telemetry policy initialization.
+ *
+ * <p>This class reads the policy-init configuration that specifies how to wire up the policy
+ * pipeline (providers reading policies, eg an OpAMP provider, implementers applying policies, eg a
+ * TraceSamplingRatePolicyImplementer), resolves any {@code policyType} strings (eg
+ * "trace_sampling_rate_policy") to registered policy classes (eg TraceSamplingRatePolicy),
+ * initializes the implementer classes, and activates configured providers that read policies from
+ * the source and stream policy updates into the shared {@link PolicyStore}.
+ *
+ * <p>Generically the pipeline is: message -> provider -> policy -> policy handler -> implementer ->
+ * agent config is changed
+ *
+ * <p>A specific example is: eg "change sampling rate" message -> OpampPolicyProvider ->
+ * TraceSamplingRatePolicy -> PolicyStore -> TraceSamplingRatePolicyImplementer -> sampling rate
+ * changed
+ */
+public final class PolicyInit {
+  private static final Logger logger = Logger.getLogger(PolicyInit.class.getName());
+  private static final Map<String, Class<? extends TelemetryPolicy>> REGISTERED_POLICY_TYPES =
+      new ConcurrentHashMap<>();
+  private static final Map<Class<? extends TelemetryPolicy>, PolicyTypeInitializer>
+      POLICY_TYPE_INITIALIZERS = new ConcurrentHashMap<>();
+  private static final AtomicBoolean sourcesActivated = new AtomicBoolean(false);
+  private static final Map<Class<? extends TelemetryPolicy>, PolicyImplementer>
+      initializedImplementers = new ConcurrentHashMap<>();
+  private static final CopyOnWriteArrayList<Closeable> activeSourceWatches =
+      new CopyOnWriteArrayList<>();
+  private static final Map<PolicyProvider, List<TelemetryPolicy>> sourcePolicies =
+      new ConcurrentHashMap<>();
+  private static final PolicyStore policyStore = new PolicyStore();
+
+  static {
+    // For now, policies will be registered here.
+    // TODO: register TraceSamplingRatePolicy when registerPolicyType implemented
+    // TraceSamplingRatePolicy.registerPolicyType();
+  }
+
+  /**
+   * Registers a policy type string to a concrete policy class and its initializer factory. eg map
+   * 'trace-sampling' to the class 'TraceSamplingRatePolicy', and register the initializer factory
+   * 'TraceSamplingRatePolicy::initialize' for when the policy is present in the init config.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * PolicyInit.registerPolicyType(
+   *     TraceSamplingRatePolicy.POLICY_TYPE,
+   *     TraceSamplingRatePolicy.class,
+   *     TraceSamplingRatePolicy::initialize);
+   * }</pre>
+   *
+   * @param policyType configured policy type identifier (for example {@code trace-sampling})
+   * @param policyClass runtime class implementing that policy type
+   * @param policyTypeInitializer initializer for the policy type that returns the associated
+   *     implementer instance
+   * @throws IllegalStateException if the same type is already mapped to a different class
+   */
+  public static void registerPolicyType(
+      String policyType,
+      Class<? extends TelemetryPolicy> policyClass,
+      PolicyTypeInitializer policyTypeInitializer) {
+    Objects.requireNonNull(policyType, "policyType cannot be null");
+    Objects.requireNonNull(policyClass, "policyClass cannot be null");
+    Objects.requireNonNull(policyTypeInitializer, "policyTypeInitializer cannot be null");
+    Class<? extends TelemetryPolicy> existing =
+        REGISTERED_POLICY_TYPES.put(policyType, policyClass);
+    if (existing != null && !existing.equals(policyClass)) {
+      throw new IllegalStateException(
+          "Policy type '" + policyType + "' is already registered by " + existing.getName());
+    }
+    POLICY_TYPE_INITIALIZERS.put(policyClass, policyTypeInitializer);
+  }
+
+  /**
+   * Installs registry initialization into SDK auto-configuration.
+   *
+   * <p>When either init-config property is present, this loads JSON or YAML config, resolves and
+   * initializes mapped policy classes, and activates runtime policy sources.
+   *
+   * <p>Example properties:
+   *
+   * <ul>
+   *   <li>{@code otel.java.experimental.telemetry.policy.init.yaml=/path/policy-init.yaml}
+   *   <li>{@code otel.java.experimental.telemetry.policy.init.json=/path/policy-init.json}
+   * </ul>
+   *
+   * @param autoConfiguration OpenTelemetry auto-configuration customizer
+   */
+  public static void init(AutoConfigurationCustomizer autoConfiguration) {
+    autoConfiguration.addPropertiesCustomizer(
+        config -> {
+          PolicyInitConfig initConfig = PolicyInitConfig.readFromConfigProperties(config);
+          if (initConfig == null) {
+            return Collections.emptyMap();
+          }
+          resolveAndInitializeConfiguredPolicyTypes(initConfig, autoConfiguration);
+          activateSources(initConfig, config);
+          return Collections.emptyMap();
+        });
+  }
+
+  /** Initializes dynamic-control policy wiring from declarative config component input. */
+  public static void initFromDeclarativeConfig(
+      DeclarativeConfigProperties declarativeConfig, ConfigProperties config) {
+    Objects.requireNonNull(declarativeConfig, "declarativeConfig cannot be null");
+    Objects.requireNonNull(config, "config cannot be null");
+    PolicyInitConfig initConfig =
+        PolicyInitConfig.readFromTelemetryPolicyDeclarativeConfig(declarativeConfig);
+    if (initConfig == null) {
+      initConfig = PolicyInitConfig.readFromDeclarativeConfigProperties(declarativeConfig);
+    }
+    if (initConfig == null) {
+      return;
+    }
+    resolveAndInitializeConfiguredPolicyTypes(initConfig, createNoopAutoConfigurationCustomizer());
+    try {
+      activateSources(initConfig, config);
+    } catch (RuntimeException e) {
+      logger.log(
+          Level.WARNING,
+          "Failed to activate telemetry policy sources from declarative component config",
+          e);
+    }
+  }
+
+  private static AutoConfigurationCustomizer createNoopAutoConfigurationCustomizer() {
+    return (AutoConfigurationCustomizer)
+        Proxy.newProxyInstance(
+            AutoConfigurationCustomizer.class.getClassLoader(),
+            new Class<?>[] {AutoConfigurationCustomizer.class},
+            (proxy, method, args) -> null);
+  }
+
+  /**
+   * Resolves all mapped policy types to classes and invokes each policy-type initializer once.
+   *
+   * <p>eg if the init config has {@code policyType: trace-sampling}, this resolves that policy type
+   * to its registered class, TraceSamplingRatePolicy, and runs the registered policy-type
+   * initializer for that class, TraceSamplingRatePolicy::initialize.
+   *
+   * @param initConfig parsed registry initialization model
+   * @param autoConfiguration OpenTelemetry auto-configuration customizer
+   */
+  private static void resolveAndInitializeConfiguredPolicyTypes(
+      PolicyInitConfig initConfig, AutoConfigurationCustomizer autoConfiguration) {
+    Set<Class<? extends TelemetryPolicy>> initializedPolicyClasses = new HashSet<>();
+    for (PolicySourceConfig source : initConfig.getSources()) {
+      for (PolicySourceMappingConfig mapping : source.getMappings()) {
+        String mappedPolicyType = mapping.getPolicyType();
+        Class<? extends TelemetryPolicy> policyClass =
+            REGISTERED_POLICY_TYPES.get(mappedPolicyType);
+        if (policyClass == null) {
+          throw new IllegalArgumentException(
+              "Unknown policyType '"
+                  + mappedPolicyType
+                  + "' in mapping for source kind '"
+                  + source.getKind().configValue()
+                  + "' key '"
+                  + mapping.getSourceKey()
+                  + "'");
+        }
+        initializePolicyClass(policyClass, autoConfiguration, initializedPolicyClasses);
+        logger.log(
+            Level.INFO,
+            "Mapped policyType ''{0}'' to class ''{1}''",
+            new Object[] {mappedPolicyType, policyClass.getName()});
+      }
+    }
+  }
+
+  /**
+   * Initializes one policy class exactly once for this init pass. eg run {@code
+   * TraceSamplingRatePolicy::initialize} and cache the returned implementer.
+   *
+   * @param policyClass policy class to initialize
+   * @param autoConfiguration OpenTelemetry auto-configuration customizer
+   * @param initializedPolicyClasses set tracking which classes were already initialized
+   */
+  private static void initializePolicyClass(
+      Class<? extends TelemetryPolicy> policyClass,
+      AutoConfigurationCustomizer autoConfiguration,
+      Set<Class<? extends TelemetryPolicy>> initializedPolicyClasses) {
+    if (!initializedPolicyClasses.add(policyClass)) {
+      return;
+    }
+    PolicyTypeInitializer policyTypeInitializer = POLICY_TYPE_INITIALIZERS.get(policyClass);
+    if (policyTypeInitializer == null) {
+      throw new IllegalStateException(
+          "No policyTypeInitializer registered for policy class '" + policyClass.getName() + "'");
+    }
+    try {
+      PolicyImplementer implementer = policyTypeInitializer.initialize(autoConfiguration);
+      initializedImplementers.put(policyClass, implementer);
+      // policyStore.registerImplementer(implementer);
+      logger.log(Level.INFO, "Initialized policy class ''{0}''", policyClass.getName());
+    } catch (RuntimeException e) {
+      throw new IllegalStateException(
+          "Policy initializer failed for class '" + policyClass.getName() + "'", e);
+    }
+  }
+
+  /**
+   * Activates runtime sources from the init config and wires policy update propagation. eg activate
+   * the OpAMPPolicyProvider to start reading from its source per the init config.
+   *
+   * <p>This is idempotent; repeated calls after first activation are ignored.
+   */
+  private static void activateSources(PolicyInitConfig initConfig, ConfigProperties config) {
+    if (!sourcesActivated.compareAndSet(false, true)) {
+      return;
+    }
+    for (PolicySourceConfig source : initConfig.getSources()) {
+      List<PolicyValidator> validators = createSourceValidators(source);
+      if (validators.isEmpty()) {
+        logger.log(
+            Level.INFO,
+            "Skipping source kind ''{0}'' because no validators matched configured mappings",
+            source.getKind().configValue());
+        continue;
+      }
+      PolicyProvider provider = source.getKind().createProvider(source, config, validators);
+      if (provider == null) {
+        logger.log(
+            Level.INFO,
+            "Skipping source kind ''{0}'' because no provider could be created",
+            source.getKind().configValue());
+        continue;
+      }
+      try {
+        List<TelemetryPolicy> initialPolicies = provider.fetchPolicies();
+        updatePoliciesForSource(provider, initialPolicies);
+      } catch (Exception e) {
+        logger.log(
+            Level.INFO,
+            "Failed to fetch initial policies for provider source ''{0}''",
+            source.getLocation());
+      }
+      Closeable watch =
+          provider.startWatching(
+              policies -> {
+                updatePoliciesForSource(provider, policies);
+                logger.log(
+                    Level.INFO,
+                    "provider source ''{0}'' produced {1} policies",
+                    new Object[] {source.getLocation(), policies.size()});
+              });
+      activeSourceWatches.add(watch);
+      logger.log(
+          Level.INFO,
+          "Activated OpAMP policy source with location key ''{0}''",
+          source.getLocation());
+    }
+  }
+
+  /**
+   * Resolves policy validators for a source based on mapped policy classes.
+   *
+   * <p>For each mapped policy class, this uses the already initialized implementer and aggregates
+   * {@link PolicyImplementer#getValidators()}.
+   *
+   * <p>Example: if a source policy maps to {@code TraceSamplingRatePolicy.class}, and its
+   * implementer returns a {@code TraceSamplingValidator}, that validator is included in the source
+   * validator list.
+   */
+  private static List<PolicyValidator> createSourceValidators(PolicySourceConfig source) {
+    Set<Class<? extends TelemetryPolicy>> mappedClasses =
+        collectMappedPolicyClasses(source.getMappings());
+    ArrayList<PolicyValidator> validators = new ArrayList<>();
+    for (Class<? extends TelemetryPolicy> policyClass : mappedClasses) {
+      PolicyImplementer implementer = initializedImplementers.get(policyClass);
+      if (implementer != null) {
+        validators.addAll(implementer.getValidators());
+      }
+    }
+    return validators;
+  }
+
+  /**
+   * Merges source snapshots and updates the effective policy store. This doesn't yet do any useful
+   * merging, it just combines them all into a single list.
+   *
+   * <p>Each source contributes an immutable snapshot; the store receives the flattened union. eg
+   * OpAMPPolicyProvider and FilePolicyProvider both produce a new TraceSamplingRatePolicy, this
+   * will combine them all into a single list.
+   */
+  private static void updatePoliciesForSource(
+      PolicyProvider provider, List<TelemetryPolicy> policiesFromSource) {
+    List<TelemetryPolicy> snapshot =
+        policiesFromSource == null
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(policiesFromSource));
+    sourcePolicies.put(provider, snapshot);
+    ArrayList<TelemetryPolicy> merged = new ArrayList<>();
+    for (List<TelemetryPolicy> policies : sourcePolicies.values()) {
+      merged.addAll(policies);
+    }
+    policyStore.updatePolicies(merged);
+  }
+
+  /**
+   * Collects mapped policy classes for one source mapping list.
+   *
+   * <p>Example: if mappings contain policy type {@code trace-sampling} twice, both resolve to
+   * {@code TraceSamplingRatePolicy.class}, but the result contains that class only once.
+   */
+  private static Set<Class<? extends TelemetryPolicy>> collectMappedPolicyClasses(
+      List<PolicySourceMappingConfig> mappings) {
+    LinkedHashSet<Class<? extends TelemetryPolicy>> result = new LinkedHashSet<>();
+    for (PolicySourceMappingConfig mapping : mappings) {
+      Class<? extends TelemetryPolicy> policyClass =
+          REGISTERED_POLICY_TYPES.get(mapping.getPolicyType());
+      if (policyClass != null) {
+        result.add(policyClass);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Shuts down active policy sources and clears runtime registry state.
+   *
+   * <p>This closes all currently active source watches and allows a subsequent {@link #init}
+   * invocation to activate sources again.
+   */
+  public static void shutdown() {
+    for (Closeable watch : activeSourceWatches) {
+      try {
+        watch.close();
+      } catch (IOException e) {
+        logger.log(Level.INFO, "Failed to close active source watch during shutdown", e);
+      }
+    }
+    activeSourceWatches.clear();
+    sourcePolicies.clear();
+    sourcesActivated.set(false);
+    initializedImplementers.clear();
+  }
+
+  /**
+   * Resets static registry state used by tests.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * @AfterEach
+   * void tearDown() {
+   *   PolicyInit.resetForTest();
+   * }
+   * }</pre>
+   */
+  static void resetForTest() {
+    shutdown();
+    OpampPolicyProvider.resetForTest();
+  }
+
+  private PolicyInit() {}
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -282,8 +282,8 @@ public final class PolicyInit {
       activeSourceWatches.add(watch);
       logger.log(
           Level.INFO,
-          "Activated OpAMP policy source with location key ''{0}''",
-          source.getLocation());
+          "Activated {0} policy source with location ''{1}''",
+          new Object[] {source.getKind().configValue(), source.getLocation()});
     }
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
@@ -118,6 +118,9 @@ public final class PolicyInitConfig {
    *       - sourceKey: ...
    *         policyType: ...
    * }</pre>
+   *
+   * @throws IllegalArgumentException if telemetry_policy is present but invalid (for example,
+   *     missing or empty sources)
    */
   @Nullable
   public static PolicyInitConfig readFromTelemetryPolicyDeclarativeConfig(
@@ -126,7 +129,7 @@ public final class PolicyInitConfig {
     List<DeclarativeConfigProperties> sourceConfigs =
         telemetryPolicyConfig.getStructuredList(SOURCES_DECLARATIVE_KEY);
     if (sourceConfigs == null || sourceConfigs.isEmpty()) {
-      return null;
+      throw new IllegalArgumentException("Config must contain a non-empty 'sources' array.");
     }
     List<PolicySourceConfig> sources = new ArrayList<>();
     for (DeclarativeConfigProperties sourceConfig : sourceConfigs) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
@@ -104,6 +104,38 @@ public final class PolicyInitConfig {
   }
 
   /**
+   * Reads policy-init configuration from a declarative block that already points at {@code
+   * telemetry_policy}.
+   *
+   * <p>Expected shape is:
+   *
+   * <pre>{@code
+   * sources:
+   *   - kind: ...
+   *     format: ...
+   *     location: ...
+   *     mappings:
+   *       - sourceKey: ...
+   *         policyType: ...
+   * }</pre>
+   */
+  @Nullable
+  public static PolicyInitConfig readFromTelemetryPolicyDeclarativeConfig(
+      DeclarativeConfigProperties telemetryPolicyConfig) {
+    Objects.requireNonNull(telemetryPolicyConfig, "telemetryPolicyConfig cannot be null");
+    List<DeclarativeConfigProperties> sourceConfigs =
+        telemetryPolicyConfig.getStructuredList(SOURCES_DECLARATIVE_KEY);
+    if (sourceConfigs == null || sourceConfigs.isEmpty()) {
+      return null;
+    }
+    List<PolicySourceConfig> sources = new ArrayList<>();
+    for (DeclarativeConfigProperties sourceConfig : sourceConfigs) {
+      sources.add(parseDeclarativeSource(sourceConfig));
+    }
+    return new PolicyInitConfig(sources);
+  }
+
+  /**
    * Reads policy-init configuration with declarative-first fallback.
    *
    * <p>When declarative config contains {@code telemetry_policy.sources}, that configuration is

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
@@ -209,6 +209,42 @@ class PolicyInitConfigTest {
   }
 
   @Test
+  void readFromTelemetryPolicyDeclarativeConfigThrowsWhenSourcesMissing() {
+    DeclarativeConfigProperties telemetryPolicy = mock(DeclarativeConfigProperties.class);
+    when(telemetryPolicy.getStructuredList(PolicyInitConfig.SOURCES_DECLARATIVE_KEY))
+        .thenReturn(null);
+
+    assertThatThrownBy(
+            () -> PolicyInitConfig.readFromTelemetryPolicyDeclarativeConfig(telemetryPolicy))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sources");
+  }
+
+  @Test
+  void readFromTelemetryPolicyDeclarativeConfigThrowsWhenSourcesEmpty() {
+    DeclarativeConfigProperties telemetryPolicy = mock(DeclarativeConfigProperties.class);
+    when(telemetryPolicy.getStructuredList(PolicyInitConfig.SOURCES_DECLARATIVE_KEY))
+        .thenReturn(Collections.emptyList());
+
+    assertThatThrownBy(
+            () -> PolicyInitConfig.readFromTelemetryPolicyDeclarativeConfig(telemetryPolicy))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sources");
+  }
+
+  @Test
+  void readFromTelemetryPolicyDeclarativeConfigReadsSources() {
+    DeclarativeConfigProperties telemetryPolicy = telemetryPolicyConfig("from-declarative");
+
+    PolicyInitConfig config =
+        PolicyInitConfig.readFromTelemetryPolicyDeclarativeConfig(telemetryPolicy);
+
+    assertThat(config).isNotNull();
+    assertThat(config.getSources()).hasSize(1);
+    assertThat(config.getSources().get(0).getLocation()).isEqualTo("from-declarative");
+  }
+
+  @Test
   void readFromDeclarativeOrConfigPropertiesPrefersDeclarativeWhenPresent() throws Exception {
     Path jsonPath = tempDir.resolve("policy-init.json");
     Files.write(jsonPath, jsonWithLocation("from-file").getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
**Description:**

This adds PolicyInit which coordinates registration and initialization of policies when the policy pipeline is created

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

The natural testing here is coordinated with at least one basic policy, but the policy registration hasn't yet been implemented in this PR (to keep it simpler), so testing will be added with the next PR with a policy registration added

**Documentation:**

Included

**Outstanding items:**


Wiring up the policy pipeline: 
- Generic: message -> provider -> policy -> policy handler -> implementer
- eg "change sampling rate" message -> OpampPolicyProvider -> TraceSamplingRatePolicy -> PolicyStore -> TraceSamplingRatePolicyImplementer

Steps needed for the wiring:
- configuring the pipeline
   - DONE: PolicyInitConfig
- providers reading policies, eg OpampPolicyProvider, FilePolicyProvider, etc
   - DONE: OpampPolicyProvider
- implementers applying policies, eg TraceSamplingRatePolicyImplementer
   - DONE: TraceSamplingRatePolicyImplementer
- policy structures (eg TraceSamplingRatePolicy) that the provider converts messages into
   - DONE: TraceSamplingRatePolicy
- registering config to policy structures (eg "trace_sampling_rate_policy" registered to TraceSamplingRatePolicy)
- initializing policy classes (eg TraceSamplingRatePolicy needs to install a custom sampler)
   - DONE: TraceSamplingRatePolicy initialization
- activate configured providers (eg start OpampPolicyprovider reading from it's source)
   - TBD
- register implementers for policies (eg a new TraceSamplingRatePolicy is applied by a TraceSamplingRatePolicyImplementer)
   - TBD
- link the provider to processing policies and applying implementers
   - DONE abstractly in this PR (PolicyInit)