### PR TITLE
[dynamic control] wire up first policy

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -13,6 +13,7 @@ import io.opentelemetry.contrib.dynamic.policy.PolicyStore;
 import io.opentelemetry.contrib.dynamic.policy.PolicyTypeInitializer;
 import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.io.Closeable;
@@ -65,9 +66,7 @@ public final class PolicyInit {
   private static final PolicyStore policyStore = new PolicyStore();
 
   static {
-    // For now, policies will be registered here.
-    // TODO: register TraceSamplingRatePolicy when registerPolicyType implemented
-    // TraceSamplingRatePolicy.registerPolicyType();
+    TraceSamplingRatePolicy.registerPolicyType();
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -66,6 +66,7 @@ public final class PolicyInit {
   private static final PolicyStore policyStore = new PolicyStore();
 
   static {
+    // For now, policies will be registered here. TODO: move to a more dynamic way.
     TraceSamplingRatePolicy.registerPolicyType();
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
@@ -35,12 +37,18 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
    * <p>If the extension is configured to use this policy, this installs an opinionated sampler that
    * overrides any other sampler
    */
-  public static void initialize(AutoConfigurationCustomizer autoConfiguration) {
+  public static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
     Objects.requireNonNull(autoConfiguration, "autoConfiguration cannot be null");
     Sampler initialDelegate = createSampler(1.0);
     DelegatingSampler delegatingSampler = new DelegatingSampler(initialDelegate);
     initializedSampler = delegatingSampler;
     autoConfiguration.addSamplerCustomizer((sampler, config) -> delegatingSampler);
+    return new TraceSamplingRatePolicyImplementer(delegatingSampler);
+  }
+
+  public static void registerPolicyType() {
+    PolicyInit.registerPolicyType(
+        POLICY_TYPE, TraceSamplingRatePolicy.class, TraceSamplingRatePolicy::initialize);
   }
 
   /**
@@ -67,6 +75,10 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   @Nullable
   public static DelegatingSampler getInitializedSampler() {
     return initializedSampler;
+  }
+
+  static void resetForTest() {
+    initializedSampler = null;
   }
 
   @Override

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
@@ -89,7 +89,7 @@ class PolicyInitConfigTest {
     assertThat(source.getLocation()).isEqualTo("vendor");
     assertThat(source.getMappings()).hasSize(1);
     assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
-    assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace_sampling_rate_policy");
+    assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
   }
 
   @Test
@@ -191,7 +191,7 @@ class PolicyInitConfigTest {
     assertThat(source.getLocation()).isEqualTo("from-declarative");
     assertThat(source.getMappings()).hasSize(1);
     assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
-    assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace_sampling_rate_policy");
+    assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
   }
 
   @Test
@@ -428,7 +428,7 @@ class PolicyInitConfigTest {
     when(mapping.getString(PolicyInitConfig.SOURCE_KEY_DECLARATIVE_KEY))
         .thenReturn("sampling_rate");
     when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY))
-        .thenReturn("trace_sampling_rate_policy");
+        .thenReturn("trace-sampling");
     return mapping;
   }
 
@@ -453,13 +453,13 @@ class PolicyInitConfigTest {
 
   private static String minimalJsonConfig() {
     return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\"vendor\","
-        + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace_sampling_rate_policy\"}]}]}";
+        + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
   }
 
   private static String jsonWithLocation(String location) {
     return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\""
         + location
-        + "\",\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace_sampling_rate_policy\"}]}]}";
+        + "\",\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
   }
 
   private static String minimalYamlConfig() {
@@ -469,7 +469,7 @@ class PolicyInitConfigTest {
         + "    location: vendor\n"
         + "    mappings:\n"
         + "      - sourceKey: sampling_rate\n"
-        + "        policyType: trace_sampling_rate_policy\n";
+        + "        policyType: trace-sampling\n";
   }
 
   private static String yamlWithLocation(String location) {
@@ -481,6 +481,6 @@ class PolicyInitConfigTest {
         + "\n"
         + "    mappings:\n"
         + "      - sourceKey: sampling_rate\n"
-        + "        policyType: trace_sampling_rate_policy\n";
+        + "        policyType: trace-sampling\n";
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -53,22 +53,6 @@ class PolicyInitTest {
   }
 
   @Test
-  void doesNotInitializePolicyWhenTopLevelTelemetryPolicyDeclarativeConfigMissing() {
-    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
-    PolicyInit.init(customizer);
-    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
-        capturePropertiesCustomizer(customizer);
-
-    ConfigProperties config = mock(ConfigProperties.class);
-    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(null);
-    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_JSON)).thenReturn(null);
-    Map<String, String> ignored = propertiesCustomizer.apply(config);
-
-    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNull();
-    assertThat(ignored).isNotNull();
-  }
-
-  @Test
   void initializesPolicyFromInitConfigInAutoConfigurationMode() throws Exception {
     AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
     PolicyInit.init(customizer);

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -6,21 +6,29 @@
 package io.opentelemetry.contrib.dynamic.policy.registry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 class PolicyInitTest {
+  @TempDir Path tempDir;
 
   @AfterEach
   void tearDown() throws Exception {
@@ -60,6 +68,49 @@ class PolicyInitTest {
     assertThat(ignored).isNotNull();
   }
 
+  @Test
+  void initializesPolicyFromInitConfigInAutoConfigurationMode() throws Exception {
+    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
+    PolicyInit.init(customizer);
+    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
+        capturePropertiesCustomizer(customizer);
+
+    Path configPath = tempDir.resolve("policy-init.json");
+    Files.write(configPath, minimalJsonInitConfig().getBytes(StandardCharsets.UTF_8));
+
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(null);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_JSON))
+        .thenReturn(configPath.toString());
+
+    Map<String, String> ignored = propertiesCustomizer.apply(config);
+
+    assertThat(ignored).isNotNull();
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNotNull();
+  }
+
+  @Test
+  void initializesRegisteredPolicyTypeFromDeclarativeConfig() {
+    ConfigProperties config = mock(ConfigProperties.class);
+
+    PolicyInit.initFromDeclarativeConfig(
+        telemetryPolicyNodeConfig(TraceSamplingRatePolicy.POLICY_TYPE), config);
+
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNotNull();
+  }
+
+  @Test
+  void throwsWhenDeclarativeConfigUsesUnknownPolicyType() {
+    ConfigProperties config = mock(ConfigProperties.class);
+
+    assertThatThrownBy(
+            () ->
+                PolicyInit.initFromDeclarativeConfig(
+                    telemetryPolicyNodeConfig("trace_sampling_rate_policy"), config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unknown policyType");
+  }
+
   private static Function<ConfigProperties, Map<String, String>> capturePropertiesCustomizer(
       AutoConfigurationCustomizer customizer) {
     @SuppressWarnings("unchecked")
@@ -73,5 +124,30 @@ class PolicyInitTest {
     Method method = targetClass.getDeclaredMethod(methodName);
     method.setAccessible(true);
     method.invoke(null);
+  }
+
+  private static DeclarativeConfigProperties telemetryPolicyNodeConfig(String policyType) {
+    DeclarativeConfigProperties telemetryPolicy = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties source = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties mapping = mock(DeclarativeConfigProperties.class);
+
+    when(telemetryPolicy.getStructuredList(PolicyInitConfig.SOURCES_DECLARATIVE_KEY))
+        .thenReturn(Collections.singletonList(source));
+    when(source.getString(PolicyInitConfig.KIND_DECLARATIVE_KEY)).thenReturn("opamp");
+    when(source.getString(PolicyInitConfig.FORMAT_DECLARATIVE_KEY)).thenReturn("jsonkeyvalue");
+    when(source.getString(PolicyInitConfig.LOCATION_DECLARATIVE_KEY)).thenReturn("vendor");
+    when(source.getStructuredList(PolicyInitConfig.MAPPINGS_DECLARATIVE_KEY))
+        .thenReturn(Collections.singletonList(mapping));
+    when(mapping.getString(PolicyInitConfig.SOURCE_KEY_DECLARATIVE_KEY))
+        .thenReturn("sampling_rate");
+    when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY)).thenReturn(policyType);
+    return telemetryPolicy;
+  }
+
+  private static String minimalJsonInitConfig() {
+    return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\"vendor\","
+        + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\""
+        + TraceSamplingRatePolicy.POLICY_TYPE
+        + "\"}]}]}";
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.registry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PolicyInitTest {
+
+  @AfterEach
+  void tearDown() throws Exception {
+    PolicyInit.resetForTest();
+    invokeStaticNoArg(TraceSamplingRatePolicy.class, "resetForTest");
+  }
+
+  @Test
+  void doesNotInitializePolicyFromDeclarativeOnlyConfigInAutoConfigurationMode() {
+    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
+    PolicyInit.init(customizer);
+    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
+        capturePropertiesCustomizer(customizer);
+
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(null);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_JSON)).thenReturn(null);
+    Map<String, String> ignored = propertiesCustomizer.apply(config);
+
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNull();
+    assertThat(ignored).isNotNull();
+  }
+
+  @Test
+  void doesNotInitializePolicyWhenTopLevelTelemetryPolicyDeclarativeConfigMissing() {
+    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
+    PolicyInit.init(customizer);
+    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
+        capturePropertiesCustomizer(customizer);
+
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(null);
+    when(config.getString(PolicyInitConfig.POLICY_INIT_CONFIG_PROPERTY_JSON)).thenReturn(null);
+    Map<String, String> ignored = propertiesCustomizer.apply(config);
+
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNull();
+    assertThat(ignored).isNotNull();
+  }
+
+  private static Function<ConfigProperties, Map<String, String>> capturePropertiesCustomizer(
+      AutoConfigurationCustomizer customizer) {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Function<ConfigProperties, Map<String, String>>> captor =
+        ArgumentCaptor.forClass(Function.class);
+    verify(customizer).addPropertiesCustomizer(captor.capture());
+    return captor.getValue();
+  }
+
+  private static void invokeStaticNoArg(Class<?> targetClass, String methodName) throws Exception {
+    Method method = targetClass.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(null);
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonPolicyInitConfigReaderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonPolicyInitConfigReaderTest.java
@@ -34,8 +34,7 @@ class JsonPolicyInitConfigReaderTest {
       assertThat(source.getLocation()).isEqualTo("vendor-specific");
       assertThat(source.getMappings()).hasSize(4);
       assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
-      assertThat(source.getMappings().get(0).getPolicyType())
-          .isEqualTo("trace_sampling_rate_policy");
+      assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
     }
   }
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/yaml/YamlPolicyInitConfigReaderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/yaml/YamlPolicyInitConfigReaderTest.java
@@ -34,8 +34,7 @@ class YamlPolicyInitConfigReaderTest {
       assertThat(source.getLocation()).isEqualTo("vendor-specific");
       assertThat(source.getMappings()).hasSize(4);
       assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
-      assertThat(source.getMappings().get(0).getPolicyType())
-          .isEqualTo("trace_sampling_rate_policy");
+      assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
     }
   }
 

--- a/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/json/policy-init-example.json
+++ b/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/json/policy-init-example.json
@@ -5,7 +5,7 @@
       "format": "jsonkeyvalue",
       "location": "vendor-specific",
       "mappings": [
-        { "sourceKey": "sampling_rate", "policyType": "trace_sampling_rate_policy" },
+        { "sourceKey": "sampling_rate", "policyType": "trace-sampling" },
         { "sourceKey": "send_logs", "policyType": "log_export_enabled_policy" },
         { "sourceKey": "send_traces", "policyType": "trace_export_enabled_policy" },
         { "sourceKey": "send_metrics", "policyType": "metric_export_enabled_policy" }

--- a/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/yaml/policy-init-example.yaml
+++ b/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/yaml/policy-init-example.yaml
@@ -4,7 +4,7 @@ sources:
     location: vendor-specific
     mappings:
       - sourceKey: sampling_rate
-        policyType: trace_sampling_rate_policy
+        policyType: trace-sampling
       - sourceKey: send_logs
         policyType: log_export_enabled_policy
       - sourceKey: send_traces


### PR DESCRIPTION
**Description:**

Wire up TraceSamplingRatePolicy so it can be used in config.

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Added

**Documentation:**

Included

**Outstanding items:**

Wiring up the policy pipeline: 
- Generic: message -> provider -> policy -> policy handler -> implementer
- eg "change sampling rate" message -> OpampPolicyProvider -> TraceSamplingRatePolicy -> PolicyStore -> TraceSamplingRatePolicyImplementer

Steps needed for the wiring:
- configuring the pipeline
   - DONE: PolicyInitConfig
- providers reading policies, eg OpampPolicyProvider, FilePolicyProvider, etc
   - DONE: OpampPolicyProvider
- implementers applying policies, eg TraceSamplingRatePolicyImplementer
   - DONE: TraceSamplingRatePolicyImplementer
- policy structures (eg TraceSamplingRatePolicy) that the provider converts messages into
   - DONE: TraceSamplingRatePolicy
- registering config to policy structures (eg "trace_sampling_rate_policy" registered to TraceSamplingRatePolicy)
   - This PR
- initializing policy classes (eg TraceSamplingRatePolicy needs to install a custom sampler)
   - DONE: TraceSamplingRatePolicy initialization
- activate configured providers (eg start OpampPolicyprovider reading from it's source)
   - TBD
- register implementers for policies (eg a new TraceSamplingRatePolicy is applied by a TraceSamplingRatePolicyImplementer)
   - TBD
- link the provider to processing policies and applying implementers
   - DONE PolicyInit