### PR TITLE
Remove mateusz from resource providers.

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -74,7 +74,6 @@ components:
     - jkwatson
   resource-providers:
     - breedx-splk
-    - mateuszrzeszutek
     - laurit
   runtime-attach:
     - jeanbisutti

--- a/resource-providers/README.md
+++ b/resource-providers/README.md
@@ -29,7 +29,6 @@ It is capable of detecting common scenarios among the popular application server
 ## Component owners
 
 * [Jason Plumb](https://github.com/breedx-splk), Splunk
-* [Mateusz Rzeszutek](https://github.com/mateuszrzeszutek), Splunk
 * [Lauri Tulmin](https://github.com/laurit), Splunk
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).


### PR DESCRIPTION
Removing @mateuszrzeszutek from the component owners for the `resource_providers` module.

We will welcome you back from any org, just say the word.