### PR TITLE
[dynamic control] Register implementers

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -11,15 +11,19 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Holds the latest validated policy snapshot and reports whether an update changed effective
  * configuration.
  */
 public final class PolicyStore {
+  private static final Logger logger = Logger.getLogger(PolicyStore.class.getName());
 
   private List<TelemetryPolicy> policies = Collections.emptyList();
-  private final List<PolicyImplementer> implementers = new ArrayList<>();
+  private final List<RegisteredImplementer> implementers = new ArrayList<>();
+  private long policyVersion;
 
   /**
    * Replaces the stored policies when the new snapshot is not equal to the current one.
@@ -37,29 +41,35 @@ public final class PolicyStore {
     Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
     LinkedHashSet<TelemetryPolicy> newPolicySet = new LinkedHashSet<>(newPolicies);
     List<TelemetryPolicy> policiesSnapshot;
-    List<PolicyImplementer> implementersSnapshot;
+    List<RegisteredImplementer> implementersSnapshot;
+    long snapshotVersion;
     synchronized (this) {
       if (new LinkedHashSet<>(policies).equals(newPolicySet)) {
         return false;
       }
       policies = new ArrayList<>(newPolicySet);
+      policyVersion++;
+      snapshotVersion = policyVersion;
       policiesSnapshot = new ArrayList<>(policies);
       implementersSnapshot = new ArrayList<>(implementers);
     }
-    for (PolicyImplementer implementer : implementersSnapshot) {
-      implementer.onPoliciesChanged(relevantPoliciesFor(implementer, policiesSnapshot));
+    for (RegisteredImplementer implementer : implementersSnapshot) {
+      notifyImplementer(implementer, policiesSnapshot, snapshotVersion);
     }
     return true;
   }
 
   public void registerImplementer(PolicyImplementer implementer) {
     Objects.requireNonNull(implementer, "implementer cannot be null");
+    RegisteredImplementer registeredImplementer = new RegisteredImplementer(implementer);
     List<TelemetryPolicy> policiesSnapshot;
+    long snapshotVersion;
     synchronized (this) {
-      implementers.add(implementer);
+      implementers.add(registeredImplementer);
+      snapshotVersion = policyVersion;
       policiesSnapshot = new ArrayList<>(policies);
     }
-    implementer.onPoliciesChanged(relevantPoliciesFor(implementer, policiesSnapshot));
+    notifyImplementer(registeredImplementer, policiesSnapshot, snapshotVersion);
   }
 
   public synchronized List<TelemetryPolicy> getPolicies() {
@@ -69,6 +79,7 @@ public final class PolicyStore {
   public synchronized void clear() {
     policies = Collections.emptyList();
     implementers.clear();
+    policyVersion = 0;
   }
 
   private static List<TelemetryPolicy> relevantPoliciesFor(
@@ -86,5 +97,31 @@ public final class PolicyStore {
       }
     }
     return Collections.unmodifiableList(relevant);
+  }
+
+  private static void notifyImplementer(
+      RegisteredImplementer registration, List<TelemetryPolicy> policiesSnapshot, long version) {
+    synchronized (registration) {
+      if (version <= registration.lastDeliveredVersion) {
+        return;
+      }
+      try {
+        registration.implementer.onPoliciesChanged(
+            relevantPoliciesFor(registration.implementer, policiesSnapshot));
+      } catch (RuntimeException e) {
+        logger.log(Level.WARNING, "Policy implementer failed to apply policy update", e);
+      } finally {
+        registration.lastDeliveredVersion = version;
+      }
+    }
+  }
+
+  private static final class RegisteredImplementer {
+    private final PolicyImplementer implementer;
+    private long lastDeliveredVersion = -1;
+
+    private RegisteredImplementer(PolicyImplementer implementer) {
+      this.implementer = implementer;
+    }
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Holds the latest validated policy snapshot and reports whether an update changed effective
@@ -18,6 +19,7 @@ import java.util.Objects;
 public final class PolicyStore {
 
   private List<TelemetryPolicy> policies = Collections.emptyList();
+  private final List<PolicyImplementer> implementers = new ArrayList<>();
 
   /**
    * Replaces the stored policies when the new snapshot is not equal to the current one.
@@ -31,17 +33,58 @@ public final class PolicyStore {
    *
    * @return {@code true} if the store was updated, {@code false} if the snapshot was unchanged
    */
-  public synchronized boolean updatePolicies(List<TelemetryPolicy> newPolicies) {
+  public boolean updatePolicies(List<TelemetryPolicy> newPolicies) {
     Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
     LinkedHashSet<TelemetryPolicy> newPolicySet = new LinkedHashSet<>(newPolicies);
-    if (new LinkedHashSet<>(policies).equals(newPolicySet)) {
-      return false;
+    List<TelemetryPolicy> policiesSnapshot;
+    List<PolicyImplementer> implementersSnapshot;
+    synchronized (this) {
+      if (new LinkedHashSet<>(policies).equals(newPolicySet)) {
+        return false;
+      }
+      policies = new ArrayList<>(newPolicySet);
+      policiesSnapshot = new ArrayList<>(policies);
+      implementersSnapshot = new ArrayList<>(implementers);
     }
-    policies = new ArrayList<>(newPolicySet);
+    for (PolicyImplementer implementer : implementersSnapshot) {
+      implementer.onPoliciesChanged(relevantPoliciesFor(implementer, policiesSnapshot));
+    }
     return true;
+  }
+
+  public void registerImplementer(PolicyImplementer implementer) {
+    Objects.requireNonNull(implementer, "implementer cannot be null");
+    List<TelemetryPolicy> policiesSnapshot;
+    synchronized (this) {
+      implementers.add(implementer);
+      policiesSnapshot = new ArrayList<>(policies);
+    }
+    implementer.onPoliciesChanged(relevantPoliciesFor(implementer, policiesSnapshot));
   }
 
   public synchronized List<TelemetryPolicy> getPolicies() {
     return Collections.unmodifiableList(new ArrayList<>(policies));
+  }
+
+  public synchronized void clear() {
+    policies = Collections.emptyList();
+    implementers.clear();
+  }
+
+  private static List<TelemetryPolicy> relevantPoliciesFor(
+      PolicyImplementer implementer, List<TelemetryPolicy> policies) {
+    Set<String> supportedTypes = new LinkedHashSet<>();
+    for (PolicyValidator validator : implementer.getValidators()) {
+      if (validator != null && validator.getPolicyType() != null) {
+        supportedTypes.add(validator.getPolicyType());
+      }
+    }
+    ArrayList<TelemetryPolicy> relevant = new ArrayList<>();
+    for (TelemetryPolicy policy : policies) {
+      if (supportedTypes.contains(policy.getType())) {
+        relevant.add(policy);
+      }
+    }
+    return Collections.unmodifiableList(relevant);
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -204,8 +204,9 @@ public final class PolicyInit {
   }
 
   /**
-   * Initializes one policy class exactly once for this init pass. eg run {@code
-   * TraceSamplingRatePolicy::initialize} and cache the returned implementer.
+   * Initializes one policy class exactly once until shutdown. eg run {@code
+   * TraceSamplingRatePolicy::initialize}, cache the returned implementer, and register it with the
+   * policy store.
    *
    * @param policyClass policy class to initialize
    * @param autoConfiguration OpenTelemetry auto-configuration customizer
@@ -218,20 +219,32 @@ public final class PolicyInit {
     if (!initializedPolicyClasses.add(policyClass)) {
       return;
     }
-    PolicyTypeInitializer policyTypeInitializer = POLICY_TYPE_INITIALIZERS.get(policyClass);
-    if (policyTypeInitializer == null) {
-      throw new IllegalStateException(
-          "No policyTypeInitializer registered for policy class '" + policyClass.getName() + "'");
-    }
+    PolicyImplementer implementer;
     try {
-      PolicyImplementer implementer = policyTypeInitializer.initialize(autoConfiguration);
-      initializedImplementers.put(policyClass, implementer);
-      policyStore.registerImplementer(implementer);
-      logger.log(Level.INFO, "Initialized policy class ''{0}''", policyClass.getName());
+      synchronized (initializedImplementers) {
+        PolicyImplementer existing = initializedImplementers.get(policyClass);
+        if (existing != null) {
+          return;
+        }
+        PolicyTypeInitializer policyTypeInitializer = POLICY_TYPE_INITIALIZERS.get(policyClass);
+        if (policyTypeInitializer == null) {
+          throw new IllegalStateException(
+              "No policyTypeInitializer registered for policy class '"
+                  + policyClass.getName()
+                  + "'");
+        }
+        implementer =
+            Objects.requireNonNull(
+                policyTypeInitializer.initialize(autoConfiguration),
+                "policyTypeInitializer returned null");
+        initializedImplementers.put(policyClass, implementer);
+      }
     } catch (RuntimeException e) {
       throw new IllegalStateException(
           "Policy initializer failed for class '" + policyClass.getName() + "'", e);
     }
+    policyStore.registerImplementer(implementer);
+    logger.log(Level.INFO, "Initialized policy class ''{0}''", policyClass.getName());
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -226,8 +226,7 @@ public final class PolicyInit {
     try {
       PolicyImplementer implementer = policyTypeInitializer.initialize(autoConfiguration);
       initializedImplementers.put(policyClass, implementer);
-      // TODO: register implementer with policyStore, not yet implemented
-      // policyStore.registerImplementer(implementer);
+      policyStore.registerImplementer(implementer);
       logger.log(Level.INFO, "Initialized policy class ''{0}''", policyClass.getName());
     } catch (RuntimeException e) {
       throw new IllegalStateException(
@@ -318,6 +317,11 @@ public final class PolicyInit {
    * <p>Each source contributes an immutable snapshot; the store receives the flattened union. eg
    * OpAMPPolicyProvider and FilePolicyProvider both produce a new TraceSamplingRatePolicy, this
    * will combine them all into a single list.
+   *
+   * <p>TODO: implement spec-compliant merge semantics: matching policies' keep values must be
+   * combined using the most restrictive result; overlapping policy effects must be commutative,
+   * idempotent, and deterministic; duplicate policy IDs across providers must be resolved by
+   * provider priority.
    */
   private static void updatePoliciesForSource(
       PolicyProvider provider, List<TelemetryPolicy> policiesFromSource) {
@@ -374,6 +378,7 @@ public final class PolicyInit {
     sourcePolicies.clear();
     sourcesActivated.set(false);
     initializedImplementers.clear();
+    policyStore.clear();
   }
 
   /**

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -7,6 +7,10 @@ package io.opentelemetry.contrib.dynamic.policy;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import java.util.Arrays;
@@ -65,5 +69,37 @@ class PolicyStoreTest {
   @Test
   void getPoliciesReturnsEmptyWhenNeverUpdated() {
     assertThat(new PolicyStore().getPolicies()).isEqualTo(Collections.emptyList());
+  }
+
+  @Test
+  void registerImplementerReceivesCurrentRelevantPolicies() {
+    PolicyStore store = new PolicyStore();
+    store.updatePolicies(
+        Arrays.asList(new TraceSamplingRatePolicy(0.5), new TelemetryPolicy("other-policy")));
+
+    PolicyImplementer implementer = mock(PolicyImplementer.class);
+    PolicyValidator validator = mock(PolicyValidator.class);
+    when(validator.getPolicyType()).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
+    when(implementer.getValidators()).thenReturn(singletonList(validator));
+
+    store.registerImplementer(implementer);
+
+    verify(implementer).onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(0.5)));
+  }
+
+  @Test
+  void updatePoliciesNotifiesRegisteredImplementerWithRelevantPolicies() {
+    PolicyStore store = new PolicyStore();
+    PolicyImplementer implementer = mock(PolicyImplementer.class);
+    PolicyValidator validator = mock(PolicyValidator.class);
+    when(validator.getPolicyType()).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
+    when(implementer.getValidators()).thenReturn(singletonList(validator));
+
+    store.registerImplementer(implementer);
+    clearInvocations(implementer);
+    store.updatePolicies(
+        Arrays.asList(new TelemetryPolicy("other-policy"), new TraceSamplingRatePolicy(0.25)));
+
+    verify(implementer).onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(0.25)));
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.dynamic.policy;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,10 +91,7 @@ class PolicyStoreTest {
   @Test
   void updatePoliciesNotifiesRegisteredImplementerWithRelevantPolicies() {
     PolicyStore store = new PolicyStore();
-    PolicyImplementer implementer = mock(PolicyImplementer.class);
-    PolicyValidator validator = mock(PolicyValidator.class);
-    when(validator.getPolicyType()).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
-    when(implementer.getValidators()).thenReturn(singletonList(validator));
+    PolicyImplementer implementer = traceSamplingImplementer();
 
     store.registerImplementer(implementer);
     clearInvocations(implementer);
@@ -101,5 +99,53 @@ class PolicyStoreTest {
         Arrays.asList(new TelemetryPolicy("other-policy"), new TraceSamplingRatePolicy(0.25)));
 
     verify(implementer).onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(0.25)));
+  }
+
+  @Test
+  void updatePoliciesContinuesWhenImplementerThrows() {
+    PolicyStore store = new PolicyStore();
+    PolicyImplementer failingImplementer = traceSamplingImplementer();
+    PolicyImplementer nextImplementer = traceSamplingImplementer();
+    List<TelemetryPolicy> updatedPolicies = singletonList(new TraceSamplingRatePolicy(0.25));
+    doThrow(new IllegalStateException("boom"))
+        .when(failingImplementer)
+        .onPoliciesChanged(updatedPolicies);
+
+    store.registerImplementer(failingImplementer);
+    store.registerImplementer(nextImplementer);
+    clearInvocations(failingImplementer, nextImplementer);
+
+    assertThat(store.updatePolicies(updatedPolicies)).isTrue();
+
+    verify(failingImplementer).onPoliciesChanged(updatedPolicies);
+    verify(nextImplementer).onPoliciesChanged(updatedPolicies);
+    assertThat(store.getPolicies()).isEqualTo(updatedPolicies);
+  }
+
+  @Test
+  void registerImplementerContinuesAfterPreviousImplementerThrows() {
+    PolicyStore store = new PolicyStore();
+    List<TelemetryPolicy> currentPolicies = singletonList(new TraceSamplingRatePolicy(0.5));
+    assertThat(store.updatePolicies(currentPolicies)).isTrue();
+
+    PolicyImplementer failingImplementer = traceSamplingImplementer();
+    PolicyImplementer nextImplementer = traceSamplingImplementer();
+    doThrow(new IllegalStateException("boom"))
+        .when(failingImplementer)
+        .onPoliciesChanged(currentPolicies);
+
+    store.registerImplementer(failingImplementer);
+    store.registerImplementer(nextImplementer);
+
+    verify(failingImplementer).onPoliciesChanged(currentPolicies);
+    verify(nextImplementer).onPoliciesChanged(currentPolicies);
+  }
+
+  private static PolicyImplementer traceSamplingImplementer() {
+    PolicyImplementer implementer = mock(PolicyImplementer.class);
+    PolicyValidator validator = mock(PolicyValidator.class);
+    when(validator.getPolicyType()).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
+    when(implementer.getValidators()).thenReturn(singletonList(validator));
+    return implementer;
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -8,10 +8,13 @@ package io.opentelemetry.contrib.dynamic.policy.registry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -21,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -95,6 +99,28 @@ class PolicyInitTest {
         .hasMessageContaining("Unknown policyType");
   }
 
+  @Test
+  void initializesPolicyClassOnlyOnceAcrossRepeatedInitCalls() {
+    String policyType = "test-policy-idempotent";
+    AtomicInteger initializeCount = new AtomicInteger();
+    PolicyImplementer implementer = mock(PolicyImplementer.class);
+    when(implementer.getValidators()).thenReturn(Collections.emptyList());
+    PolicyInit.registerPolicyType(
+        policyType,
+        IdempotentTestPolicy.class,
+        autoConfiguration -> {
+          initializeCount.incrementAndGet();
+          return implementer;
+        });
+    ConfigProperties config = mock(ConfigProperties.class);
+
+    PolicyInit.initFromDeclarativeConfig(telemetryPolicyNodeConfig(policyType), config);
+    PolicyInit.initFromDeclarativeConfig(telemetryPolicyNodeConfig(policyType), config);
+
+    assertThat(initializeCount.get()).isEqualTo(1);
+    verify(implementer, times(1)).onPoliciesChanged(Collections.emptyList());
+  }
+
   private static Function<ConfigProperties, Map<String, String>> capturePropertiesCustomizer(
       AutoConfigurationCustomizer customizer) {
     @SuppressWarnings("unchecked")
@@ -133,5 +159,11 @@ class PolicyInitTest {
         + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\""
         + TraceSamplingRatePolicy.POLICY_TYPE
         + "\"}]}]}";
+  }
+
+  private static final class IdempotentTestPolicy extends TelemetryPolicy {
+    private IdempotentTestPolicy() {
+      super("test-policy-idempotent");
+    }
   }
 }


### PR DESCRIPTION
**Description:**

Wire up implementers so they get applied by policies.

closes #2546 

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2546

**Testing:**

Added

**Documentation:**

Previously included

**Outstanding items:**

Wiring up the policy pipeline: 
- Generic: message -> provider -> policy -> policy handler -> implementer
- eg "change sampling rate" message -> OpampPolicyProvider -> TraceSamplingRatePolicy -> PolicyStore -> TraceSamplingRatePolicyImplementer

Steps needed for the wiring:
- configuring the pipeline
   - DONE: PolicyInitConfig
- providers reading policies, eg OpampPolicyProvider, FilePolicyProvider, etc
   - DONE: OpampPolicyProvider
- implementers applying policies, eg TraceSamplingRatePolicyImplementer
   - DONE: TraceSamplingRatePolicyImplementer
- policy structures (eg TraceSamplingRatePolicy) that the provider converts messages into
   - DONE: TraceSamplingRatePolicy
- registering config to policy structures (eg "trace_sampling_rate_policy" registered to TraceSamplingRatePolicy)
   - DONE: PolicyInit static initialiizer
- initializing policy classes (eg TraceSamplingRatePolicy needs to install a custom sampler)
   - DONE: TraceSamplingRatePolicy initialization
- activate configured providers (eg start OpampPolicyprovider reading from it's source)
   - DONE
- register implementers for policies (eg a new TraceSamplingRatePolicy is applied by a TraceSamplingRatePolicyImplementer)
   - This PR
- link the provider to processing policies and applying implementers
   - DONE PolicyInit