### PR TITLE
Use protected environment for publishing secrets

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable-lint.yml
 
   publish-snapshots:
+    environment: protected
     needs:
       - common
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   release:
+    environment: protected
     permissions:
       contents: write # for creating the release
       id-token: write # for signing artifacts with Sigstore

--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   analyze:
+    environment: protected
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Use the protected environment for workflow jobs that read publishing or Sonatype audit secrets.

I added the new env and secrets. I'm going to wait until after next minor release to remove the existing ones in case a patch release is needed on the current minor release (whose release branch doesn't have the new workflow yaml environment declaration).