### PR TITLE
[dynamic control] enable autoconfigurable extension

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfiguration.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfiguration.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.dynamic;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import java.util.logging.Level;
@@ -26,6 +27,7 @@ public class DynamicControlAutoConfiguration implements AutoConfigurationCustomi
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     logger.log(Level.INFO, "Dynamic control extension has been loaded by the agent");
+    PolicyInit.init(autoConfiguration);
   }
 
   @Override

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfiguration.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfiguration.java
@@ -27,7 +27,14 @@ public class DynamicControlAutoConfiguration implements AutoConfigurationCustomi
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     logger.log(Level.INFO, "Dynamic control extension has been loaded by the agent");
-    PolicyInit.init(autoConfiguration);
+    try {
+      PolicyInit.init(autoConfiguration);
+    } catch (RuntimeException e) {
+      logger.log(
+          Level.SEVERE,
+          "Dynamic control policy initialization failed; continuing without dynamic control",
+          e);
+    }
   }
 
   @Override

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.contrib.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import org.junit.jupiter.api.Test;
@@ -20,8 +22,7 @@ class DynamicControlAutoConfigurationTest {
 
     config.customize(customizer);
 
-    // The customize method should not throw and should be callable
-    // Logging is tested manually or via integration tests
+    verify(customizer).addPropertiesCustomizer(any());
   }
 
   @Test

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
@@ -6,23 +6,58 @@
 package io.opentelemetry.contrib.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 class DynamicControlAutoConfigurationTest {
+  private static final String POLICY_INIT_CONFIG_PROPERTY_JSON =
+      "otel.java.experimental.telemetry.policy.init.json";
+  private static final String POLICY_INIT_CONFIG_PROPERTY_YAML =
+      "otel.java.experimental.telemetry.policy.init.yaml";
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void tearDown() throws Exception {
+    invokeStaticNoArg(PolicyInit.class, "resetForTest");
+    invokeStaticNoArg(TraceSamplingRatePolicy.class, "resetForTest");
+  }
 
   @Test
-  void testCustomize() {
+  void customizeRegistersPropertiesCustomizerThatInitializesConfiguredPolicy() throws Exception {
     DynamicControlAutoConfiguration config = new DynamicControlAutoConfiguration();
     AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
 
     config.customize(customizer);
+    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
+        capturePropertiesCustomizer(customizer);
 
-    verify(customizer).addPropertiesCustomizer(any());
+    Path configPath = tempDir.resolve("policy-init.yaml");
+    Files.write(configPath, minimalYamlInitConfig().getBytes(StandardCharsets.UTF_8));
+    ConfigProperties properties = mock(ConfigProperties.class);
+    when(properties.getString(POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(configPath.toString());
+    when(properties.getString(POLICY_INIT_CONFIG_PROPERTY_JSON)).thenReturn(null);
+
+    Map<String, String> overrides = propertiesCustomizer.apply(properties);
+
+    assertThat(overrides).isEmpty();
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNotNull();
   }
 
   @Test
@@ -31,5 +66,32 @@ class DynamicControlAutoConfigurationTest {
     DynamicControlAutoConfiguration config = new DynamicControlAutoConfiguration();
     // Default order should be 0
     assertThat(config.order()).isEqualTo(0);
+  }
+
+  private static Function<ConfigProperties, Map<String, String>> capturePropertiesCustomizer(
+      AutoConfigurationCustomizer customizer) {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Function<ConfigProperties, Map<String, String>>> captor =
+        ArgumentCaptor.forClass(Function.class);
+    verify(customizer).addPropertiesCustomizer(captor.capture());
+    return captor.getValue();
+  }
+
+  private static String minimalYamlInitConfig() {
+    return "sources:\n"
+        + "  - kind: opamp\n"
+        + "    format: jsonkeyvalue\n"
+        + "    location: vendor\n"
+        + "    mappings:\n"
+        + "      - sourceKey: sampling_rate\n"
+        + "        policyType: "
+        + TraceSamplingRatePolicy.POLICY_TYPE
+        + "\n";
+  }
+
+  private static void invokeStaticNoArg(Class<?> targetClass, String methodName) throws Exception {
+    Method method = targetClass.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(null);
   }
 }


### PR DESCRIPTION
**Description:**

Initial Telemetry policy implementation is done with one policy supported (sampling rate changes), this enables the extension to be autoconfigurable

**Existing Issue(s):**

https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2416

**Testing:**

Manually tested as working end-to-end with changes

**Documentation:**

To be added

**Outstanding items:**

see #2868 