### PR TITLE
[dynamic control] Add shadowJar target for fat jar including dependencies

### DIFF
--- a/dynamic-control/build.gradle.kts
+++ b/dynamic-control/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("com.gradleup.shadow")
   id("otel.java-conventions")
   id("otel.publish-conventions")
 }
@@ -38,4 +39,14 @@ dependencies {
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-inline")
   testImplementation("org.mockito:mockito-junit-jupiter")
+}
+
+tasks {
+  shadowJar {
+    archiveClassifier.set("all")
+    mergeServiceFiles()
+    manifest {
+      attributes["Implementation-Version"] = project.version
+    }
+  }
 }


### PR DESCRIPTION
**Description:**

New target `gradlew :dynamic-control:shadowJar` which produces `dynamic-control\build\libs\opentelemetry-dynamic-control-*-all.jar` that includes dependencies which is really useful for using the project as an extension

**Existing Issue(s):**

part of #2868 

**Testing:**

Manually built

**Documentation:**

To be added in the readme for how to build and use the extension

**Outstanding items:**

see #2868 