### PR TITLE
Gate use of mavenLocal and use https for license

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 repositories {
   mavenCentral()
   gradlePluginPortal()
-  mavenLocal()
+  if (providers.gradleProperty("useLocalMaven").isPresent) {
+    mavenLocal()
+  }
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -42,7 +42,7 @@ publishing {
         licenses {
           license {
             name.set("The Apache License, Version 2.0")
-            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
           }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,9 @@ plugins {
 dependencyResolutionManagement {
   repositories {
     mavenCentral()
-    mavenLocal()
+    if (providers.gradleProperty("useLocalMaven").isPresent) {
+      mavenLocal()
+    }
     // for otel snapshots
     maven {
       url = uri("https://central.sonatype.com/repository/maven-snapshots/")


### PR DESCRIPTION
**Description:**

Avoid using `mavenLocal()` by default since it introduces non-reproducible builds and bypasses normal artifact provenance controls. Make local artifact resolution opt-in.