### PR TITLE
Change ibm-mq-metrics to use snake yaml engine v2

### DIFF
--- a/ibm-mq-metrics/build.gradle.kts
+++ b/ibm-mq-metrics/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   api("io.swagger:swagger-annotations:1.6.16")
   api("org.jetbrains:annotations:26.1.0")
   api("com.ibm.mq:com.ibm.mq.allclient:9.4.5.1")
-  api("org.yaml:snakeyaml:2.6")
+  api("org.snakeyaml:snakeyaml-engine:2.10")
   api("com.fasterxml.jackson.core:jackson-databind:2.21.3")
   api("io.opentelemetry:opentelemetry-sdk")
   api("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapper.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapper.java
@@ -7,6 +7,7 @@ package io.opentelemetry.ibm.mq.opentelemetry;
 
 import static java.util.Collections.emptyList;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -37,15 +38,19 @@ public final class ConfigWrapper {
     this.config = config;
   }
 
-  @SuppressWarnings(
-      "unchecked") // snakeyaml-engine returns Object; a valid config file is always a map
   public static ConfigWrapper parse(String configFile) throws IOException {
     Load load = new Load(LoadSettings.builder().build());
-    Map<String, ?> config =
-        (Map<String, ?>)
-            load.loadFromReader(
-                Files.newBufferedReader(Paths.get(configFile), Charset.defaultCharset()));
-    return new ConfigWrapper(config);
+    try (BufferedReader reader =
+        Files.newBufferedReader(Paths.get(configFile), Charset.defaultCharset())) {
+      Object loaded = load.loadFromReader(reader);
+      if (!(loaded instanceof Map)) {
+        throw new IllegalArgumentException(
+            "Config file does not contain a YAML map: " + configFile);
+      }
+      @SuppressWarnings("unchecked") // Verified above
+      Map<String, ?> config = (Map<String, ?>) loaded;
+      return new ConfigWrapper(config);
+    }
   }
 
   public int getNumberOfThreads() {

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapper.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapper.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 /** Low-fi domain-specific yaml wrapper. */
 public final class ConfigWrapper {
@@ -36,10 +37,14 @@ public final class ConfigWrapper {
     this.config = config;
   }
 
+  @SuppressWarnings(
+      "unchecked") // snakeyaml-engine returns Object; a valid config file is always a map
   public static ConfigWrapper parse(String configFile) throws IOException {
-    Yaml yaml = new Yaml();
+    Load load = new Load(LoadSettings.builder().build());
     Map<String, ?> config =
-        yaml.load(Files.newBufferedReader(Paths.get(configFile), Charset.defaultCharset()));
+        (Map<String, ?>)
+            load.loadFromReader(
+                Files.newBufferedReader(Paths.get(configFile), Charset.defaultCharset()));
     return new ConfigWrapper(config);
   }
 

--- a/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapperTest.java
+++ b/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapperTest.java
@@ -6,12 +6,19 @@
 package io.opentelemetry.ibm.mq.opentelemetry;
 
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
 
 class ConfigWrapperTest {
 
@@ -47,5 +54,13 @@ class ConfigWrapperTest {
   void testTaskInitialDelay() throws Exception {
     ConfigWrapper config = ConfigWrapper.parse(file);
     assertThat(config.getTaskInitialDelaySeconds()).isEqualTo(0);
+  }
+
+  @Test
+  void testYamlTagDeserialisationRejected(@TempDir Path tempDir) throws IOException {
+    Path tempFile = tempDir.resolve("gadget.yml");
+    Files.write(tempFile, "!!java.lang.Runtime {}".getBytes(StandardCharsets.UTF_8));
+    assertThatThrownBy(() -> ConfigWrapper.parse(tempFile.toString()))
+        .isInstanceOf(YamlEngineException.class);
   }
 }

--- a/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapperTest.java
+++ b/ibm-mq-metrics/src/test/java/io/opentelemetry/ibm/mq/opentelemetry/ConfigWrapperTest.java
@@ -57,7 +57,7 @@ class ConfigWrapperTest {
   }
 
   @Test
-  void testYamlTagDeserialisationRejected(@TempDir Path tempDir) throws IOException {
+  void testYamlTagDeserializationRejected(@TempDir Path tempDir) throws IOException {
     Path tempFile = tempDir.resolve("gadget.yml");
     Files.write(tempFile, "!!java.lang.Runtime {}".getBytes(StandardCharsets.UTF_8));
     assertThatThrownBy(() -> ConfigWrapper.parse(tempFile.toString()))


### PR DESCRIPTION
Upgrade ibm-mq-metrics to use snake yaml engine v2. In addition to this being the latest version of the library, and the same version used in opentelemetry-java for declarative config, it also removes the possibility of arbitrary java type instantiation using custom YAML tags since support for that feature was dropped. 