### PR TITLE
[disk-buffering] Add guard for non-numeric files

### DIFF
--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
@@ -102,7 +102,11 @@ public final class FolderManager implements Closeable {
     closeCurrentFiles();
     List<File> undeletedFiles = new ArrayList<>();
 
-    for (File file : Objects.requireNonNull(folder.listFiles())) {
+    File[] files = folder.listFiles();
+    if (files == null) {
+      throw new IOException("Could not list files in " + folder);
+    }
+    for (File file : files) {
       if (!file.delete()) {
         undeletedFiles.add(file);
       }
@@ -172,7 +176,12 @@ public final class FolderManager implements Closeable {
       throws IOException {
     int filesDeleted = 0;
     for (File existingFile : existingFiles) {
-      if (hasExpiredForReading(currentTimeMillis, Long.parseLong(existingFile.getName()))) {
+      String fileName = existingFile.getName();
+      if (!NUMBER_PATTERN.matcher(fileName).matches()) {
+        logger.finer(String.format("Skipping non-cache file: '%s'", fileName));
+        continue;
+      }
+      if (hasExpiredForReading(currentTimeMillis, Long.parseLong(fileName))) {
         if (currentReadableFile != null && existingFile.equals(currentReadableFile.getFile())) {
           currentReadableFile.close();
         }

--- a/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
+++ b/disk-buffering/src/main/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManager.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -89,8 +90,9 @@ public final class FolderManager implements Closeable {
     long systemCurrentTimeMillis = nowMillis(clock);
     File[] existingFiles = folder.listFiles();
     if (existingFiles != null) {
-      if (purgeExpiredFilesIfAny(existingFiles, systemCurrentTimeMillis) == 0) {
-        removeOldestFileIfSpaceIsNeeded(existingFiles);
+      File[] cacheFiles = listNumericFiles(existingFiles);
+      if (purgeExpiredFilesIfAny(cacheFiles, systemCurrentTimeMillis) == 0) {
+        removeOldestFileIfSpaceIsNeeded(cacheFiles);
       }
     }
     File file = new File(folder, String.valueOf(systemCurrentTimeMillis));
@@ -132,11 +134,25 @@ public final class FolderManager implements Closeable {
     return Collections.unmodifiableList(files);
   }
 
+  private File[] listNumericFiles(File[] files) {
+    List<File> cacheFiles = new ArrayList<>();
+    for (File file : files) {
+      if (NUMBER_PATTERN.matcher(file.getName()).matches()) {
+        cacheFiles.add(file);
+      } else if (logger.isLoggable(Level.FINER)) {
+        logger.finer("Skipping non-cache file: '" + file.getName() + "'");
+      }
+    }
+    return cacheFiles.toArray(new File[0]);
+  }
+
   @Nullable
   private CacheFile fileToCacheFile(File file) {
     String fileName = file.getName();
     if (!NUMBER_PATTERN.matcher(fileName).matches()) {
-      logger.finer(String.format("Invalid cache file name: '%s'", fileName));
+      if (logger.isLoggable(Level.FINER)) {
+        logger.finer("Invalid cache file name: '" + fileName + "'");
+      }
       return null;
     }
     return new CacheFile(file, Long.parseLong(fileName));
@@ -177,10 +193,6 @@ public final class FolderManager implements Closeable {
     int filesDeleted = 0;
     for (File existingFile : existingFiles) {
       String fileName = existingFile.getName();
-      if (!NUMBER_PATTERN.matcher(fileName).matches()) {
-        logger.finer(String.format("Skipping non-cache file: '%s'", fileName));
-        continue;
-      }
       if (hasExpiredForReading(currentTimeMillis, Long.parseLong(fileName))) {
         if (currentReadableFile != null && existingFile.equals(currentReadableFile.getFile())) {
           currentReadableFile.close();

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.
 import static io.opentelemetry.contrib.disk.buffering.internal.storage.TestData.MIN_FILE_AGE_FOR_READ_MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -260,6 +261,31 @@ class FolderManagerTest {
     createFiles(writableFile);
 
     assertThat(getReadableFile()).isNull();
+  }
+
+  @Test
+  void createWritableFile_ignoresNonNumericFilesWhenPurgingExpired() throws IOException {
+    // Non-numeric files (e.g. .nomedia on Android, .DS_Store on macOS) must not crash the write
+    // path.
+    File nomedia = new File(rootDir, ".nomedia");
+    if (!nomedia.createNewFile()) {
+      fail("Could not create .nomedia file");
+    }
+    when(clock.now()).thenReturn(MILLISECONDS.toNanos(1000L));
+
+    WritableFile file = folderManager.createWritableFile();
+
+    assertThat(file.getFile().getName()).isEqualTo("1000");
+    assertThat(nomedia.exists()).isTrue();
+  }
+
+  @Test
+  void clear_throwsIOException_whenFolderIsUnreadable() {
+    rootDir.delete();
+
+    assertThatThrownBy(() -> folderManager.clear())
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Could not list files");
   }
 
   @Test

--- a/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
+++ b/disk-buffering/src/test/java/io/opentelemetry/contrib/disk/buffering/internal/storage/FolderManagerTest.java
@@ -281,7 +281,7 @@ class FolderManagerTest {
 
   @Test
   void clear_throwsIOException_whenFolderIsUnreadable() {
-    rootDir.delete();
+    assertThat(rootDir.delete()).isTrue();
 
     assertThatThrownBy(() -> folderManager.clear())
         .isInstanceOf(IOException.class)


### PR DESCRIPTION
**Description:**

`purgeExpiredFilesIfAny` was calling `Long.parseLong(...` with no guard, which could throw `NumberFormatException` for non-numeric files. The `fileToCacheFile` method already had a pattern check so made this method consistnt with that approach.

Also a small update for the `clear()` method, just adding a more descriptive error message instead of a generic NPE if a directory is unreachable.