### PR TITLE
[awsxray] Prevent regex on hot path

### DIFF
--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/AwsXrayRemoteSampler.java
@@ -37,7 +37,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -278,11 +277,10 @@ public final class AwsXrayRemoteSampler implements Sampler, Closeable {
   }
 
   private static String generateClientId() {
-    Random rand = new Random();
     char[] hex = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
     char[] clientIdChars = new char[24];
     for (int i = 0; i < clientIdChars.length; i++) {
-      clientIdChars[i] = hex[rand.nextInt(hex.length)];
+      clientIdChars[i] = hex[ThreadLocalRandom.current().nextInt(hex.length)];
     }
     return new String(clientIdChars);
   }

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
@@ -42,6 +42,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 final class XrayRulesSampler implements Sampler {
@@ -71,6 +72,7 @@ final class XrayRulesSampler implements Sampler {
   private final Cache<String, AwsXrayAdaptiveSamplingConfig.UsageType> traceUsageCache;
 
   @Nullable private AwsXrayAdaptiveSamplingConfig adaptiveSamplingConfig;
+  @Nullable private List<Pattern> errorCodePatterns;
   @Nullable private RateLimiter anomalyCaptureRateLimiter;
 
   XrayRulesSampler(
@@ -125,6 +127,7 @@ final class XrayRulesSampler implements Sampler {
     }
     this.adaptiveSamplingRuleExists = adaptiveSamplingRuleExists;
     this.adaptiveSamplingConfig = adaptiveSamplingConfig;
+    this.errorCodePatterns = compileErrorCodePatterns(adaptiveSamplingConfig);
     this.traceUsageCache = traceUsageCache;
 
     // Initialize anomaly capture rate limiter
@@ -208,6 +211,7 @@ final class XrayRulesSampler implements Sampler {
       throw new IllegalStateException("Programming bug - Adaptive sampling config is already set");
     } else if (config != null && this.adaptiveSamplingConfig == null) {
       this.adaptiveSamplingConfig = config;
+      this.errorCodePatterns = compileErrorCodePatterns(config);
 
       // Initialize anomaly capture rate limiter if error capture limit is configured
       if (config.getAnomalyCaptureLimit() != null) {
@@ -358,7 +362,8 @@ final class XrayRulesSampler implements Sampler {
       if (operation == null) {
         operation = generateIngressOperation(spanData);
       }
-      for (AwsXrayAdaptiveSamplingConfig.AnomalyConditions condition : anomalyConditions) {
+      for (int i = 0; i < anomalyConditions.size(); i++) {
+        AwsXrayAdaptiveSamplingConfig.AnomalyConditions condition = anomalyConditions.get(i);
         // Skip condition if it would only re-apply action already being taken
         if ((shouldBoostSampling
                 && AwsXrayAdaptiveSamplingConfig.UsageType.SAMPLING_BOOST.equals(
@@ -376,15 +381,16 @@ final class XrayRulesSampler implements Sampler {
         // Check if any anomalyConditions detect an anomaly either through error code or latency
         boolean isAnomaly = false;
 
-        String errorCodeRegex = condition.getErrorCodeRegex();
-        if (statusCode != null && errorCodeRegex != null) {
-          isAnomaly = statusCode.toString().matches(errorCodeRegex);
+        Pattern errorCodePattern =
+            (errorCodePatterns != null) ? errorCodePatterns.get(i) : null;
+        if (statusCode != null && errorCodePattern != null) {
+          isAnomaly = errorCodePattern.matcher(statusCode.toString()).matches();
         }
 
         Long highLatencyMs = condition.getHighLatencyMs();
         if (highLatencyMs != null) {
           isAnomaly =
-              (errorCodeRegex == null || isAnomaly)
+              (errorCodePattern == null || isAnomaly)
                   && (span.getLatencyNanos() / 1_000_000.0) >= highLatencyMs;
         }
 
@@ -490,6 +496,17 @@ final class XrayRulesSampler implements Sampler {
     } else {
       this.traceUsageCache.put(traceId, AwsXrayAdaptiveSamplingConfig.UsageType.NEITHER);
     }
+  }
+
+  @Nullable
+  private static List<Pattern> compileErrorCodePatterns(
+      @Nullable AwsXrayAdaptiveSamplingConfig config) {
+    if (config == null || config.getAnomalyConditions() == null) {
+      return null;
+    }
+    return config.getAnomalyConditions().stream()
+        .map(c -> c.getErrorCodeRegex() != null ? Pattern.compile(c.getErrorCodeRegex()) : null)
+        .collect(toList());
   }
 
   private static Map<String, String> createRuleHashMaps(

--- a/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
+++ b/aws-xray/src/main/java/io/opentelemetry/contrib/awsxray/XrayRulesSampler.java
@@ -381,8 +381,7 @@ final class XrayRulesSampler implements Sampler {
         // Check if any anomalyConditions detect an anomaly either through error code or latency
         boolean isAnomaly = false;
 
-        Pattern errorCodePattern =
-            (errorCodePatterns != null) ? errorCodePatterns.get(i) : null;
+        Pattern errorCodePattern = (errorCodePatterns != null) ? errorCodePatterns.get(i) : null;
         if (statusCode != null && errorCodePattern != null) {
           isAnomaly = errorCodePattern.matcher(statusCode.toString()).matches();
         }


### PR DESCRIPTION
**Description:**

Small fixes

- Remove use of `Random()`
- Pre-compiling the regex pattern once when the adaptive sampling config is applied so it doesn't need to re-parse and compile the same regex string on every span that passes through the sampler.
