### PR TITLE
chore: fixing issue with extension service files being overriden

### DIFF
--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -62,7 +62,9 @@ tasks {
     // letting them overwrite each other. Without this, the SDK's EnvironmentResourceProvider
     // registration is dropped and OTEL_RESOURCE_ATTRIBUTES / OTEL_SERVICE_NAME are ignored.
     mergeServiceFiles()
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE // required for mergeServiceFiles()
+    filesMatching("META-INF/services/**") {
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
   }
 
   assemble {

--- a/maven-extension/build.gradle.kts
+++ b/maven-extension/build.gradle.kts
@@ -58,6 +58,11 @@ tasks {
       attributes["Implementation-Version"] = project.version
     }
     archiveClassifier.set("")
+    // Concatenate colliding META-INF/services SPI files from bundled dependencies instead of
+    // letting them overwrite each other. Without this, the SDK's EnvironmentResourceProvider
+    // registration is dropped and OTEL_RESOURCE_ATTRIBUTES / OTEL_SERVICE_NAME are ignored.
+    mergeServiceFiles()
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE // required for mergeServiceFiles()
   }
 
   assemble {


### PR DESCRIPTION

**Description:**

The maven-extension service files were being overridden, which lead to EnvironmentResourceProvider not being respected and forcing the span attributes to be whatever is defaulted. This lead to things like service.name and service.version always being hard coded to the maven version (see below)

Snippets from a build job where i had this jar committed

old
```
16:30:38  [DEBUG] OpenTelemetry: OpenTelemetrySdkService initialized, resource:Resource{schemaUrl=null, attributes={service.name="maven", service.version="3.8.9", telemetry.distro.name="opentelemetry-maven-extension", telemetry.distro.version="1.57.0-alpha", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.62.0"}}
```

new
```
15:18:46  [DEBUG] OpenTelemetry: OpenTelemetry SDK initialized with  Configuration: otel.traces.exporter=otlp, otel.exporter.otlp.endpoint=http://<otlp endpoint>, otel.resource.attributes=deployment.environment=prod,service.version=1.0.27-20260528151646,location=CI,build.release=false, otel.service.name=build, Resource: {build.release="false", deployment.environment="prod", location="CI", service.name="build", service.version="1.0.27-20260528151646", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.27.0"}
```


**Existing Issue(s):**

#2537 

**Testing:**

I wired up the jar by overriding the maven extension path to see the debug logs showing the OTEL_RESOURCE_ATTRIBUTES was being respected by adding our custom tags

