### PR TITLE
fix(ibm-mq-metrics): update metric unit from 'microseconds' to 'us'

### DIFF
--- a/ibm-mq-metrics/docs/metrics.md
+++ b/ibm-mq-metrics/docs/metrics.md
@@ -342,7 +342,7 @@
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `ibm.mq.oldest.msg.age` | Gauge | `microseconds` | Queue message oldest age | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ibm.mq.oldest.msg.age` | Gauge | `us` | Queue message oldest age | ![Development](https://img.shields.io/badge/-development-blue) |
 
 
 ### `ibm.mq.oldest.msg.age` Attributes
@@ -558,7 +558,7 @@
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `ibm.mq.onqtime.short_period` | Gauge | `microseconds` | Amount of time, in microseconds, that a message spent on the queue, over a short period | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ibm.mq.onqtime.short_period` | Gauge | `us` | Amount of time, in microseconds, that a message spent on the queue, over a short period | ![Development](https://img.shields.io/badge/-development-blue) |
 
 
 ### `ibm.mq.onqtime.short_period` Attributes
@@ -577,7 +577,7 @@
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `ibm.mq.onqtime.long_period` | Gauge | `microseconds` | Amount of time, in microseconds, that a message spent on the queue, over a longer period | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ibm.mq.onqtime.long_period` | Gauge | `us` | Amount of time, in microseconds, that a message spent on the queue, over a longer period | ![Development](https://img.shields.io/badge/-development-blue) |
 
 
 ### `ibm.mq.onqtime.long_period` Attributes

--- a/ibm-mq-metrics/docs/metrics.md
+++ b/ibm-mq-metrics/docs/metrics.md
@@ -342,7 +342,7 @@
 
 | Name     | Instrument Type | Unit (UCUM) | Description    | Stability |
 | -------- | --------------- | ----------- | -------------- | --------- |
-| `ibm.mq.oldest.msg.age` | Gauge | `us` | Queue message oldest age | ![Development](https://img.shields.io/badge/-development-blue) |
+| `ibm.mq.oldest.msg.age` | Gauge | `s` | Queue message oldest age | ![Development](https://img.shields.io/badge/-development-blue) |
 
 
 ### `ibm.mq.oldest.msg.age` Attributes

--- a/ibm-mq-metrics/model/metrics.yaml
+++ b/ibm-mq-metrics/model/metrics.yaml
@@ -283,7 +283,7 @@ groups:
     stability: development
     brief: "Queue message oldest age"
     instrument: gauge
-    unit: "us"
+    unit: "s"
     attributes:
       - ref: ibm.mq.queue.manager
         requirement_level: required

--- a/ibm-mq-metrics/model/metrics.yaml
+++ b/ibm-mq-metrics/model/metrics.yaml
@@ -283,7 +283,7 @@ groups:
     stability: development
     brief: "Queue message oldest age"
     instrument: gauge
-    unit: "microseconds"
+    unit: "us"
     attributes:
       - ref: ibm.mq.queue.manager
         requirement_level: required
@@ -439,7 +439,7 @@ groups:
     stability: development
     brief: "Amount of time, in microseconds, that a message spent on the queue, over a short period"
     instrument: gauge
-    unit: "microseconds"
+    unit: "us"
     attributes:
       - ref: ibm.mq.queue.manager
         requirement_level: required
@@ -453,7 +453,7 @@ groups:
     stability: development
     brief: "Amount of time, in microseconds, that a message spent on the queue, over a longer period"
     instrument: gauge
-    unit: "microseconds"
+    unit: "us"
     attributes:
       - ref: ibm.mq.queue.manager
         requirement_level: required

--- a/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/MetricProducer.java
+++ b/ibm-mq-metrics/src/main/java/io/opentelemetry/ibm/mq/metrics/MetricProducer.java
@@ -375,7 +375,7 @@ public final class MetricProducer implements io.opentelemetry.sdk.metrics.export
             this.instrumentationScopeInfo,
             "ibm.mq.oldest.msg.age",
             "Queue message oldest age",
-            "microseconds",
+            "us",
             MetricDataType.LONG_GAUGE,
             GaugeData.createLongGaugeData(
                 Collections.singletonList(
@@ -555,7 +555,7 @@ public final class MetricProducer implements io.opentelemetry.sdk.metrics.export
             this.instrumentationScopeInfo,
             "ibm.mq.onqtime.short_period",
             "Amount of time, in microseconds, that a message spent on the queue, over a short period",
-            "microseconds",
+            "us",
             MetricDataType.LONG_GAUGE,
             GaugeData.createLongGaugeData(
                 Collections.singletonList(
@@ -570,7 +570,7 @@ public final class MetricProducer implements io.opentelemetry.sdk.metrics.export
             this.instrumentationScopeInfo,
             "ibm.mq.onqtime.long_period",
             "Amount of time, in microseconds, that a message spent on the queue, over a longer period",
-            "microseconds",
+            "us",
             MetricDataType.LONG_GAUGE,
             GaugeData.createLongGaugeData(
                 Collections.singletonList(


### PR DESCRIPTION
**Description:**
This PR updates the metric unit for time-based metrics (`oldest.msg.age`, `onqtime.short_period`, `onqtime.long_period`) from `"microseconds"` to `"us".` 

**Existing Issue(s):**
Fixes #2838

**Documentation:**
Updated `docs/metrics.md` to reflect the correct `us` unit in the markdown tables. 
