### PR TITLE
document app_server resource detector with declarative config

### DIFF
--- a/resource-providers/README.md
+++ b/resource-providers/README.md
@@ -42,9 +42,10 @@ resource:
       - service:
 ```
 
-The `app_server` detector needs to be listed before the `service` detector to give priority over
-the `service.name` value set by the `service` detector. Also, the `detection/development` resource
-detection has lower priority than the explicit configuration of `service.name` resource attribute.
+The `app_server` detector needs to be listed before the `service` detector to allow overriding
+the `service.name` attribute with the `OTEL_SERVICE_NAME` environment variable. Also, the resource
+detectors in `detection/development` have lower priority over the explicit `resource.attributes`
+configuration.
 
 ## Component owners
 

--- a/resource-providers/README.md
+++ b/resource-providers/README.md
@@ -26,6 +26,23 @@ It is capable of detecting common scenarios among the popular application server
 * IBM Websphere Liberty
 * Wildfly
 
+## Usage with Declarative configuration
+
+```yaml
+file_format: "1.0"
+resource:
+  detection/development:
+    detectors:
+      # Provides 'service.name' from the application server
+      - app_server:
+      # Provides 'service.name' and 'service.instance.id'
+      - service:
+```
+
+The `app_server` detector needs to be listed before the `service` detector to give priority over
+the `service.name` value set by the `service` detector. Also, the `detection/development` resource
+detection has lower priority than the explicit configuration of `service.name` resource attribute.
+
 ## Component owners
 
 * [Jason Plumb](https://github.com/breedx-splk), Splunk

--- a/resource-providers/README.md
+++ b/resource-providers/README.md
@@ -26,7 +26,10 @@ It is capable of detecting common scenarios among the popular application server
 * IBM Websphere Liberty
 * Wildfly
 
-## Usage with Declarative configuration
+## Usage with declarative configuration
+
+You can configure the app server resource detector using declarative YAML configuration with the
+OpenTelemetry SDK. For example:
 
 ```yaml
 file_format: "1.0"


### PR DESCRIPTION
The `app_server` resource provider is compatible with declarative configuration but lacks documentation about it.

This PR provides a sample yaml configuration to document usage with declarative configuration.