### PR TITLE
feat(gcp-auth): support 'none' option in GOOGLE_OTEL_AUTH_TARGET_SIGNALS

### DIFF
--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -64,7 +64,7 @@ Here is a list of required and optional configuration available for the extensio
 * `GOOGLE_OTEL_AUTH_TARGET_SIGNALS`: Environment variable that specifies a
   comma-separated list of OpenTelemetry signals for which this authentication
   extension should be active.
-  Valid values are `metrics`, `traces`, and `all`.
+  Valid values are `metrics`, `traces`, `all`, and `none`.
   If left unspecified, `all` is assumed, meaning the extension will attempt to
   apply authentication to exports for all signals.
 

--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -66,7 +66,9 @@ Here is a list of required and optional configuration available for the extensio
   extension should be active.
   Valid values are `metrics`, `traces`, `all`, and `none`.
   If left unspecified, `all` is assumed, meaning the extension will attempt to
-  apply authentication to exports for all signals.
+  apply authentication to exports for all signals. If `none` is set, disables
+  authentication for all exports. If set alongside other signal types,
+  it takes precedence and all other signal types will be ignored.
 
   * Can also be configured using `google.otel.auth.target.signals` system property.
 

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -46,7 +46,7 @@ enum ConfigurableOption {
    *   <li>{@code metrics} - Enables authentication for metric exports.
    *   <li>{@code traces} - Enables authentication for trace exports.
    *   <li>{@code all} - Enables authentication for all exports.
-   *   <li>{@code none} - Disables authentication for all exports.
+   *   <li>{@code none} - Disables authentication for all exports. If set alongside other signal types, it takes precedence and all other signal types will be ignored.
    * </ul>
    *
    * <p>The values are case-sensitive. Whitespace around commas and values is ignored. Can be

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -46,7 +46,8 @@ enum ConfigurableOption {
    *   <li>{@code metrics} - Enables authentication for metric exports.
    *   <li>{@code traces} - Enables authentication for trace exports.
    *   <li>{@code all} - Enables authentication for all exports.
-   *   <li>{@code none} - Disables authentication for all exports. If set alongside other signal types, it takes precedence and all other signal types will be ignored.
+   *   <li>{@code none} - Disables authentication for all exports. If set alongside other signal
+   *       types, it takes precedence and all other signal types will be ignored.
    * </ul>
    *
    * <p>The values are case-sensitive. Whitespace around commas and values is ignored. Can be

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -46,6 +46,7 @@ enum ConfigurableOption {
    *   <li>{@code metrics} - Enables authentication for metric exports.
    *   <li>{@code traces} - Enables authentication for trace exports.
    *   <li>{@code all} - Enables authentication for all exports.
+   *   <li>{@code none} - Disables authentication for all exports.
    * </ul>
    *
    * <p>The values are case-sensitive. Whitespace around commas and values is ignored. Can be

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -70,6 +70,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   static final String SIGNAL_TYPE_TRACES = "traces";
   static final String SIGNAL_TYPE_METRICS = "metrics";
   static final String SIGNAL_TYPE_ALL = "all";
+  static final String SIGNAL_TYPE_NONE = "none";
 
   /**
    * Customizes the provided {@link AutoConfigurationCustomizer} such that authenticated exports to
@@ -126,7 +127,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       SpanExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
       return addAuthorizationHeaders(exporter, credentials, configProperties);
-    } else {
+    } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
       String[] params = {SIGNAL_TYPE_TRACES, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
           Level.WARNING,
@@ -140,7 +141,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       MetricExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
       return addAuthorizationHeaders(exporter, credentials, configProperties);
-    } else {
+    } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
       String[] params = {SIGNAL_TYPE_METRICS, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
           Level.WARNING,
@@ -152,14 +153,19 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   // Checks if the auth extension is configured to target the passed signal for authentication.
   private static boolean isSignalTargeted(String checkSignal, ConfigProperties configProperties) {
+    if (hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
+      return false;
+    }
+    return hasSignal(checkSignal, configProperties) || hasSignal(SIGNAL_TYPE_ALL, configProperties);
+  }
+
+  private static boolean hasSignal(String signal, ConfigProperties configProperties) {
     String userSpecifiedTargetedSignals =
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getConfiguredValueWithFallback(
             configProperties, () -> SIGNAL_TYPE_ALL);
     return stream(userSpecifiedTargetedSignals.split(","))
         .map(String::trim)
-        .anyMatch(
-            targetedSignal ->
-                targetedSignal.equals(checkSignal) || targetedSignal.equals(SIGNAL_TYPE_ALL));
+        .anyMatch(targetedSignal -> targetedSignal.equals(signal));
   }
 
   // Adds authorization headers to the calls made by the OtlpGrpcSpanExporter and

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -34,9 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * An AutoConfigurationCustomizerProvider for Google Cloud Platform (GCP) OpenTelemetry (OTLP)
@@ -100,22 +102,32 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    */
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
-    GoogleCredentials credentials;
-    try {
-      credentials = GoogleCredentials.getApplicationDefault();
-    } catch (IOException e) {
-      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-    }
+    Supplier<GoogleCredentials> credentialsSupplier =
+        new Supplier<GoogleCredentials>() {
+          @Nullable private GoogleCredentials credentials;
+
+          @Override
+          public synchronized GoogleCredentials get() {
+            if (credentials == null) {
+              try {
+                credentials = GoogleCredentials.getApplicationDefault();
+              } catch (IOException e) {
+                throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+              }
+            }
+            return credentials;
+          }
+        };
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
-                customizeSpanExporter(spanExporter, credentials, configProperties))
+                customizeSpanExporter(spanExporter, credentialsSupplier, configProperties))
         .addMetricExporterCustomizer(
             (metricExporter, configProperties) ->
-                customizeMetricExporter(metricExporter, credentials, configProperties))
+                customizeMetricExporter(metricExporter, credentialsSupplier, configProperties))
         .addResourceCustomizer(
             (resource, configProperties) ->
-                customizeResource(resource, credentials, configProperties));
+                customizeResource(resource, credentialsSupplier, configProperties));
   }
 
   @Override
@@ -124,9 +136,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   private static SpanExporter customizeSpanExporter(
-      SpanExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
+      SpanExporter exporter,
+      Supplier<GoogleCredentials> credentialsSupplier,
+      ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentials, configProperties);
+      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
       String[] params = {SIGNAL_TYPE_TRACES, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
@@ -138,9 +152,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   private static MetricExporter customizeMetricExporter(
-      MetricExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
+      MetricExporter exporter,
+      Supplier<GoogleCredentials> credentialsSupplier,
+      ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentials, configProperties);
+      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
       String[] params = {SIGNAL_TYPE_METRICS, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
@@ -238,12 +254,18 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   // Updates the current resource with the attributes required for ingesting OTLP data on GCP.
   private static Resource customizeResource(
-      Resource resource, GoogleCredentials credentials, ConfigProperties configProperties) {
+      Resource resource,
+      Supplier<GoogleCredentials> credentialsSupplier,
+      ConfigProperties configProperties) {
+    if (!isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)
+        && !isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
+      return resource;
+    }
     String gcpProjectId;
     try {
       gcpProjectId = ConfigurableOption.GOOGLE_CLOUD_PROJECT.getConfiguredValue(configProperties);
     } catch (ConfigurationException e) {
-      gcpProjectId = credentials.getProjectId();
+      gcpProjectId = credentialsSupplier.get().getProjectId();
       if (gcpProjectId == null || gcpProjectId.isEmpty()) {
         throw e;
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.gcp.auth;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -141,11 +143,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
       return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
-    } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
-      String[] params = {SIGNAL_TYPE_TRACES, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
+    } else {
+      String[] params = {SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
           Level.WARNING,
-          "GCP Authentication Extension is not configured for signal type: {0}. {1}",
+          "GCP Authentication Extension is not configured for signal type: {0} or is configured with signal type: {1}. {2}",
           params);
     }
     return exporter;
@@ -157,11 +159,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
       return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
-    } else if (!hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
-      String[] params = {SIGNAL_TYPE_METRICS, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
+    } else {
+      String[] params = {SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
       logger.log(
           Level.WARNING,
-          "GCP Authentication Extension is not configured for signal type: {0}. {1}",
+          "GCP Authentication Extension is not configured for signal type: {0} or is configured with signal type: {1}. {2}",
           params);
     }
     return exporter;
@@ -169,19 +171,15 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   // Checks if the auth extension is configured to target the passed signal for authentication.
   private static boolean isSignalTargeted(String checkSignal, ConfigProperties configProperties) {
-    if (hasSignal(SIGNAL_TYPE_NONE, configProperties)) {
-      return false;
-    }
-    return hasSignal(checkSignal, configProperties) || hasSignal(SIGNAL_TYPE_ALL, configProperties);
-  }
-
-  private static boolean hasSignal(String signal, ConfigProperties configProperties) {
     String userSpecifiedTargetedSignals =
         ConfigurableOption.GOOGLE_OTEL_AUTH_TARGET_SIGNALS.getConfiguredValueWithFallback(
             configProperties, () -> SIGNAL_TYPE_ALL);
-    return stream(userSpecifiedTargetedSignals.split(","))
-        .map(String::trim)
-        .anyMatch(targetedSignal -> targetedSignal.equals(signal));
+    List<String> targetedSignals =
+        stream(userSpecifiedTargetedSignals.split(",")).map(String::trim).collect(toList());
+    if (targetedSignals.contains(SIGNAL_TYPE_NONE)) {
+      return false;
+    }
+    return targetedSignals.contains(checkSignal) || targetedSignals.contains(SIGNAL_TYPE_ALL);
   }
 
   // Adds authorization headers to the calls made by the OtlpGrpcSpanExporter and

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -144,7 +143,9 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
       return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else {
-      String[] params = {SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
+      String[] params = {
+        SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
+      };
       logger.log(
           Level.WARNING,
           "GCP Authentication Extension is not configured for signal type: {0} or is configured with signal type: {1}. {2}",
@@ -160,7 +161,9 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
       return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else {
-      String[] params = {SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION};
+      String[] params = {
+        SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
+      };
       logger.log(
           Level.WARNING,
           "GCP Authentication Extension is not configured for signal type: {0} or is configured with signal type: {1}. {2}",

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -761,6 +761,60 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
                         "none"))
                 .setExpectedIsMetricsSignalModified(false)
                 .setExpectedIsTraceSignalModified(false)
+                .build()),
+        Arguments.of(
+            TargetSignalBehavior.builder()
+                .setConfiguredTargetSignals("metrics, trace, none")
+                .setUserSpecifiedOtelProperties(
+                    ImmutableMap.of(
+                        "otel.exporter.otlp.metrics.endpoint",
+                        "https://localhost:4813/v1/metrics",
+                        "otel.exporter.otlp.traces.endpoint",
+                        "https://localhost:4813/v1/traces",
+                        "otel.traces.exporter",
+                        "otlp",
+                        "otel.metrics.exporter",
+                        "otlp",
+                        "otel.logs.exporter",
+                        "none"))
+                .setExpectedIsMetricsSignalModified(false)
+                .setExpectedIsTraceSignalModified(false)
+                .build()),
+        Arguments.of(
+            TargetSignalBehavior.builder()
+                .setConfiguredTargetSignals("all, none")
+                .setUserSpecifiedOtelProperties(
+                    ImmutableMap.of(
+                        "otel.exporter.otlp.metrics.endpoint",
+                        "https://localhost:4813/v1/metrics",
+                        "otel.exporter.otlp.traces.endpoint",
+                        "https://localhost:4813/v1/traces",
+                        "otel.traces.exporter",
+                        "otlp",
+                        "otel.metrics.exporter",
+                        "otlp",
+                        "otel.logs.exporter",
+                        "none"))
+                .setExpectedIsMetricsSignalModified(false)
+                .setExpectedIsTraceSignalModified(false)
+                .build()),
+        Arguments.of(
+            TargetSignalBehavior.builder()
+                .setConfiguredTargetSignals("metrics, none")
+                .setUserSpecifiedOtelProperties(
+                    ImmutableMap.of(
+                        "otel.exporter.otlp.metrics.endpoint",
+                        "https://localhost:4813/v1/metrics",
+                        "otel.exporter.otlp.traces.endpoint",
+                        "https://localhost:4813/v1/traces",
+                        "otel.traces.exporter",
+                        "otlp",
+                        "otel.metrics.exporter",
+                        "otlp",
+                        "otel.logs.exporter",
+                        "none"))
+                .setExpectedIsMetricsSignalModified(false)
+                .setExpectedIsTraceSignalModified(false)
                 .build()));
   }
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -743,6 +743,24 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
                         "none"))
                 .setExpectedIsMetricsSignalModified(true)
                 .setExpectedIsTraceSignalModified(false)
+                .build()),
+        Arguments.of(
+            TargetSignalBehavior.builder()
+                .setConfiguredTargetSignals("none")
+                .setUserSpecifiedOtelProperties(
+                    ImmutableMap.of(
+                        "otel.exporter.otlp.metrics.endpoint",
+                        "https://localhost:4813/v1/metrics",
+                        "otel.exporter.otlp.traces.endpoint",
+                        "https://localhost:4813/v1/traces",
+                        "otel.traces.exporter",
+                        "otlp",
+                        "otel.metrics.exporter",
+                        "otlp",
+                        "otel.logs.exporter",
+                        "none"))
+                .setExpectedIsMetricsSignalModified(false)
+                .setExpectedIsTraceSignalModified(false)
                 .build()));
   }
 


### PR DESCRIPTION
## Description
This PR introduces a new `none` option for the `GOOGLE_OTEL_AUTH_TARGET_SIGNALS` environment variable (and `google.otel.auth.target.signals` system property) in the GCP Authentication Extension.

Previously, there was no explicit way to completely disable the extension if it was loaded. This change allows users to explicitly set the target signals to `none`, which:
 
1.  Disables authentication (no authorization headers are added) for all signals.
2.  Suppresses the warning logs (e.g., "GCP Authentication Extension is not configured for signal type...") that would otherwise appear when signals are not targeted, ensuring a silent and intentional disablement.

Documentation in `README.md` and `ConfigurableOption` Javadoc has been updated to reflect this new option.

## Testing
*   Added a new parameterized test case in `GcpAuthAutoConfigurationCustomizerProviderTest` to verify that `none` correctly prevents modification of both traces and metrics exporters, and that warnings are suppressed.