### PR TITLE
feat(jmx): add tomcat.threads state=limit metric for max connector threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### JMX metrics / JMX scraper
+
+- Add `tomcat.threads` `state=limit` data point sourced from `maxThreads` attribute on `ThreadPool` MBean,
+  exposing the maximum number of threads configured per Tomcat connector
+
 ## Version 1.57.0 (2026-05-20)
 
 ### Baggage processor

--- a/jmx-metrics/docs/target-systems/tomcat.md
+++ b/jmx-metrics/docs/target-systems/tomcat.md
@@ -41,7 +41,7 @@ These metrics are sourced from: <https://docs.oracle.com/cd/E11857_01/em.111/e10
 * Name: `tomcat.threads`
 * Description: The number of threads.
 * Unit: `threads`
-* Labels: `proto_handler`, `state` (`idle`, `busy`, `limit`)
+* Labels: `proto_handler`, `state` (`idle` = currentThreadCount, `busy` = currentThreadsBusy, `limit` = maxThreads — the maximum configured threads for the connector)
 * Instrument Type: LongValueCallback
 
 ### tomcat.max_time

--- a/jmx-metrics/docs/target-systems/tomcat.md
+++ b/jmx-metrics/docs/target-systems/tomcat.md
@@ -41,7 +41,7 @@ These metrics are sourced from: <https://docs.oracle.com/cd/E11857_01/em.111/e10
 * Name: `tomcat.threads`
 * Description: The number of threads.
 * Unit: `threads`
-* Labels: `proto_handler`, `state`
+* Labels: `proto_handler`, `state` (`idle`, `busy`, `limit`)
 * Instrument Type: LongValueCallback
 
 ### tomcat.max_time

--- a/jmx-metrics/docs/target-systems/tomcat.md
+++ b/jmx-metrics/docs/target-systems/tomcat.md
@@ -41,7 +41,8 @@ These metrics are sourced from: <https://docs.oracle.com/cd/E11857_01/em.111/e10
 * Name: `tomcat.threads`
 * Description: The number of threads.
 * Unit: `threads`
-* Labels: `proto_handler`, `state` (`idle` = currentThreadCount, `busy` = currentThreadsBusy, `limit` = maxThreads — the maximum configured threads for the connector)
+* Labels: `proto_handler`, `state` (`idle`, `busy`, `limit`)
+  * `limit` is sourced from `maxThreads` — the maximum configured threads for the connector
 * Instrument Type: LongValueCallback
 
 ### tomcat.max_time

--- a/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/TomcatIntegrationTest.java
+++ b/jmx-metrics/src/integrationTest/java/io/opentelemetry/contrib/jmxmetrics/target_systems/TomcatIntegrationTest.java
@@ -92,7 +92,10 @@ class TomcatIntegrationTest extends AbstractIntegrationTest {
                         entry("proto_handler", "\"http-nio-8080\""), entry("state", "idle")),
                 attrs ->
                     attrs.containsOnly(
-                        entry("proto_handler", "\"http-nio-8080\""), entry("state", "busy"))),
+                        entry("proto_handler", "\"http-nio-8080\""), entry("state", "busy")),
+                attrs ->
+                    attrs.containsOnly(
+                        entry("proto_handler", "\"http-nio-8080\""), entry("state", "limit"))),
         metric ->
             assertGaugeWithAttributes(
                 metric,

--- a/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
+++ b/jmx-metrics/src/main/resources/target-systems/tomcat.groovy
@@ -40,7 +40,7 @@ otel.instrument(beantomcatrequestProcessor, "tomcat.traffic",
 def beantomcatconnectors = otel.mbeans("Catalina:type=ThreadPool,name=*")
 otel.instrument(beantomcatconnectors, "tomcat.threads", "The number of threads", "{thread}",
   ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
-  ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)
+  ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}],"maxThreads":["state":{"limit"}]], otel.&longValueCallback)
 
 def beantomcatnewmanager = otel.mbeans("Tomcat:type=Manager,host=localhost,context=*")
 otel.instrument(beantomcatnewmanager, "tomcat.sessions", "The number of active sessions.", "{session}", "activeSessions", otel.&longValueCallback)
@@ -67,4 +67,4 @@ otel.instrument(beantomcatnewrequestProcessor, "tomcat.traffic",
 def beantomcatnewconnectors = otel.mbeans("Tomcat:type=ThreadPool,name=*")
 otel.instrument(beantomcatnewconnectors, "tomcat.threads", "The number of threads", "{thread}",
     ["proto_handler" : { mbean -> mbean.name().getKeyProperty("name") }],
-    ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}]], otel.&longValueCallback)
+    ["currentThreadCount":["state":{"idle"}],"currentThreadsBusy":["state":{"busy"}],"maxThreads":["state":{"limit"}]], otel.&longValueCallback)

--- a/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
+++ b/jmx-scraper/src/integrationTest/java/io/opentelemetry/contrib/jmxscraper/target_systems/TomcatIntegrationTest.java
@@ -99,6 +99,9 @@ class TomcatIntegrationTest extends TargetSystemIntegrationTest {
                             attribute("proto_handler", "\"http-nio-8080\"")),
                         attributeGroup(
                             attribute("state", "busy"),
+                            attribute("proto_handler", "\"http-nio-8080\"")),
+                        attributeGroup(
+                            attribute("state", "limit"),
                             attribute("proto_handler", "\"http-nio-8080\""))))
         .add(
             "tomcat.max_time",

--- a/jmx-scraper/src/main/resources/tomcat.yaml
+++ b/jmx-scraper/src/main/resources/tomcat.yaml
@@ -81,3 +81,10 @@ rules:
         unit: "{thread}"
         metricAttribute:
           state: const(busy)
+      maxThreads:
+        metric: threads
+        desc: The number of threads
+        type: gauge
+        unit: "{thread}"
+        metricAttribute:
+          state: const(limit)

--- a/jmx-scraper/src/main/resources/tomcat.yaml
+++ b/jmx-scraper/src/main/resources/tomcat.yaml
@@ -83,7 +83,7 @@ rules:
           state: const(busy)
       maxThreads:
         metric: threads
-        desc: The number of threads
+        desc: The maximum number of threads configured for the connector
         type: gauge
         unit: "{thread}"
         metricAttribute:


### PR DESCRIPTION
## Description

Adds maxThreads from the Tomcat ThreadPool MBean as a new state=limit data point on the existing tomcat.threads gauge, alongside the already-collected state=idle and state=busy data points.

This brings parity with Telegraf's tomcat_connector_max_threads metric and allows computing connector utilization as 
busy / limit.

## Changes

* tomcat.yaml / tomcat.groovy — added maxThreads → state=limit mapping for both Catalina: and Tomcat: ThreadPool beans
* Both TomcatIntegrationTest classes — added state=limit assertion
* tomcat.md — updated state label docs
* CHANGELOG.md — added unreleased entry
