### PR TITLE
Run tests on java 25

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -98,6 +98,7 @@ jobs:
           - 11
           - 17
           - 21
+          - 25
           - 26 # renovate(java-version)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
25 is a lts version, we run tests on other lts versions. I guess it is up for discussion whether or how long we wish to keep running tests for all of the old lts versions.