### PR TITLE
Disable digest pinning for Java version manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,17 @@
       ],
       groupName: 'kotlin plugin updates',
     },
+    {
+      // The workflow only stores the Java version number, so Renovate has nowhere to write a
+      // Docker digest for this custom-managed dependency.
+      matchDepNames: [
+        'azul/zulu-openjdk',
+      ],
+      matchUpdateTypes: [
+        'pinDigest',
+      ],
+      enabled: false,
+    },
 
     // ── Version constraints ────────────────────────────────────────────
 


### PR DESCRIPTION
Disable pinDigest updates for the custom-managed azul/zulu-openjdk Java version dependency. The workflow matrix only stores the Java version value, so Renovate cannot write Docker digests there and currently fails the Pin dependencies branch with an update failure.