### PR TITLE
Improve consistent probability sampler test

### DIFF
--- a/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentProbabilityBasedSamplerTest.java
+++ b/consistent-sampling/src/test/java/io/opentelemetry/contrib/sampler/consistent/ConsistentProbabilityBasedSamplerTest.java
@@ -47,10 +47,10 @@ class ConsistentProbabilityBasedSamplerTest {
   private void test(SplittableRandom rng, double samplingProbability) {
     int numSpans = 1000000;
 
+    RandomGenerator randomGenerator = RandomGenerator.create(rng::nextLong);
     Sampler sampler =
         ConsistentSampler.probabilityBased(
-            samplingProbability,
-            s -> RandomGenerator.create(rng::nextLong).numberOfLeadingZerosOfRandomLong());
+            samplingProbability, s -> randomGenerator.numberOfLeadingZerosOfRandomLong());
 
     Map<Integer, Long> observedPvalues = new HashMap<>();
     for (long i = 0; i < numSpans; ++i) {


### PR DESCRIPTION
See https://scans.gradle.com/s/dtymzqemaggcu/tests/overview
Currently ConsistentProbabilityBasedSamplerTest can run for a very long time on jdk 26. This is because `RandomGenerator` internally uses a `ThreadLocal` and this test creates a lot of them instead of sharing the `RandomGenerator`.