### PR TITLE
[dynamic control] Add deleted policy

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import java.util.Objects;
+
+public final class DeletedTelemetryPolicy extends TelemetryPolicy {
+  private final TelemetryPolicyIdentity identity;
+
+  public DeletedTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
+    super(type);
+    this.identity = Objects.requireNonNull(identity, "identity cannot be null");
+  }
+
+  public TelemetryPolicyIdentity getIdentity() {
+    return identity;
+  }
+
+  @Override
+  public boolean isDeleted() {
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof DeletedTelemetryPolicy)) {
+      return false;
+    }
+    DeletedTelemetryPolicy that = (DeletedTelemetryPolicy) obj;
+    return identity.equals(that.identity) && getType().equals(that.getType());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = identity.hashCode();
+    result = 31 * result + getType().hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DeletedTelemetryPolicy{identity=" + identity + ", type='" + getType() + "'}";
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -59,6 +59,10 @@ public class TelemetryPolicy {
     return type;
   }
 
+  public boolean isDeleted() {
+    return false;
+  }
+
   /**
    * Type-only policies ({@link TelemetryPolicy} instances) do not equal typed subclasses that share
    * the same {@link #getType() type} string. Subclasses must override {@code equals} (and {@code

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -62,7 +62,10 @@ public class TelemetryPolicy {
   /**
    * Returns whether this policy represents a deleted element.
    *
-   * <p>Deleted policies are used to signal explicit removal of a previously known policy.
+   * <p>Deleted policies are used to signal explicit removal of a previously known policy. Most
+   * policies are not deleted and should leave this method returning false.
+   *
+   * @return true if this policy represents a deleted element, false otherwise.
    */
   public boolean isDeleted() {
     return false;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -59,6 +59,11 @@ public class TelemetryPolicy {
     return type;
   }
 
+  /**
+   * Returns whether this policy represents a deleted element.
+   *
+   * <p>Deleted policies are used to signal explicit removal of a previously known policy.
+   */
   public boolean isDeleted() {
     return false;
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
@@ -31,20 +31,17 @@ class DeletedTelemetryPolicyTest {
   void equalsAndHashCodeUseIdentityAndType() {
     DeletedTelemetryPolicy first =
         new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
-            "trace-sampling");
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "trace-sampling");
     DeletedTelemetryPolicy same =
         new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
-            "trace-sampling");
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "trace-sampling");
     DeletedTelemetryPolicy differentIdentity =
         new DeletedTelemetryPolicy(
             new TelemetryPolicyIdentity("other-trace-sampling", "Other trace sampling rate"),
             "trace-sampling");
     DeletedTelemetryPolicy differentType =
         new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
-            "other-policy");
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "other-policy");
 
     assertThat(first).isEqualTo(same);
     assertThat(first.hashCode()).isEqualTo(same.hashCode());

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DeletedTelemetryPolicyTest {
+
+  @Test
+  void storesIdentityTypeAndDeletedState() {
+    TelemetryPolicyIdentity identity =
+        new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
+    DeletedTelemetryPolicy policy = new DeletedTelemetryPolicy(identity, "trace-sampling");
+
+    assertThat(policy.getIdentity()).isEqualTo(identity);
+    assertThat(policy.getType()).isEqualTo("trace-sampling");
+    assertThat(policy.isDeleted()).isTrue();
+  }
+
+  @Test
+  void baseTelemetryPolicyIsNotDeleted() {
+    assertThat(new TelemetryPolicy("trace-sampling").isDeleted()).isFalse();
+  }
+
+  @Test
+  void equalsAndHashCodeUseIdentityAndType() {
+    DeletedTelemetryPolicy first =
+        new DeletedTelemetryPolicy(
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
+            "trace-sampling");
+    DeletedTelemetryPolicy same =
+        new DeletedTelemetryPolicy(
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
+            "trace-sampling");
+    DeletedTelemetryPolicy differentIdentity =
+        new DeletedTelemetryPolicy(
+            new TelemetryPolicyIdentity("other-trace-sampling", "Other trace sampling rate"),
+            "trace-sampling");
+    DeletedTelemetryPolicy differentType =
+        new DeletedTelemetryPolicy(
+            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"),
+            "other-policy");
+
+    assertThat(first).isEqualTo(same);
+    assertThat(first.hashCode()).isEqualTo(same.hashCode());
+    assertThat(first).isNotEqualTo(differentIdentity);
+    assertThat(first).isNotEqualTo(differentType);
+    assertThat(first).isNotEqualTo(null);
+    assertThat(first).isNotEqualTo("not-a-policy");
+  }
+}


### PR DESCRIPTION
**Description:**

Feedback during previous reviews recommended moving TelemetryPolicy to an interface, and not using it as a "deleted policy" instance. This is the first step of that

**Existing Issue(s):**

part of #2868

**Testing:**

Added

**Documentation:**

Not yet, will be added with changes to using the deleted policies

**Outstanding items:**

- Apply deleted policy to telemetry policy deletion flow
- Change TelemetryPolicy to an interface

see #2868 . 
