### PR TITLE
[dynamic control] Apply deleted policy to telemetry policy deletion flow

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -15,6 +15,7 @@ public final class DeletedTelemetryPolicy extends TelemetryPolicy {
     this.identity = Objects.requireNonNull(identity, "identity cannot be null");
   }
 
+  @Override
   public TelemetryPolicyIdentity getIdentity() {
     return identity;
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
-import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -118,7 +117,7 @@ public final class PolicyStore {
     ArrayList<TelemetryPolicy> deletedPolicies = new ArrayList<>();
     for (TelemetryPolicy previousPolicy : previousPolicies) {
       String policyKey = policyKey(previousPolicy);
-      TelemetryPolicyIdentity identity = policyIdentity(previousPolicy);
+      TelemetryPolicyIdentity identity = previousPolicy.getIdentity();
       if (policyKey != null && identity != null && !activePolicyKeys.contains(policyKey)) {
         deletedPolicies.add(new DeletedTelemetryPolicy(identity, previousPolicy.getType()));
       }
@@ -128,19 +127,8 @@ public final class PolicyStore {
 
   @Nullable
   private static String policyKey(TelemetryPolicy policy) {
-    TelemetryPolicyIdentity identity = policyIdentity(policy);
+    TelemetryPolicyIdentity identity = policy.getIdentity();
     return identity == null ? null : policy.getType() + "\u0000" + identity.getId();
-  }
-
-  @Nullable
-  private static TelemetryPolicyIdentity policyIdentity(TelemetryPolicy policy) {
-    if (policy instanceof TraceSamplingRatePolicy) {
-      return ((TraceSamplingRatePolicy) policy).getIdentity();
-    }
-    if (policy instanceof DeletedTelemetryPolicy) {
-      return ((DeletedTelemetryPolicy) policy).getIdentity();
-    }
-    return null;
   }
 
   private static void notifyImplementer(

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -55,8 +55,10 @@ public final class PolicyStore {
       policyVersion++;
       snapshotVersion = policyVersion;
       policiesSnapshot = new ArrayList<>(policies);
-      notificationSnapshot = new ArrayList<>(policiesSnapshot);
+      notificationSnapshot =
+          new ArrayList<>(deletedPolicies.size() + policiesSnapshot.size());
       notificationSnapshot.addAll(deletedPolicies);
+      notificationSnapshot.addAll(policiesSnapshot);
       implementersSnapshot = new ArrayList<>(implementers);
     }
     for (RegisteredImplementer implementer : implementersSnapshot) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -55,8 +55,7 @@ public final class PolicyStore {
       policyVersion++;
       snapshotVersion = policyVersion;
       policiesSnapshot = new ArrayList<>(policies);
-      notificationSnapshot =
-          new ArrayList<>(deletedPolicies.size() + policiesSnapshot.size());
+      notificationSnapshot = new ArrayList<>(deletedPolicies.size() + policiesSnapshot.size());
       notificationSnapshot.addAll(deletedPolicies);
       notificationSnapshot.addAll(policiesSnapshot);
       implementersSnapshot = new ArrayList<>(implementers);

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -13,6 +14,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 /**
  * Holds the latest validated policy snapshot and reports whether an update changed effective
@@ -41,20 +43,25 @@ public final class PolicyStore {
     Objects.requireNonNull(newPolicies, "newPolicies cannot be null");
     LinkedHashSet<TelemetryPolicy> newPolicySet = new LinkedHashSet<>(newPolicies);
     List<TelemetryPolicy> policiesSnapshot;
+    List<TelemetryPolicy> notificationSnapshot;
     List<RegisteredImplementer> implementersSnapshot;
     long snapshotVersion;
     synchronized (this) {
       if (new LinkedHashSet<>(policies).equals(newPolicySet)) {
         return false;
       }
+      List<TelemetryPolicy> deletedPolicies =
+          deletedPoliciesFrom(policies, new ArrayList<>(newPolicySet));
       policies = new ArrayList<>(newPolicySet);
       policyVersion++;
       snapshotVersion = policyVersion;
       policiesSnapshot = new ArrayList<>(policies);
+      notificationSnapshot = new ArrayList<>(policiesSnapshot);
+      notificationSnapshot.addAll(deletedPolicies);
       implementersSnapshot = new ArrayList<>(implementers);
     }
     for (RegisteredImplementer implementer : implementersSnapshot) {
-      notifyImplementer(implementer, policiesSnapshot, snapshotVersion);
+      notifyImplementer(implementer, notificationSnapshot, snapshotVersion);
     }
     return true;
   }
@@ -97,6 +104,43 @@ public final class PolicyStore {
       }
     }
     return Collections.unmodifiableList(relevant);
+  }
+
+  private static List<TelemetryPolicy> deletedPoliciesFrom(
+      List<TelemetryPolicy> previousPolicies, List<TelemetryPolicy> newPolicies) {
+    Set<String> activePolicyKeys = new LinkedHashSet<>();
+    for (TelemetryPolicy policy : newPolicies) {
+      String policyKey = policyKey(policy);
+      if (policyKey != null) {
+        activePolicyKeys.add(policyKey);
+      }
+    }
+    ArrayList<TelemetryPolicy> deletedPolicies = new ArrayList<>();
+    for (TelemetryPolicy previousPolicy : previousPolicies) {
+      String policyKey = policyKey(previousPolicy);
+      TelemetryPolicyIdentity identity = policyIdentity(previousPolicy);
+      if (policyKey != null && identity != null && !activePolicyKeys.contains(policyKey)) {
+        deletedPolicies.add(new DeletedTelemetryPolicy(identity, previousPolicy.getType()));
+      }
+    }
+    return deletedPolicies;
+  }
+
+  @Nullable
+  private static String policyKey(TelemetryPolicy policy) {
+    TelemetryPolicyIdentity identity = policyIdentity(policy);
+    return identity == null ? null : policy.getType() + "\u0000" + identity.getId();
+  }
+
+  @Nullable
+  private static TelemetryPolicyIdentity policyIdentity(TelemetryPolicy policy) {
+    if (policy instanceof TraceSamplingRatePolicy) {
+      return ((TraceSamplingRatePolicy) policy).getIdentity();
+    }
+    if (policy instanceof DeletedTelemetryPolicy) {
+      return ((DeletedTelemetryPolicy) policy).getIdentity();
+    }
+    return null;
   }
 
   private static void notifyImplementer(

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.dynamic.policy;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represents a single Telemetry Policy identified by type.
@@ -57,6 +58,16 @@ public class TelemetryPolicy {
    */
   public String getType() {
     return type;
+  }
+
+  /**
+   * Returns the policy identity when this policy has one.
+   *
+   * <p>Type-only policies do not have an identity and return null.
+   */
+  @Nullable
+  public TelemetryPolicyIdentity getIdentity() {
+    return null;
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -32,6 +32,7 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
     this.probability = normalizeProbability(probability);
   }
 
+  @Override
   public TelemetryPolicyIdentity getIdentity() {
     return identity;
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
@@ -21,9 +21,8 @@ import java.util.logging.Logger;
  * "trace-sampling"} and applies {@link TraceSamplingRatePolicy#getProbability()} to the delegate
  * sampler via {@link TraceSamplingRatePolicy#createSampler(double)}.
  *
- * <p>If a type-only {@link TelemetryPolicy} of type {@code "trace-sampling"} is received, it is
- * treated as policy removal and the delegate is reset using {@code
- * TraceSamplingRatePolicy.createSampler(1.0)}.
+ * <p>If a deleted policy of type {@code "trace-sampling"} is received, it is treated as policy
+ * removal and the delegate is reset using {@code TraceSamplingRatePolicy.createSampler(1.0)}.
  *
  * <p>Validation is performed by {@link TraceSamplingValidator}; this implementer only consumes
  * policies produced by that validator.
@@ -61,10 +60,12 @@ public final class TraceSamplingRatePolicyImplementer implements PolicyImplement
       if (!TraceSamplingRatePolicy.POLICY_TYPE.equals(policy.getType())) {
         continue;
       }
-      if (!(policy instanceof TraceSamplingRatePolicy)) {
-        // Type-only policy represents removing trace-sampling config.
+      if (policy.isDeleted()) {
         delegatingSampler.setDelegate(TraceSamplingRatePolicy.createSampler(1.0));
         logger.info("Applied trace sampling policy reset: probability reset to 1.0");
+        continue;
+      }
+      if (!(policy instanceof TraceSamplingRatePolicy)) {
         continue;
       }
       double ratio = ((TraceSamplingRatePolicy) policy).getProbability();

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.dynamic.policy;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -99,6 +100,45 @@ class PolicyStoreTest {
         Arrays.asList(new TelemetryPolicy("other-policy"), new TraceSamplingRatePolicy(0.25)));
 
     verify(implementer).onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(0.25)));
+  }
+
+  @Test
+  void updatePoliciesNotifiesDeletedPolicyWhenPolicyDisappears() {
+    PolicyStore store = new PolicyStore();
+    PolicyImplementer implementer = traceSamplingImplementer();
+    TraceSamplingRatePolicy removedPolicy = new TraceSamplingRatePolicy(0.5);
+    store.updatePolicies(singletonList(removedPolicy));
+    store.registerImplementer(implementer);
+    clearInvocations(implementer);
+
+    assertThat(store.updatePolicies(Collections.emptyList())).isTrue();
+
+    verify(implementer)
+        .onPoliciesChanged(
+            argThat(
+                policies ->
+                    policies.size() == 1
+                        && policies.get(0) instanceof DeletedTelemetryPolicy
+                        && policies.get(0).isDeleted()
+                        && ((DeletedTelemetryPolicy) policies.get(0))
+                            .getIdentity()
+                            .equals(removedPolicy.getIdentity())
+                        && policies.get(0).getType().equals(removedPolicy.getType())));
+    assertThat(store.getPolicies()).isEmpty();
+  }
+
+  @Test
+  void updatePoliciesDoesNotNotifyDeletedPolicyWhenPolicyValueChangesWithSameIdentity() {
+    PolicyStore store = new PolicyStore();
+    PolicyImplementer implementer = traceSamplingImplementer();
+    TraceSamplingRatePolicy updatedPolicy = new TraceSamplingRatePolicy(0.75);
+    store.updatePolicies(singletonList(new TraceSamplingRatePolicy(0.5)));
+    store.registerImplementer(implementer);
+    clearInvocations(implementer);
+
+    assertThat(store.updatePolicies(singletonList(updatedPolicy))).isTrue();
+
+    verify(implementer).onPoliciesChanged(singletonList(updatedPolicy));
   }
 
   @Test

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -142,6 +142,32 @@ class PolicyStoreTest {
   }
 
   @Test
+  void updatePoliciesNotifiesDeletedPolicyForAnyIdentityBearingPolicy() {
+    PolicyStore store = new PolicyStore();
+    PolicyImplementer implementer = implementerFor("test-policy");
+    TestTelemetryPolicy removedPolicy =
+        new TestTelemetryPolicy(
+            new TelemetryPolicyIdentity("test-policy-id", "Test policy"), "test-policy", "old");
+    store.updatePolicies(singletonList(removedPolicy));
+    store.registerImplementer(implementer);
+    clearInvocations(implementer);
+
+    assertThat(store.updatePolicies(Collections.emptyList())).isTrue();
+
+    verify(implementer)
+        .onPoliciesChanged(
+            argThat(
+                policies ->
+                    policies.size() == 1
+                        && policies.get(0) instanceof DeletedTelemetryPolicy
+                        && policies.get(0).isDeleted()
+                        && ((DeletedTelemetryPolicy) policies.get(0))
+                            .getIdentity()
+                            .equals(removedPolicy.getIdentity())
+                        && policies.get(0).getType().equals(removedPolicy.getType())));
+  }
+
+  @Test
   void updatePoliciesContinuesWhenImplementerThrows() {
     PolicyStore store = new PolicyStore();
     PolicyImplementer failingImplementer = traceSamplingImplementer();
@@ -182,10 +208,52 @@ class PolicyStoreTest {
   }
 
   private static PolicyImplementer traceSamplingImplementer() {
+    return implementerFor(TraceSamplingRatePolicy.POLICY_TYPE);
+  }
+
+  private static PolicyImplementer implementerFor(String policyType) {
     PolicyImplementer implementer = mock(PolicyImplementer.class);
     PolicyValidator validator = mock(PolicyValidator.class);
-    when(validator.getPolicyType()).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
+    when(validator.getPolicyType()).thenReturn(policyType);
     when(implementer.getValidators()).thenReturn(singletonList(validator));
     return implementer;
+  }
+
+  private static final class TestTelemetryPolicy extends TelemetryPolicy {
+    private final TelemetryPolicyIdentity identity;
+    private final String value;
+
+    private TestTelemetryPolicy(TelemetryPolicyIdentity identity, String type, String value) {
+      super(type);
+      this.identity = identity;
+      this.value = value;
+    }
+
+    @Override
+    public TelemetryPolicyIdentity getIdentity() {
+      return identity;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof TestTelemetryPolicy)) {
+        return false;
+      }
+      TestTelemetryPolicy that = (TestTelemetryPolicy) obj;
+      return identity.equals(that.identity)
+          && getType().equals(that.getType())
+          && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = identity.hashCode();
+      result = 31 * result + getType().hashCode();
+      result = 31 * result + value.hashCode();
+      return result;
+    }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+import io.opentelemetry.contrib.dynamic.policy.DeletedTelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
@@ -23,13 +24,15 @@ import org.junit.jupiter.api.Test;
 class TraceSamplingRatePolicyImplementerTest {
 
   @Test
-  void typeOnlyTraceSamplingPolicyFallsBackToAlwaysOn() {
+  void deletedTraceSamplingPolicyFallsBackToAlwaysOn() {
     DelegatingSampler delegatingSampler = new DelegatingSampler(Sampler.alwaysOff());
     TraceSamplingRatePolicyImplementer implementer =
         new TraceSamplingRatePolicyImplementer(delegatingSampler);
 
     implementer.onPoliciesChanged(
-        singletonList(new TelemetryPolicy(TraceSamplingRatePolicy.POLICY_TYPE)));
+        singletonList(
+            new DeletedTelemetryPolicy(
+                TraceSamplingRatePolicy.DEFAULT_IDENTITY, TraceSamplingRatePolicy.POLICY_TYPE)));
 
     assertThat(decisionFor(delegatingSampler)).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }


### PR DESCRIPTION
**Description:**

Feedback during previous reviews recommended moving TelemetryPolicy to an interface, and not using it as a "deleted policy" instance. This is the next step of that, changing the TelemetryPolicy instances to DeletedTelemetryPolicy instances

**Existing Issue(s):**

part of #2868

**Testing:**

Added

**Documentation:**

Added

**Outstanding items:**

- Change TelemetryPolicy to an interface

see #2868 . 
