### PR TITLE
[dynamic control] Make TelemetryPolicy an interface

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -7,17 +7,23 @@ package io.opentelemetry.contrib.dynamic.policy;
 
 import java.util.Objects;
 
-public final class DeletedTelemetryPolicy extends TelemetryPolicy {
+public final class DeletedTelemetryPolicy implements TelemetryPolicy {
   private final TelemetryPolicyIdentity identity;
+  private final String type;
 
   public DeletedTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
-    super(type);
     this.identity = Objects.requireNonNull(identity, "identity cannot be null");
+    this.type = Objects.requireNonNull(type, "type cannot be null");
   }
 
   @Override
   public TelemetryPolicyIdentity getIdentity() {
     return identity;
+  }
+
+  @Override
+  public String getType() {
+    return type;
   }
 
   @Override

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyStore.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /**
  * Holds the latest validated policy snapshot and reports whether an update changed effective
@@ -29,12 +28,11 @@ public final class PolicyStore {
   /**
    * Replaces the stored policies when the new snapshot is not equal to the current one.
    *
-   * <p>Input lists are normalized to a set of distinct policies ({@link TelemetryPolicy#equals
-   * value equality}): duplicates are dropped and only the first occurrence of each policy is kept
-   * (insertion order). Change detection uses set equality, so list order does not matter. That
-   * matches telemetry policy semantics where the effective result does not depend on processing
-   * order (see the telemetry policy OTEP, commutativity / no user-defined ordering between
-   * policies).
+   * <p>Input lists are normalized to a set of distinct policies using value equality: duplicates
+   * are dropped and only the first occurrence of each policy is kept (insertion order). Change
+   * detection uses set equality, so list order does not matter. That matches telemetry policy
+   * semantics where the effective result does not depend on processing order (see the telemetry
+   * policy OTEP, commutativity / no user-defined ordering between policies).
    *
    * @return {@code true} if the store was updated, {@code false} if the snapshot was unchanged
    */
@@ -110,26 +108,21 @@ public final class PolicyStore {
       List<TelemetryPolicy> previousPolicies, List<TelemetryPolicy> newPolicies) {
     Set<String> activePolicyKeys = new LinkedHashSet<>();
     for (TelemetryPolicy policy : newPolicies) {
-      String policyKey = policyKey(policy);
-      if (policyKey != null) {
-        activePolicyKeys.add(policyKey);
-      }
+      activePolicyKeys.add(policyKey(policy));
     }
     ArrayList<TelemetryPolicy> deletedPolicies = new ArrayList<>();
     for (TelemetryPolicy previousPolicy : previousPolicies) {
       String policyKey = policyKey(previousPolicy);
       TelemetryPolicyIdentity identity = previousPolicy.getIdentity();
-      if (policyKey != null && identity != null && !activePolicyKeys.contains(policyKey)) {
+      if (!activePolicyKeys.contains(policyKey)) {
         deletedPolicies.add(new DeletedTelemetryPolicy(identity, previousPolicy.getType()));
       }
     }
     return deletedPolicies;
   }
 
-  @Nullable
   private static String policyKey(TelemetryPolicy policy) {
-    TelemetryPolicyIdentity identity = policy.getIdentity();
-    return identity == null ? null : policy.getType() + "\u0000" + identity.getId();
+    return policy.getType() + "\u0000" + policy.getIdentity().getId();
   }
 
   private static void notifyImplementer(

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -5,70 +5,35 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
-import java.util.Objects;
-import javax.annotation.Nullable;
-
 /**
- * Represents a single Telemetry Policy identified by type.
+ * Represents a single telemetry policy with spec-required identity and policy type.
  *
- * <p>A {@code TelemetryPolicy} instance encapsulates a specific rule or configuration intent
- * identified by its {@link #getType() type}.
- *
- * <p>Policies are immutable data carriers.
- *
- * <p>As an example, policy type {@code trace-sampling} indicates that trace sampling behavior
- * should be configured.
- *
- * <p>Direct instantiation of this base class is intentionally supported for type-only policy
- * signals (for example, to indicate policy removal/reset without policy-specific values).
- *
- * <p><b>Subclasses:</b> {@link #equals(Object)} on this class returns {@code false} when either
- * operand is a typed subclass (not {@code TelemetryPolicy} itself), so a type-only instance never
- * equals a value-carrying subclass with the same {@link #getType() type}. Each concrete subclass
- * <b>must</b> override both {@code equals} and {@code hashCode} consistently with its fields, and
- * obey the {@code equals}/{@code hashCode} contract. That is required for consumers such as {@link
- * io.opentelemetry.contrib.dynamic.policy.PolicyStore} that deduplicate and detect changes using
- * {@link Object#equals(Object)}.
+ * <p>Policies are immutable data carriers. Concrete implementations must provide value-based {@code
+ * equals} and {@code hashCode} implementations because {@link PolicyStore} deduplicates and detects
+ * changes using policy equality.
  *
  * @see io.opentelemetry.contrib.dynamic.policy
  */
-public class TelemetryPolicy {
-  private final String type; // e.g. "trace-sampling"
+public interface TelemetryPolicy {
+  /**
+   * Returns the identity for this policy instance.
+   *
+   * <p>The identity distinguishes policy instances within a policy type and is used by {@link
+   * PolicyStore} to detect policy removals.
+   *
+   * @return the non-null policy identity
+   */
+  TelemetryPolicyIdentity getIdentity();
 
   /**
-   * Constructs a new TelemetryPolicy.
+   * Returns the policy type.
    *
-   * <p>This constructor is used by type-specific subclasses and also directly for type-only policy
-   * signals such as policy removal/reset.
+   * <p>The type identifies the policy behavior and the implementer responsible for applying it, for
+   * example {@code trace-sampling}.
    *
-   * @param type the type of the policy (e.g., "trace-sampling"), must not be null.
+   * @return the non-null policy type
    */
-  public TelemetryPolicy(String type) {
-    Objects.requireNonNull(type, "type cannot be null");
-    this.type = type;
-  }
-
-  /**
-   * Returns the type of this policy.
-   *
-   * <p>The type identifies the domain and expected behavior of the policy (e.g., "trace-sampling",
-   * "metric-rate").
-   *
-   * @return the policy type.
-   */
-  public String getType() {
-    return type;
-  }
-
-  /**
-   * Returns the policy identity when this policy has one.
-   *
-   * <p>Type-only policies do not have an identity and return null.
-   */
-  @Nullable
-  public TelemetryPolicyIdentity getIdentity() {
-    return null;
-  }
+  String getType();
 
   /**
    * Returns whether this policy represents a deleted element.
@@ -78,32 +43,7 @@ public class TelemetryPolicy {
    *
    * @return true if this policy represents a deleted element, false otherwise.
    */
-  public boolean isDeleted() {
+  default boolean isDeleted() {
     return false;
-  }
-
-  /**
-   * Type-only policies ({@link TelemetryPolicy} instances) do not equal typed subclasses that share
-   * the same {@link #getType() type} string. Subclasses must override {@code equals} (and {@code
-   * hashCode}) for value-based equality; see the class Javadoc.
-   */
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof TelemetryPolicy)) {
-      return false;
-    }
-    TelemetryPolicy that = (TelemetryPolicy) obj;
-    if (that.getClass() != TelemetryPolicy.class || getClass() != TelemetryPolicy.class) {
-      return false;
-    }
-    return type.equals(that.type);
-  }
-
-  @Override
-  public int hashCode() {
-    return type.hashCode();
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -16,7 +16,7 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
-public final class TraceSamplingRatePolicy extends TelemetryPolicy {
+public final class TraceSamplingRatePolicy implements TelemetryPolicy {
   public static final String POLICY_TYPE = "trace-sampling";
   public static final TelemetryPolicyIdentity DEFAULT_IDENTITY =
       new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
@@ -27,7 +27,6 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   private final double probability;
 
   public TraceSamplingRatePolicy(double probability) {
-    super(POLICY_TYPE);
     this.identity = DEFAULT_IDENTITY;
     this.probability = normalizeProbability(probability);
   }
@@ -35,6 +34,11 @@ public final class TraceSamplingRatePolicy extends TelemetryPolicy {
   @Override
   public TelemetryPolicyIdentity getIdentity() {
     return identity;
+  }
+
+  @Override
+  public String getType() {
+    return POLICY_TYPE;
   }
 
   public double getProbability() {

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
@@ -23,8 +23,8 @@ class DeletedTelemetryPolicyTest {
   }
 
   @Test
-  void baseTelemetryPolicyIsNotDeleted() {
-    assertThat(new TelemetryPolicy("trace-sampling").isDeleted()).isFalse();
+  void ordinaryTelemetryPolicyIsNotDeleted() {
+    assertThat(new TestTelemetryPolicy("trace-sampling").isDeleted()).isFalse();
   }
 
   @Test
@@ -49,5 +49,25 @@ class DeletedTelemetryPolicyTest {
     assertThat(first).isNotEqualTo(differentType);
     assertThat(first).isNotEqualTo(null);
     assertThat(first).isNotEqualTo("not-a-policy");
+  }
+
+  private static final class TestTelemetryPolicy implements TelemetryPolicy {
+    private final TelemetryPolicyIdentity identity;
+    private final String type;
+
+    private TestTelemetryPolicy(String type) {
+      this.identity = new TelemetryPolicyIdentity(type, "Test policy");
+      this.type = type;
+    }
+
+    @Override
+    public TelemetryPolicyIdentity getIdentity() {
+      return identity;
+    }
+
+    @Override
+    public String getType() {
+      return type;
+    }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
@@ -115,15 +115,59 @@ class LinePerPolicyFileProviderTest {
         if (!acceptJson) {
           return null;
         }
-        return new TelemetryPolicy(TRACE_SAMPLING_TYPE);
+        return testPolicy();
       }
       if (source.getFormat() == SourceFormat.KEYVALUE) {
         if (!acceptKeyValue) {
           return null;
         }
-        return new TelemetryPolicy(TRACE_SAMPLING_TYPE);
+        return testPolicy();
       }
       return null;
+    }
+  }
+
+  private static TelemetryPolicy testPolicy() {
+    return new TestTelemetryPolicy(
+        new TelemetryPolicyIdentity("test-policy", "Test policy"), TRACE_SAMPLING_TYPE);
+  }
+
+  private static final class TestTelemetryPolicy implements TelemetryPolicy {
+    private final TelemetryPolicyIdentity identity;
+    private final String type;
+
+    private TestTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
+      this.identity = identity;
+      this.type = type;
+    }
+
+    @Override
+    public TelemetryPolicyIdentity getIdentity() {
+      return identity;
+    }
+
+    @Override
+    public String getType() {
+      return type;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof TestTelemetryPolicy)) {
+        return false;
+      }
+      TestTelemetryPolicy that = (TestTelemetryPolicy) obj;
+      return identity.equals(that.identity) && type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = identity.hashCode();
+      result = 31 * result + type.hashCode();
+      return result;
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -76,8 +76,7 @@ class PolicyStoreTest {
   @Test
   void registerImplementerReceivesCurrentRelevantPolicies() {
     PolicyStore store = new PolicyStore();
-    store.updatePolicies(
-        Arrays.asList(new TraceSamplingRatePolicy(0.5), new TelemetryPolicy("other-policy")));
+    store.updatePolicies(Arrays.asList(new TraceSamplingRatePolicy(0.5), unrelatedPolicy()));
 
     PolicyImplementer implementer = mock(PolicyImplementer.class);
     PolicyValidator validator = mock(PolicyValidator.class);
@@ -96,8 +95,7 @@ class PolicyStoreTest {
 
     store.registerImplementer(implementer);
     clearInvocations(implementer);
-    store.updatePolicies(
-        Arrays.asList(new TelemetryPolicy("other-policy"), new TraceSamplingRatePolicy(0.25)));
+    store.updatePolicies(Arrays.asList(unrelatedPolicy(), new TraceSamplingRatePolicy(0.25)));
 
     verify(implementer).onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(0.25)));
   }
@@ -219,19 +217,30 @@ class PolicyStoreTest {
     return implementer;
   }
 
-  private static final class TestTelemetryPolicy extends TelemetryPolicy {
+  private static TelemetryPolicy unrelatedPolicy() {
+    return new TestTelemetryPolicy(
+        new TelemetryPolicyIdentity("other-policy", "Other policy"), "other-policy", "value");
+  }
+
+  private static final class TestTelemetryPolicy implements TelemetryPolicy {
     private final TelemetryPolicyIdentity identity;
+    private final String type;
     private final String value;
 
     private TestTelemetryPolicy(TelemetryPolicyIdentity identity, String type, String value) {
-      super(type);
       this.identity = identity;
+      this.type = type;
       this.value = value;
     }
 
     @Override
     public TelemetryPolicyIdentity getIdentity() {
       return identity;
+    }
+
+    @Override
+    public String getType() {
+      return type;
     }
 
     @Override
@@ -243,15 +252,13 @@ class PolicyStoreTest {
         return false;
       }
       TestTelemetryPolicy that = (TestTelemetryPolicy) obj;
-      return identity.equals(that.identity)
-          && getType().equals(that.getType())
-          && value.equals(that.value);
+      return identity.equals(that.identity) && type.equals(that.type) && value.equals(that.value);
     }
 
     @Override
     public int hashCode() {
       int result = identity.hashCode();
-      result = 31 * result + getType().hashCode();
+      result = 31 * result + type.hashCode();
       result = 31 * result + value.hashCode();
       return result;
     }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -161,9 +162,18 @@ class PolicyInitTest {
         + "\"}]}]}";
   }
 
-  private static final class IdempotentTestPolicy extends TelemetryPolicy {
-    private IdempotentTestPolicy() {
-      super("test-policy-idempotent");
+  private static final class IdempotentTestPolicy implements TelemetryPolicy {
+    private static final TelemetryPolicyIdentity IDENTITY =
+        new TelemetryPolicyIdentity("test-policy-idempotent", "Test policy idempotent");
+
+    @Override
+    public TelemetryPolicyIdentity getIdentity() {
+      return IDENTITY;
+    }
+
+    @Override
+    public String getType() {
+      return "test-policy-idempotent";
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -13,6 +13,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.dynamic.policy.DeletedTelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
@@ -54,7 +55,7 @@ class TraceSamplingRatePolicyImplementerTest {
     TraceSamplingRatePolicyImplementer implementer =
         new TraceSamplingRatePolicyImplementer(delegatingSampler);
 
-    implementer.onPoliciesChanged(singletonList(new TelemetryPolicy("other-policy")));
+    implementer.onPoliciesChanged(singletonList(new TestTelemetryPolicy("other-policy")));
 
     assertThat(decisionFor(delegatingSampler)).isEqualTo(SamplingDecision.DROP);
   }
@@ -83,5 +84,25 @@ class TraceSamplingRatePolicyImplementerTest {
             Attributes.empty(),
             Collections.emptyList());
     return result.getDecision();
+  }
+
+  private static final class TestTelemetryPolicy implements TelemetryPolicy {
+    private final TelemetryPolicyIdentity identity;
+    private final String type;
+
+    private TestTelemetryPolicy(String type) {
+      this.identity = new TelemetryPolicyIdentity(type, "Test policy");
+      this.type = type;
+    }
+
+    @Override
+    public TelemetryPolicyIdentity getIdentity() {
+      return identity;
+    }
+
+    @Override
+    public String getType() {
+      return type;
+    }
   }
 }


### PR DESCRIPTION
**Description:**

Feedback during previous reviews recommended moving TelemetryPolicy to an interface, and not using it as a "deleted policy" instance. This is the last step of that

**Existing Issue(s):**

part of #2868

**Testing:**

Added

**Documentation:**

Added

**Outstanding items:**

see #2868 . 
