### PR TITLE
[dynamic control] refactor sourceKey to policyId to align to spec

### DIFF
--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -50,7 +50,7 @@ echo "  - kind: opamp" >> config.yaml
 echo "    format: jsonkeyvalue" >> config.yaml
 echo "    location: vendor" >> config.yaml
 echo "    mappings:" >> config.yaml
-echo "      - sourceKey: sampling_rate" >> config.yaml
+echo "      - policyId: sampling_rate" >> config.yaml
 echo "        policyType: trace-sampling" >> config.yaml
 java -Dotel.javaagent.extensions=./opentelemetry-dynamic-control-all.jar -Dotel.java.experimental.telemetry.policy.init.yaml=./config.yaml -Dotel.opamp.service.url=http://127.0.0.1:4320/v1/opamp -javaagent:path/to/opentelemetry-javaagent.jar -Dotel.service.name=my-service -jar myapp.jar
 ```
@@ -115,7 +115,7 @@ telemetry_policy/development:
       format: jsonkeyvalue
       location: vendor
       mappings:
-        - sourceKey: sampling_rate
+        - policyId: sampling_rate
           policyType: trace-sampling
 
 ```
@@ -138,7 +138,7 @@ sources:
     format: jsonkeyvalue
     location: vendor
     mappings:
-      - sourceKey: sampling_rate
+      - policyId: sampling_rate
         policyType: trace-sampling
 
 ```
@@ -158,12 +158,12 @@ finding the value at the key given by `location`. The contents of that value are
 simple json objects that are key and value, eg '{ "key": value}' or '[{ "key1": value1}, { "key2": value2}]'
   * `keyvalue`: expects the contents to be convertible as a string into one or more
 line separated 'key=value' pairs (eg a properties file)
-* `mappings`: one or more mappings from source-specific keys to dynamic-control policy types
+* `mappings`: one or more mappings from policy IDs to dynamic-control policy types
 * `location`: optional source-specific selector. For `opamp`, this is the OpAMP config map key, for example `vendor`
 
 Each mapping must specify:
 
-* `sourceKey`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
+* `policyId`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
 by the user or already being used/sent from some source)
 * `policyType`: the dynamic-control policy type to update, currently only `trace-sampling` is valid
 
@@ -175,7 +175,7 @@ sources:
     format: jsonkeyvalue|keyvalue
     location: 'opamp config map key'|'file path'|'http url'|omit row
     mappings:
-      - sourceKey: user-defined-string
+      - policyId: user-defined-string
         policyType: trace-sampling
 
 ```
@@ -200,15 +200,15 @@ sources:
     format: jsonkeyvalue
     location: vendor
     mappings:
-      - sourceKey: sampling_rate
+      - policyId: sampling_rate
         policyType: trace-sampling
   - kind: file
     format: keyvalue
     location: /path/to/here.conf
     mappings:
-      - sourceKey: trace_rate
+      - policyId: trace_rate
         policyType: trace-sampling
-      - sourceKey: traceid_ratio
+      - policyId: traceid_ratio
         policyType: trace-sampling
 
 ```
@@ -216,14 +216,14 @@ sources:
 There are two sources. The first expects a message from an OpAMP server (`kind: opamp`),
 from which it will access the config map and extract the value at key `vendor` (`location: vendor`).
 The value is expected to be this json style key-value (`format: jsonkeyvalue`)
-object string (ignoring whitespace and numeric diffs) {"sampling_rate": 0.5} (key defined by `sourceKey: sampling_rate`).
+object string (ignoring whitespace and numeric diffs) {"sampling_rate": 0.5} (key defined by `policyId: sampling_rate`).
 On receipt of this, the message is converted to a trace-sampling policy (`policyType: trace-sampling`)
 and the new sampling rate applied to the sampler.
 
 The second source expects a file (`kind: file`) at file path /path/to/here.conf (`location: /path/to/here.conf`)
 which when changed will be re-read. The contents are expected to be key=value entries,
-one per line (`format: keyvalue`). The only keys recognized are `trace_rate` (`sourceKey: trace_rate`)
-and `traceid_ratio` (`sourceKey: traceid_ratio`). When the value changes, the message is converted
+one per line (`format: keyvalue`). The only keys recognized are `trace_rate` (`policyId: trace_rate`)
+and `traceid_ratio` (`policyId: traceid_ratio`). When the value changes, the message is converted
 to a trace-sampling policy (`policyType: trace-sampling`)
 and the new sampling rate applied to the sampler.
 
@@ -234,7 +234,7 @@ at the same time, the opamp change would be applied and the file change dropped.
 
 Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
-* `policyType` in the pipeline initialization maps a source key to the Java policy implementation.
+* `policyType` in the pipeline initialization maps a policy ID to the Java policy implementation.
   For example, `policyType: trace-sampling` tells dynamic control to validate matching source
   values as trace sampling policies and deliver them to the trace sampling implementer.
 * `id` identifies one policy instance within a policy type. It is used to distinguish updates,
@@ -250,7 +250,7 @@ type `trace-sampling-per-span`, but one would have id `sample-database-spans` wh
 would have id `sample-healthcheck-spans`. The id would allow these two different instances to be
 updated separately.
 
-The pipeline initialization maps a source key to the implementation:
+The pipeline initialization maps a policy ID to the implementation:
 
 ```yaml
 sources:
@@ -258,11 +258,14 @@ sources:
     format: jsonkeyvalue
     location: vendor
     mappings:
-      - sourceKey: trace_sampling_policies
+      - policyId: sample-database-spans
+        policyType: trace-sampling-per-span
+      - policyId: sample-healthcheck-spans
         policyType: trace-sampling-per-span
 ```
 
-The source payload would use `trace_sampling_policies`.
+The source payload would use the policy ID as the key for this current key-value-style
+format.
 The resulting policies would have the same policyType but different ids
 (note `matching` is defined in the spec as part of the policy not the pipeline,
 but is not yet implemented in this repo,
@@ -270,7 +273,7 @@ so the `match` field here is currently for illustrative purposes only):
 
 ```json
 {
-  "trace_sampling_policies": {
+  "sample-database-spans": {
     "id": "sample-database-spans",
     "name": "Sample database spans",
     "match": {
@@ -284,7 +287,7 @@ so the `match` field here is currently for illustrative purposes only):
 
 ```json
 {
-  "trace_sampling_policies": {
+  "sample-healthcheck-spans": {
     "id": "sample-healthcheck-spans",
     "name": "Sample healthcheck spans",
     "match": {

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -234,9 +234,10 @@ at the same time, the opamp change would be applied and the file change dropped.
 
 Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
-* The pipeline initialization maps a policy ID (`policyId`) to a `policyType`, which selects the Java policy implementation.
-  For example, `policyType: trace-sampling` tells dynamic control to validate matching source
-  values as trace sampling policies and deliver them to the trace sampling implementer.
+* `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
+* `policyType` selects the Java policy implementation for that mapped policy ID. For example,
+  `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
+  sampling policies and deliver them to the trace sampling implementer.
 * `id` identifies one policy instance within a policy type. It is used to distinguish updates,
   removals, and duplicate policies of the same type.
 * `name` is a human-readable description of the policy identified by `id`.
@@ -258,14 +259,11 @@ sources:
     format: jsonkeyvalue
     location: vendor
     mappings:
-      - policyId: sample-database-spans
-        policyType: trace-sampling-per-span
-      - policyId: sample-healthcheck-spans
+      - policyId: trace_sampling_policies
         policyType: trace-sampling-per-span
 ```
 
-The source payload would use the policy ID as the key for this current key-value-style
-format.
+The source payload would use `trace_sampling_policies`.
 The resulting policies would have the same policyType but different ids
 (note `matching` is defined in the spec as part of the policy not the pipeline,
 but is not yet implemented in this repo,
@@ -273,7 +271,7 @@ so the `match` field here is currently for illustrative purposes only):
 
 ```json
 {
-  "sample-database-spans": {
+  "trace_sampling_policies": {
     "id": "sample-database-spans",
     "name": "Sample database spans",
     "match": {
@@ -287,7 +285,7 @@ so the `match` field here is currently for illustrative purposes only):
 
 ```json
 {
-  "sample-healthcheck-spans": {
+  "trace_sampling_policies": {
     "id": "sample-healthcheck-spans",
     "name": "Sample healthcheck spans",
     "match": {

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -234,7 +234,7 @@ at the same time, the opamp change would be applied and the file change dropped.
 
 Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
-* `policyType` in the pipeline initialization maps a policy ID to the Java policy implementation.
+* The pipeline initialization maps a policy ID (`policyId`) to a `policyType`, which selects the Java policy implementation.
   For example, `policyType: trace-sampling` tells dynamic control to validate matching source
   values as trace sampling policies and deliver them to the trace sampling implementer.
 * `id` identifies one policy instance within a policy type. It is used to distinguish updates,

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -49,7 +49,7 @@ import opamp.proto.ServerErrorResponse;
  * {@link PolicyProvider} implementation backed by OpAMP remote configuration updates.
  *
  * <p>The provider subscribes to an OpAMP endpoint, extracts the configured payload for one source
- * location key, maps incoming source keys to internal policy types, validates them with the
+ * location key, maps incoming policy IDs to internal policy types, validates them with the
  * supplied validators, and publishes the resulting policies to callers.
  */
 public final class OpampPolicyProvider implements PolicyProvider {
@@ -75,7 +75,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
   private final Map<String, String> headers;
   private final SourceFormat format;
   private final List<PolicyValidator> validators;
-  private final Map<String, String> sourceKeyToPolicyType;
+  private final Map<String, String> policyIdToPolicyType;
   private final MutablePeriodicDelay pollingDelay;
   private final AtomicReference<List<TelemetryPolicy>> currentPolicies =
       new AtomicReference<>(Collections.<TelemetryPolicy>emptyList());
@@ -88,7 +88,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
    * @param properties auto-configuration properties used to resolve endpoint/service identity
    * @param configuredLocation source location key used to select one OpAMP config entry
    * @param format payload format parser for the selected source
-   * @param mappings source-key-to-policy-type mappings for this source
+   * @param mappings policy-id-to-policy-type mappings for this source
    * @param validators validators used to materialize typed {@link TelemetryPolicy} instances
    * @throws IllegalArgumentException if required configuration such as OpAMP endpoint is missing
    */
@@ -114,7 +114,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
     this.headers = Collections.unmodifiableMap(new HashMap<>(properties.getMap(OPAMP_HEADERS)));
     this.format = format;
     this.validators = Collections.unmodifiableList(new ArrayList<>(validators));
-    this.sourceKeyToPolicyType = Collections.unmodifiableMap(buildSourceKeyToPolicyType(mappings));
+    this.policyIdToPolicyType = Collections.unmodifiableMap(buildPolicyIdToPolicyType(mappings));
     this.pollingDelay =
         new MutablePeriodicDelay(
             Objects.requireNonNull(
@@ -256,7 +256,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
     logger.info("Received OpAMP policy payload for key '" + key + "': " + policyText);
     List<SourceWrapper> parsedSources = format.parse(policyText);
     if (parsedSources == null && format == SourceFormat.JSONKEYVALUE) {
-      parsedSources = parseMappedJsonObject(policyText, sourceKeyToPolicyType.keySet());
+      parsedSources = parseMappedJsonObject(policyText, policyIdToPolicyType.keySet());
     }
     if (parsedSources == null) {
       logger.info("Ignoring invalid OpAMP config entry for key: " + key);
@@ -267,7 +267,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
       if (policyType == null || policyType.isEmpty()) {
         continue;
       }
-      String mappedPolicyType = sourceKeyToPolicyType.get(policyType);
+      String mappedPolicyType = policyIdToPolicyType.get(policyType);
       if (mappedPolicyType == null) {
         continue;
       }
@@ -437,11 +437,11 @@ public final class OpampPolicyProvider implements PolicyProvider {
     }
   }
 
-  private static Map<String, String> buildSourceKeyToPolicyType(
+  private static Map<String, String> buildPolicyIdToPolicyType(
       List<PolicySourceMappingConfig> mappings) {
     Map<String, String> mapping = new HashMap<>();
     for (PolicySourceMappingConfig item : mappings) {
-      mapping.put(item.getSourceKey(), item.getPolicyType());
+      mapping.put(item.getPolicyId(), item.getPolicyType());
     }
     return mapping;
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -49,8 +49,8 @@ import opamp.proto.ServerErrorResponse;
  * {@link PolicyProvider} implementation backed by OpAMP remote configuration updates.
  *
  * <p>The provider subscribes to an OpAMP endpoint, extracts the configured payload for one source
- * location key, maps incoming policy IDs to internal policy types, validates them with the
- * supplied validators, and publishes the resulting policies to callers.
+ * location key, maps incoming policy IDs to internal policy types, validates them with the supplied
+ * validators, and publishes the resulting policies to callers.
  */
 public final class OpampPolicyProvider implements PolicyProvider {
   private static final Logger logger = Logger.getLogger(OpampPolicyProvider.class.getName());

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -263,11 +263,11 @@ public final class OpampPolicyProvider implements PolicyProvider {
       return;
     }
     for (SourceWrapper source : parsedSources) {
-      String policyType = source.getPolicyType();
-      if (policyType == null || policyType.isEmpty()) {
+      String incomingPolicyId = source.getPolicyType();
+      if (incomingPolicyId == null || incomingPolicyId.isEmpty()) {
         continue;
       }
-      String mappedPolicyType = policyIdToPolicyType.get(policyType);
+      String mappedPolicyType = policyIdToPolicyType.get(incomingPolicyId);
       if (mappedPolicyType == null) {
         continue;
       }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -191,7 +191,7 @@ public final class PolicyInit {
                   + "' in mapping for source kind '"
                   + source.getKind().configValue()
                   + "' key '"
-                  + mapping.getSourceKey()
+                  + mapping.getPolicyId()
                   + "'");
         }
         initializePolicyClass(policyClass, autoConfiguration, initializedPolicyClasses);

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfig.java
@@ -36,7 +36,7 @@ public final class PolicyInitConfig {
   static final String FORMAT_DECLARATIVE_KEY = "format";
   static final String LOCATION_DECLARATIVE_KEY = "location";
   static final String MAPPINGS_DECLARATIVE_KEY = "mappings";
-  static final String SOURCE_KEY_DECLARATIVE_KEY = "sourceKey";
+  static final String POLICY_ID_DECLARATIVE_KEY = "policyId";
   static final String POLICY_TYPE_DECLARATIVE_KEY = "policyType";
   static final String POLICY_INIT_CONFIG_PROPERTY_JSON =
       "otel.java.experimental.telemetry.policy.init.json";
@@ -71,7 +71,7 @@ public final class PolicyInitConfig {
    *       format: ...
    *       location: ...
    *       mappings:
-   *         - sourceKey: ...
+   *         - policyId: ...
    *           policyType: ...
    * }</pre>
    *
@@ -115,7 +115,7 @@ public final class PolicyInitConfig {
    *     format: ...
    *     location: ...
    *     mappings:
-   *       - sourceKey: ...
+   *       - policyId: ...
    *         policyType: ...
    * }</pre>
    *
@@ -251,15 +251,15 @@ public final class PolicyInitConfig {
   private static PolicySourceMappingConfig parseDeclarativeMapping(
       DeclarativeConfigProperties mappingConfig) {
     Objects.requireNonNull(mappingConfig, "mapping config cannot be null");
-    String sourceKey =
+    String policyId =
         requireDeclarativeText(
-            mappingConfig.getString(SOURCE_KEY_DECLARATIVE_KEY),
-            "Each mapping must define string 'sourceKey'.");
+            mappingConfig.getString(POLICY_ID_DECLARATIVE_KEY),
+            "Each mapping must define string 'policyId'.");
     String policyType =
         requireDeclarativeText(
             mappingConfig.getString(POLICY_TYPE_DECLARATIVE_KEY),
             "Each mapping must define string 'policyType'.");
-    return new PolicySourceMappingConfig(sourceKey, policyType);
+    return new PolicySourceMappingConfig(policyId, policyType);
   }
 
   private static String requireDeclarativeText(@Nullable String value, String message) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceMappingConfig.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicySourceMappingConfig.java
@@ -7,19 +7,19 @@ package io.opentelemetry.contrib.dynamic.policy.registry;
 
 import java.util.Objects;
 
-/** One source-local mapping from source key to target policy type. */
+/** One policy mapping from policy ID to target policy type. */
 public final class PolicySourceMappingConfig {
 
-  private final String sourceKey;
+  private final String policyId;
   private final String policyType;
 
-  public PolicySourceMappingConfig(String sourceKey, String policyType) {
-    this.sourceKey = Objects.requireNonNull(sourceKey, "sourceKey cannot be null");
+  public PolicySourceMappingConfig(String policyId, String policyType) {
+    this.policyId = Objects.requireNonNull(policyId, "policyId cannot be null");
     this.policyType = Objects.requireNonNull(policyType, "policyType cannot be null");
   }
 
-  public String getSourceKey() {
-    return sourceKey;
+  public String getPolicyId() {
+    return policyId;
   }
 
   public String getPolicyType() {
@@ -35,12 +35,12 @@ public final class PolicySourceMappingConfig {
       return false;
     }
     PolicySourceMappingConfig that = (PolicySourceMappingConfig) obj;
-    return sourceKey.equals(that.sourceKey) && policyType.equals(that.policyType);
+    return policyId.equals(that.policyId) && policyType.equals(that.policyType);
   }
 
   @Override
   public int hashCode() {
-    int result = sourceKey.hashCode();
+    int result = policyId.hashCode();
     result = 31 * result + policyType.hashCode();
     return result;
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonNodePolicyInitConfigParser.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonNodePolicyInitConfigParser.java
@@ -61,11 +61,11 @@ public final class JsonNodePolicyInitConfigParser {
 
   private static PolicySourceMappingConfig parseMapping(JsonNode node) {
     JsonNode objectNode = requireObject(node, "Each mapping entry must be an object.");
-    String sourceKey =
-        requireText(objectNode.get("sourceKey"), "Each mapping must define string 'sourceKey'.");
+    String policyId =
+        requireText(objectNode.get("policyId"), "Each mapping must define string 'policyId'.");
     String policyType =
         requireText(objectNode.get("policyType"), "Each mapping must define string 'policyType'.");
-    return new PolicySourceMappingConfig(sourceKey, policyType);
+    return new PolicySourceMappingConfig(policyId, policyType);
   }
 
   @CanIgnoreReturnValue

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/DynamicControlAutoConfigurationTest.java
@@ -83,7 +83,7 @@ class DynamicControlAutoConfigurationTest {
         + "    format: jsonkeyvalue\n"
         + "    location: vendor\n"
         + "    mappings:\n"
-        + "      - sourceKey: sampling_rate\n"
+        + "      - policyId: sampling_rate\n"
         + "        policyType: "
         + TraceSamplingRatePolicy.POLICY_TYPE
         + "\n";

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
@@ -88,7 +88,7 @@ class PolicyInitConfigTest {
     assertThat(source.getFormat()).isEqualTo(SourceFormat.JSONKEYVALUE);
     assertThat(source.getLocation()).isEqualTo("vendor");
     assertThat(source.getMappings()).hasSize(1);
-    assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
+    assertThat(source.getMappings().get(0).getPolicyId()).isEqualTo("sampling_rate");
     assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
   }
 
@@ -190,7 +190,7 @@ class PolicyInitConfigTest {
     assertThat(source.getFormat()).isEqualTo(SourceFormat.JSONKEYVALUE);
     assertThat(source.getLocation()).isEqualTo("from-declarative");
     assertThat(source.getMappings()).hasSize(1);
-    assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
+    assertThat(source.getMappings().get(0).getPolicyId()).isEqualTo("sampling_rate");
     assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
   }
 
@@ -425,7 +425,7 @@ class PolicyInitConfigTest {
 
   private static DeclarativeConfigProperties mappingConfig() {
     DeclarativeConfigProperties mapping = mock(DeclarativeConfigProperties.class);
-    when(mapping.getString(PolicyInitConfig.SOURCE_KEY_DECLARATIVE_KEY))
+    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY))
         .thenReturn("sampling_rate");
     when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY))
         .thenReturn("trace-sampling");
@@ -453,13 +453,13 @@ class PolicyInitConfigTest {
 
   private static String minimalJsonConfig() {
     return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\"vendor\","
-        + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
+        + "\"mappings\":[{\"policyId\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
   }
 
   private static String jsonWithLocation(String location) {
     return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\""
         + location
-        + "\",\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
+        + "\",\"mappings\":[{\"policyId\":\"sampling_rate\",\"policyType\":\"trace-sampling\"}]}]}";
   }
 
   private static String minimalYamlConfig() {
@@ -468,7 +468,7 @@ class PolicyInitConfigTest {
         + "    format: jsonkeyvalue\n"
         + "    location: vendor\n"
         + "    mappings:\n"
-        + "      - sourceKey: sampling_rate\n"
+        + "      - policyId: sampling_rate\n"
         + "        policyType: trace-sampling\n";
   }
 
@@ -480,7 +480,7 @@ class PolicyInitConfigTest {
         + location
         + "\n"
         + "    mappings:\n"
-        + "      - sourceKey: sampling_rate\n"
+        + "      - policyId: sampling_rate\n"
         + "        policyType: trace-sampling\n";
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitConfigTest.java
@@ -425,8 +425,7 @@ class PolicyInitConfigTest {
 
   private static DeclarativeConfigProperties mappingConfig() {
     DeclarativeConfigProperties mapping = mock(DeclarativeConfigProperties.class);
-    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY))
-        .thenReturn("sampling_rate");
+    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY)).thenReturn("sampling_rate");
     when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY))
         .thenReturn("trace-sampling");
     return mapping;

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -149,7 +149,7 @@ class PolicyInitTest {
     when(source.getString(PolicyInitConfig.LOCATION_DECLARATIVE_KEY)).thenReturn("vendor");
     when(source.getStructuredList(PolicyInitConfig.MAPPINGS_DECLARATIVE_KEY))
         .thenReturn(Collections.singletonList(mapping));
-    when(mapping.getString(PolicyInitConfig.SOURCE_KEY_DECLARATIVE_KEY))
+    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY))
         .thenReturn("sampling_rate");
     when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY)).thenReturn(policyType);
     return telemetryPolicy;
@@ -157,7 +157,7 @@ class PolicyInitTest {
 
   private static String minimalJsonInitConfig() {
     return "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"location\":\"vendor\","
-        + "\"mappings\":[{\"sourceKey\":\"sampling_rate\",\"policyType\":\""
+        + "\"mappings\":[{\"policyId\":\"sampling_rate\",\"policyType\":\""
         + TraceSamplingRatePolicy.POLICY_TYPE
         + "\"}]}]}";
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -149,8 +149,7 @@ class PolicyInitTest {
     when(source.getString(PolicyInitConfig.LOCATION_DECLARATIVE_KEY)).thenReturn("vendor");
     when(source.getStructuredList(PolicyInitConfig.MAPPINGS_DECLARATIVE_KEY))
         .thenReturn(Collections.singletonList(mapping));
-    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY))
-        .thenReturn("sampling_rate");
+    when(mapping.getString(PolicyInitConfig.POLICY_ID_DECLARATIVE_KEY)).thenReturn("sampling_rate");
     when(mapping.getString(PolicyInitConfig.POLICY_TYPE_DECLARATIVE_KEY)).thenReturn(policyType);
     return telemetryPolicy;
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonPolicyInitConfigReaderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/json/JsonPolicyInitConfigReaderTest.java
@@ -33,7 +33,7 @@ class JsonPolicyInitConfigReaderTest {
       assertThat(source.getFormat()).isEqualTo(SourceFormat.JSONKEYVALUE);
       assertThat(source.getLocation()).isEqualTo("vendor-specific");
       assertThat(source.getMappings()).hasSize(4);
-      assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
+      assertThat(source.getMappings().get(0).getPolicyId()).isEqualTo("sampling_rate");
       assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
     }
   }
@@ -69,11 +69,11 @@ class JsonPolicyInitConfigReaderTest {
   }
 
   @Test
-  void mappingMissingSourceKeyThrows() {
+  void mappingMissingPolicyIdThrows() {
     String json =
         "{\"sources\":[{\"kind\":\"opamp\",\"format\":\"jsonkeyvalue\",\"mappings\":[{\"policyType\":\"x\"}]}]}";
     assertThatThrownBy(() -> JsonPolicyInitConfigReader.read(json))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("sourceKey");
+        .hasMessageContaining("policyId");
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/yaml/YamlPolicyInitConfigReaderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/yaml/YamlPolicyInitConfigReaderTest.java
@@ -33,7 +33,7 @@ class YamlPolicyInitConfigReaderTest {
       assertThat(source.getFormat()).isEqualTo(SourceFormat.JSONKEYVALUE);
       assertThat(source.getLocation()).isEqualTo("vendor-specific");
       assertThat(source.getMappings()).hasSize(4);
-      assertThat(source.getMappings().get(0).getSourceKey()).isEqualTo("sampling_rate");
+      assertThat(source.getMappings().get(0).getPolicyId()).isEqualTo("sampling_rate");
       assertThat(source.getMappings().get(0).getPolicyType()).isEqualTo("trace-sampling");
     }
   }
@@ -69,7 +69,7 @@ class YamlPolicyInitConfigReaderTest {
   }
 
   @Test
-  void mappingMissingSourceKeyThrows() {
+  void mappingMissingPolicyIdThrows() {
     String yaml =
         "sources:\n"
             + "  - kind: opamp\n"
@@ -78,6 +78,6 @@ class YamlPolicyInitConfigReaderTest {
             + "      - policyType: x\n";
     assertThatThrownBy(() -> YamlPolicyInitConfigReader.read(yaml))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("sourceKey");
+        .hasMessageContaining("policyId");
   }
 }

--- a/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/json/policy-init-example.json
+++ b/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/json/policy-init-example.json
@@ -5,10 +5,10 @@
       "format": "jsonkeyvalue",
       "location": "vendor-specific",
       "mappings": [
-        { "sourceKey": "sampling_rate", "policyType": "trace-sampling" },
-        { "sourceKey": "send_logs", "policyType": "log_export_enabled_policy" },
-        { "sourceKey": "send_traces", "policyType": "trace_export_enabled_policy" },
-        { "sourceKey": "send_metrics", "policyType": "metric_export_enabled_policy" }
+        { "policyId": "sampling_rate", "policyType": "trace-sampling" },
+        { "policyId": "send_logs", "policyType": "log_export_enabled_policy" },
+        { "policyId": "send_traces", "policyType": "trace_export_enabled_policy" },
+        { "policyId": "send_metrics", "policyType": "metric_export_enabled_policy" }
       ]
     }
   ]

--- a/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/yaml/policy-init-example.yaml
+++ b/dynamic-control/src/test/resources/io/opentelemetry/contrib/dynamic/policy/registry/yaml/policy-init-example.yaml
@@ -3,11 +3,11 @@ sources:
     format: jsonkeyvalue
     location: vendor-specific
     mappings:
-      - sourceKey: sampling_rate
+      - policyId: sampling_rate
         policyType: trace-sampling
-      - sourceKey: send_logs
+      - policyId: send_logs
         policyType: log_export_enabled_policy
-      - sourceKey: send_traces
+      - policyId: send_traces
         policyType: trace_export_enabled_policy
-      - sourceKey: send_metrics
+      - policyId: send_metrics
         policyType: metric_export_enabled_policy


### PR DESCRIPTION
**Description:**

Just a name change, nothing else. The spec "policy ID" is what I've been naming as "source key", so this refactors all usages (including variants). 

**Existing Issue(s):**

#2868

**Testing:**

Full test suite ran with new refactored values

**Documentation:**

Also refactored to be consistent

**Outstanding items:**

#2868