### PR TITLE
[dynamic control] only change the sampling rate if it has changed value

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSampler.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/DelegatingSampler.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 public class DelegatingSampler implements Sampler {
 
   private volatile Sampler delegate;
+  private double samplingProbability = Double.NaN;
 
   /**
    * Creates a new {@link DelegatingSampler} with the given initial delegate.
@@ -58,8 +59,28 @@ public class DelegatingSampler implements Sampler {
    * @param sampler the new delegate sampler to use, or {@code null} to fall back to {@link
    *     Sampler#alwaysOn()}
    */
-  public void setDelegate(@Nullable Sampler sampler) {
+  public synchronized void setDelegate(@Nullable Sampler sampler) {
     delegate = sampler != null ? sampler : Sampler.alwaysOn();
+    samplingProbability = Double.NaN;
+  }
+
+  /**
+   * Updates the delegate sampler for a trace sampling policy probability.
+   *
+   * <p>The probability is tracked with the delegate so repeated equivalent policy updates can be
+   * skipped atomically.
+   *
+   * @param probability sampling probability in the inclusive range {@code [0.0, 1.0]}
+   * @return {@code true} if the delegate changed, {@code false} if the probability was already
+   *     applied
+   */
+  public synchronized boolean setSamplingProbability(double probability) {
+    if (Double.compare(samplingProbability, probability) == 0) {
+      return false;
+    }
+    delegate = TraceSamplingRatePolicy.createSampler(probability);
+    samplingProbability = probability;
+    return true;
   }
 
   @Override

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
-import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -61,17 +60,20 @@ public final class TraceSamplingRatePolicyImplementer implements PolicyImplement
         continue;
       }
       if (policy.isDeleted()) {
-        delegatingSampler.setDelegate(TraceSamplingRatePolicy.createSampler(1.0));
-        logger.info("Applied trace sampling policy reset: probability reset to 1.0");
+        applySamplingProbability(1.0, "reset");
         continue;
       }
       if (!(policy instanceof TraceSamplingRatePolicy)) {
         continue;
       }
       double ratio = ((TraceSamplingRatePolicy) policy).getProbability();
-      Sampler sampler = TraceSamplingRatePolicy.createSampler(ratio);
-      delegatingSampler.setDelegate(sampler);
-      logger.info("Applied trace sampling policy update: probability=" + ratio);
+      applySamplingProbability(ratio, "update");
+    }
+  }
+
+  private void applySamplingProbability(double probability, String action) {
+    if (delegatingSampler.setSamplingProbability(probability)) {
+      logger.info("Applied trace sampling policy " + action + ": probability=" + probability);
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -50,6 +50,18 @@ class TraceSamplingRatePolicyImplementerTest {
   }
 
   @Test
+  void skipsRepeatedEquivalentProbability() {
+    CountingDelegatingSampler delegatingSampler = new CountingDelegatingSampler(Sampler.alwaysOff());
+    TraceSamplingRatePolicyImplementer implementer =
+        new TraceSamplingRatePolicyImplementer(delegatingSampler);
+
+    implementer.onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(1.0)));
+    implementer.onPoliciesChanged(singletonList(new TraceSamplingRatePolicy(1.0)));
+
+    assertThat(delegatingSampler.changedProbabilityCount).isEqualTo(1);
+  }
+
+  @Test
   void ignoresUnrelatedPolicyTypes() {
     DelegatingSampler delegatingSampler = new DelegatingSampler(Sampler.alwaysOff());
     TraceSamplingRatePolicyImplementer implementer =
@@ -84,6 +96,23 @@ class TraceSamplingRatePolicyImplementerTest {
             Attributes.empty(),
             Collections.emptyList());
     return result.getDecision();
+  }
+
+  private static final class CountingDelegatingSampler extends DelegatingSampler {
+    private int changedProbabilityCount;
+
+    private CountingDelegatingSampler(Sampler initialDelegate) {
+      super(initialDelegate);
+    }
+
+    @Override
+    public synchronized boolean setSamplingProbability(double probability) {
+      boolean changed = super.setSamplingProbability(probability);
+      if (changed) {
+        changedProbabilityCount++;
+      }
+      return changed;
+    }
   }
 
   private static final class TestTelemetryPolicy implements TelemetryPolicy {

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -51,7 +51,8 @@ class TraceSamplingRatePolicyImplementerTest {
 
   @Test
   void skipsRepeatedEquivalentProbability() {
-    CountingDelegatingSampler delegatingSampler = new CountingDelegatingSampler(Sampler.alwaysOff());
+    CountingDelegatingSampler delegatingSampler =
+        new CountingDelegatingSampler(Sampler.alwaysOff());
     TraceSamplingRatePolicyImplementer implementer =
         new TraceSamplingRatePolicyImplementer(delegatingSampler);
 


### PR DESCRIPTION
**Description:**

The policy aggregator spec doesn't require already applied policy changes to be eliminated, it delegates that optimization to the implementation. I've added the optimization that if there is no effective change to the sampling rate, then no actual change is applied

**Existing Issue(s):**

#2868

**Testing:**

added

**Documentation:**

n/a

**Outstanding items:**

#2868