### PR TITLE
[dynamic control] add initializing from declarative config (copy of #2881)

### DIFF
--- a/dynamic-control/build.gradle.kts
+++ b/dynamic-control/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-declarative-config:1.63.0-alpha")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-declarative-config")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
 
@@ -35,7 +35,7 @@ dependencies {
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-declarative-config:1.63.0-alpha")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-declarative-config")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
   testImplementation("org.assertj:assertj-core")

--- a/dynamic-control/build.gradle.kts
+++ b/dynamic-control/build.gradle.kts
@@ -24,8 +24,9 @@ dependencies {
 
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-declarative-config")
+  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-declarative-config:1.63.0-alpha")
   compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  compileOnly("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
 
   testCompileOnly("com.google.auto.service:auto-service-annotations")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
@@ -34,8 +35,9 @@ dependencies {
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-declarative-config")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-declarative-config:1.63.0-alpha")
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+  testImplementation("io.opentelemetry.instrumentation:opentelemetry-declarative-config-bridge")
   testImplementation("org.assertj:assertj-core")
   testImplementation("org.mockito:mockito-inline")
   testImplementation("org.mockito:mockito-junit-jupiter")

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicyDeclarativeCustomizerProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicyDeclarativeCustomizerProvider.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.service.AutoService;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInitConfig;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceConfig;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceMappingConfig;
+import io.opentelemetry.contrib.dynamic.policy.registry.json.JsonNodePolicyInitConfigParser;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizerProvider;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AttributeNameValueModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ResourceModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerPropertyModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.TracerProviderModel;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Declarative config customizer for top-level telemetry policy configuration.
+ *
+ * <p>The Java agent version currently used by this module exposes the incubating fileconfig
+ * customizer SPI. This is the declarative-config hook corresponding to the newer agent {@code
+ * sdk.autoconfigure.declarativeconfig} API.
+ */
+@AutoService(DeclarativeConfigurationCustomizerProvider.class)
+public final class TelemetryPolicyDeclarativeCustomizerProvider
+    implements DeclarativeConfigurationCustomizerProvider {
+  static final String TELEMETRY_POLICY_TOP_LEVEL_KEY = "telemetry_policy/development";
+
+  private static final Logger logger =
+      Logger.getLogger(TelemetryPolicyDeclarativeCustomizerProvider.class.getName());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Override
+  public void customize(DeclarativeConfigurationCustomizer customizer) {
+    customizer.addModelCustomizer(
+        model -> {
+          // Need to return new model if needed, can't guarantee model is mutable
+          return registerTopLevelTelemetryPolicy(model);
+        });
+  }
+
+  @CanIgnoreReturnValue
+  private static OpenTelemetryConfigurationModel registerTopLevelTelemetryPolicy(
+      OpenTelemetryConfigurationModel model) {
+    if (model == null || model.getAdditionalProperties() == null) {
+      return model;
+    }
+    Map<String, Object> additionalProperties = model.getAdditionalProperties();
+    Object telemetryPolicy = additionalProperties.remove(TELEMETRY_POLICY_TOP_LEVEL_KEY);
+    if (telemetryPolicy == null) {
+      return model;
+    }
+    if (!(telemetryPolicy instanceof Map)) {
+      logger.log(
+          Level.WARNING,
+          "Ignoring top-level declarative telemetry policy config because it is not an object");
+      return model;
+    }
+
+    Map<?, ?> telemetryPolicyConfig = (Map<?, ?>) telemetryPolicy;
+    JsonNode telemetryPolicyNode = MAPPER.valueToTree(telemetryPolicyConfig);
+    PolicyInitConfig initConfig = JsonNodePolicyInitConfigParser.parse(telemetryPolicyNode);
+    PolicyInit.setDeclarativeInitConfig(initConfig);
+    maybeInstallTelemetryPolicySampler(model, telemetryPolicyConfig, initConfig);
+    logger.log(
+        Level.INFO,
+        "Dynamic control extension has loaded top-level declarative telemetry policy config with {0} source(s)",
+        initConfig.getSources().size());
+    return model;
+  }
+
+  private static void maybeInstallTelemetryPolicySampler(
+      OpenTelemetryConfigurationModel model,
+      Map<?, ?> telemetryPolicy,
+      PolicyInitConfig initConfig) {
+    if (!containsPolicyType(initConfig, TraceSamplingRatePolicy.POLICY_TYPE)) {
+      return;
+    }
+    Object sources = telemetryPolicy.get("sources");
+    if (sources == null) {
+      return;
+    }
+    TracerProviderModel tracerProvider = model.getTracerProvider();
+    if (tracerProvider == null) {
+      tracerProvider = new TracerProviderModel();
+      model.withTracerProvider(tracerProvider);
+    }
+    SamplerModel sampler = tracerProvider.getSampler();
+    if (sampler == null) {
+      sampler = new SamplerModel();
+      tracerProvider.withSampler(sampler);
+    }
+    sampler.withAdditionalProperty(
+        TelemetryPolicySamplerComponentProvider.NAME,
+        new SamplerPropertyModel()
+            .withAdditionalProperty("sources", sources)
+            .withAdditionalProperty("resource_attributes", resourceAttributes(model))
+            .withAdditionalProperty("otel.resource.attributes", resourceAttributes(model)));
+  }
+
+  private static boolean containsPolicyType(PolicyInitConfig initConfig, String policyType) {
+    for (PolicySourceConfig source : initConfig.getSources()) {
+      for (PolicySourceMappingConfig mapping : source.getMappings()) {
+        if (policyType.equals(mapping.getPolicyType())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static Map<String, String> resourceAttributes(OpenTelemetryConfigurationModel model) {
+    ResourceModel resource = model.getResource();
+    if (resource == null || resource.getAttributes() == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> attributes = new LinkedHashMap<>();
+    List<AttributeNameValueModel> resourceAttributes = resource.getAttributes();
+    for (AttributeNameValueModel attribute : resourceAttributes) {
+      if (attribute.getName() != null && attribute.getValue() != null) {
+        attributes.put(attribute.getName(), String.valueOf(attribute.getValue()));
+      }
+    }
+    return Collections.unmodifiableMap(attributes);
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProvider.java
@@ -46,8 +46,7 @@ public final class TelemetryPolicySamplerComponentProvider implements ComponentP
     try {
       PolicyInit.initFromDeclarativeConfig(config, bridgedConfig);
     } catch (IllegalArgumentException e) {
-      // No-op when the component is present but does not include a valid telemetry_policy block.
-      logger.log(Level.FINE, "Skipping telemetry policy initialization from component config", e);
+      logger.log(Level.WARNING, "Failed to initialize telemetry policy from component config", e);
     }
     // TODO: install specifically a delegating sampler, and allow it to be dynamically updated by
     // the policy configuration

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProvider.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import io.opentelemetry.instrumentation.config.bridge.DeclarativeConfigPropertiesBridgeBuilder;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Declarative sampler component that bootstraps top-level telemetry policy wiring. */
+@AutoService(ComponentProvider.class)
+public final class TelemetryPolicySamplerComponentProvider implements ComponentProvider {
+  private static final Logger logger =
+      Logger.getLogger(TelemetryPolicySamplerComponentProvider.class.getName());
+  public static final String NAME = "telemetry_policy/development";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Sampler create(DeclarativeConfigProperties config) {
+    logger.log(
+        Level.INFO,
+        "Dynamic control extension has been loaded by the agent via declarative config");
+    ConfigProperties bridgedConfig =
+        new SystemPropertyFallbackConfigProperties(
+            new DeclarativeConfigPropertiesBridgeBuilder().build(config));
+    try {
+      PolicyInit.initFromDeclarativeConfig(config, bridgedConfig);
+    } catch (IllegalArgumentException e) {
+      // No-op when the component is present but does not include a valid telemetry_policy block.
+      logger.log(Level.FINE, "Skipping telemetry policy initialization from component config", e);
+    }
+    // TODO: install specifically a delegating sampler, and allow it to be dynamically updated by
+    // the policy configuration
+    // but for now just use the existing sampling rate sampler which is a specifically configured
+    // delegating sampler
+    Sampler initialized = TraceSamplingRatePolicy.getInitializedSampler();
+    return initialized == null ? Sampler.parentBased(Sampler.alwaysOn()) : initialized;
+  }
+
+  @Override
+  public Class<Sampler> getType() {
+    return Sampler.class;
+  }
+
+  private static final class SystemPropertyFallbackConfigProperties implements ConfigProperties {
+    private static final String OTEL_RESOURCE_ATTRIBUTES = "otel.resource.attributes";
+    private static final String OTEL_SERVICE_NAME = "otel.service.name";
+    private final ConfigProperties delegate;
+
+    private SystemPropertyFallbackConfigProperties(ConfigProperties delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    @Nullable
+    public String getString(String name) {
+      String value = safeGetString(name);
+      if (value == null && OTEL_SERVICE_NAME.equals(name)) {
+        value = getMap(OTEL_RESOURCE_ATTRIBUTES).get("service.name");
+      }
+      return value != null ? value : getSystemOrEnv(name);
+    }
+
+    @Override
+    @Nullable
+    public Boolean getBoolean(String name) {
+      return safeGet(() -> delegate.getBoolean(name));
+    }
+
+    @Override
+    @Nullable
+    public Integer getInt(String name) {
+      return safeGet(() -> delegate.getInt(name));
+    }
+
+    @Override
+    @Nullable
+    public Long getLong(String name) {
+      return safeGet(() -> delegate.getLong(name));
+    }
+
+    @Override
+    @Nullable
+    public Double getDouble(String name) {
+      return safeGet(() -> delegate.getDouble(name));
+    }
+
+    @Override
+    @Nullable
+    public Duration getDuration(String name) {
+      return safeGet(() -> delegate.getDuration(name));
+    }
+
+    @Override
+    public List<String> getList(String name) {
+      List<String> value = safeGet(() -> delegate.getList(name));
+      return value == null ? Collections.emptyList() : value;
+    }
+
+    @Override
+    public Map<String, String> getMap(String name) {
+      Map<String, String> value = safeGet(() -> delegate.getMap(name));
+      if (value != null && !value.isEmpty()) {
+        return value;
+      }
+      if (OTEL_RESOURCE_ATTRIBUTES.equals(name)) {
+        value = safeGet(() -> delegate.getMap("resource_attributes"));
+        if (value != null && !value.isEmpty()) {
+          return value;
+        }
+      }
+      String fallback = getSystemOrEnv(name);
+      return fallback == null ? Collections.emptyMap() : parseMap(fallback);
+    }
+
+    @Nullable
+    private String safeGetString(String name) {
+      return safeGet(() -> delegate.getString(name));
+    }
+
+    @Nullable
+    private static <T> T safeGet(SupplierWithRuntimeException<T> supplier) {
+      try {
+        return supplier.get();
+      } catch (RuntimeException ignored) {
+        return null;
+      }
+    }
+
+    @Nullable
+    private static String getSystemOrEnv(String propertyName) {
+      String value = System.getProperty(propertyName);
+      if (value != null) {
+        return value;
+      }
+      return System.getenv(
+          propertyName.toUpperCase(Locale.ROOT).replace('.', '_').replace('-', '_'));
+    }
+
+    private static Map<String, String> parseMap(String value) {
+      if (value == null || value.trim().isEmpty()) {
+        return Collections.emptyMap();
+      }
+      Map<String, String> result = new LinkedHashMap<>();
+      for (String entry : value.split(",")) {
+        int separator = entry.indexOf('=');
+        if (separator <= 0) {
+          continue;
+        }
+        result.put(entry.substring(0, separator).trim(), entry.substring(separator + 1).trim());
+      }
+      return Collections.unmodifiableMap(result);
+    }
+  }
+
+  @FunctionalInterface
+  private interface SupplierWithRuntimeException<T> {
+    @Nullable
+    T get();
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInit.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -64,6 +65,8 @@ public final class PolicyInit {
   private static final Map<PolicyProvider, List<TelemetryPolicy>> sourcePolicies =
       new ConcurrentHashMap<>();
   private static final PolicyStore policyStore = new PolicyStore();
+  private static final AtomicReference<PolicyInitConfig> declarativeInitConfig =
+      new AtomicReference<>();
 
   static {
     // For now, policies will be registered here. TODO: move to a more dynamic way.
@@ -124,7 +127,16 @@ public final class PolicyInit {
   public static void init(AutoConfigurationCustomizer autoConfiguration) {
     autoConfiguration.addPropertiesCustomizer(
         config -> {
-          PolicyInitConfig initConfig = PolicyInitConfig.readFromConfigProperties(config);
+          PolicyInitConfig initConfig = declarativeInitConfig.getAndSet(null);
+          if (initConfig != null) {
+            logger.log(
+                Level.INFO,
+                "Initializing telemetry policies from top-level declarative config with {0} source(s)",
+                initConfig.getSources().size());
+          } else {
+            initConfig = PolicyInitConfig.readFromConfigProperties(config);
+          }
+
           if (initConfig == null) {
             return Collections.emptyMap();
           }
@@ -132,6 +144,13 @@ public final class PolicyInit {
           activateSources(initConfig, config);
           return Collections.emptyMap();
         });
+  }
+
+  /**
+   * Stores parsed top-level declarative telemetry policy config for auto-configuration bootstrap.
+   */
+  public static void setDeclarativeInitConfig(PolicyInitConfig initConfig) {
+    declarativeInitConfig.set(Objects.requireNonNull(initConfig, "initConfig cannot be null"));
   }
 
   /** Initializes dynamic-control policy wiring from declarative config component input. */
@@ -392,6 +411,7 @@ public final class PolicyInit {
     sourcesActivated.set(false);
     initializedImplementers.clear();
     policyStore.clear();
+    declarativeInitConfig.set(null);
   }
 
   /**

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/TelemetryPolicyDeclarativeCustomizerProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/TelemetryPolicyDeclarativeCustomizerProviderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.AttributeNameValueModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.ResourceModel;
+import io.opentelemetry.sdk.autoconfigure.declarativeconfig.model.SamplerPropertyModel;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class TelemetryPolicyDeclarativeCustomizerProviderTest {
+  private static final String POLICY_INIT_CONFIG_PROPERTY_JSON =
+      "otel.java.experimental.telemetry.policy.init.json";
+  private static final String POLICY_INIT_CONFIG_PROPERTY_YAML =
+      "otel.java.experimental.telemetry.policy.init.yaml";
+
+  @AfterEach
+  void tearDown() throws Exception {
+    invokeStaticNoArg(PolicyInit.class, "resetForTest");
+    invokeStaticNoArg(TraceSamplingRatePolicy.class, "resetForTest");
+  }
+
+  @Test
+  void initializesTopLevelTelemetryPolicyWithoutSamplerComponentDeclaration() {
+    Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel> modelCustomizer =
+        captureModelCustomizer();
+
+    OpenTelemetryConfigurationModel customized =
+        modelCustomizer.apply(topLevelTelemetryPolicyModel(TraceSamplingRatePolicy.POLICY_TYPE));
+    assertThat(customized).isNotNull();
+    SamplerPropertyModel samplerProperty =
+        customized
+            .getTracerProvider()
+            .getSampler()
+            .getAdditionalProperties()
+            .get(TelemetryPolicySamplerComponentProvider.NAME);
+    assertThat(samplerProperty).isNotNull();
+    assertThat(samplerProperty.getAdditionalProperties().get("resource_attributes"))
+        .isEqualTo(resourceAttributes());
+    assertThat(samplerProperty.getAdditionalProperties().get("otel.resource.attributes"))
+        .isEqualTo(resourceAttributes());
+
+    AutoConfigurationCustomizer autoConfiguration = mock(AutoConfigurationCustomizer.class);
+    PolicyInit.init(autoConfiguration);
+    Function<ConfigProperties, Map<String, String>> propertiesCustomizer =
+        capturePropertiesCustomizer(autoConfiguration);
+
+    ConfigProperties config = mock(ConfigProperties.class);
+    when(config.getString(POLICY_INIT_CONFIG_PROPERTY_YAML)).thenReturn(null);
+    when(config.getString(POLICY_INIT_CONFIG_PROPERTY_JSON)).thenReturn(null);
+
+    assertThat(propertiesCustomizer.apply(config)).isNotNull();
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNotNull();
+  }
+
+  @Test
+  void invalidTopLevelTelemetryPolicyThrows() {
+    Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel> modelCustomizer =
+        captureModelCustomizer();
+
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    model.withAdditionalProperty(
+        TelemetryPolicyDeclarativeCustomizerProvider.TELEMETRY_POLICY_TOP_LEVEL_KEY,
+        Collections.singletonMap("sources", "not-an-array"));
+
+    assertThatThrownBy(() -> modelCustomizer.apply(model))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("sources");
+  }
+
+  private static Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel>
+      captureModelCustomizer() {
+    DeclarativeConfigurationCustomizer customizer = mock(DeclarativeConfigurationCustomizer.class);
+    new TelemetryPolicyDeclarativeCustomizerProvider().customize(customizer);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Function<OpenTelemetryConfigurationModel, OpenTelemetryConfigurationModel>>
+        captor = ArgumentCaptor.forClass(Function.class);
+    verify(customizer).addModelCustomizer(captor.capture());
+    return captor.getValue();
+  }
+
+  private static Function<ConfigProperties, Map<String, String>> capturePropertiesCustomizer(
+      AutoConfigurationCustomizer customizer) {
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Function<ConfigProperties, Map<String, String>>> captor =
+        ArgumentCaptor.forClass(Function.class);
+    verify(customizer).addPropertiesCustomizer(captor.capture());
+    return captor.getValue();
+  }
+
+  private static OpenTelemetryConfigurationModel topLevelTelemetryPolicyModel(String policyType) {
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    model.withAdditionalProperty(
+        TelemetryPolicyDeclarativeCustomizerProvider.TELEMETRY_POLICY_TOP_LEVEL_KEY,
+        telemetryPolicy(policyType));
+    model.withResource(
+        new ResourceModel()
+            .withAttributes(
+                Arrays.asList(
+                    new AttributeNameValueModel().withName("service.name").withValue("edot-otel"),
+                    new AttributeNameValueModel()
+                        .withName("deployment.environment.name")
+                        .withValue("dev"))));
+    return model;
+  }
+
+  private static Map<String, Object> telemetryPolicy(String policyType) {
+    Map<String, Object> mapping = new LinkedHashMap<>();
+    mapping.put("policyId", "sampling-rate");
+    mapping.put("policyType", policyType);
+
+    Map<String, Object> source = new LinkedHashMap<>();
+    source.put("kind", "opamp");
+    source.put("format", "jsonkeyvalue");
+    source.put("location", "elastic");
+    source.put("mappings", Collections.singletonList(mapping));
+
+    Map<String, Object> telemetryPolicy = new LinkedHashMap<>();
+    telemetryPolicy.put("sources", Collections.singletonList(source));
+    return telemetryPolicy;
+  }
+
+  private static Map<String, String> resourceAttributes() {
+    Map<String, String> attributes = new LinkedHashMap<>();
+    attributes.put("service.name", "edot-otel");
+    attributes.put("deployment.environment.name", "dev");
+    return attributes;
+  }
+
+  private static void invokeStaticNoArg(Class<?> targetClass, String methodName) throws Exception {
+    Method method = targetClass.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(null);
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/TelemetryPolicySamplerComponentProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TelemetryPolicySamplerComponentProviderTest {
+
+  @AfterEach
+  void tearDown() throws Exception {
+    invokeStaticNoArg(PolicyInit.class, "resetForTest");
+    invokeStaticNoArg(TraceSamplingRatePolicy.class, "resetForTest");
+  }
+
+  @Test
+  void initializesPolicyFromTopLevelTelemetryPolicyDeclarativeConfig() {
+    TelemetryPolicySamplerComponentProvider provider =
+        new TelemetryPolicySamplerComponentProvider();
+    provider.create(telemetryPolicyNodeConfig());
+
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNotNull();
+  }
+
+  @Test
+  void doesNothingWhenTelemetryPolicyDeclarativeConfigMissing() {
+    TelemetryPolicySamplerComponentProvider provider =
+        new TelemetryPolicySamplerComponentProvider();
+    provider.create(mock(DeclarativeConfigProperties.class));
+
+    assertThat(TraceSamplingRatePolicy.getInitializedSampler()).isNull();
+  }
+
+  private static DeclarativeConfigProperties telemetryPolicyNodeConfig() {
+    DeclarativeConfigProperties telemetryPolicy = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties source = mock(DeclarativeConfigProperties.class);
+    DeclarativeConfigProperties mapping = mock(DeclarativeConfigProperties.class);
+
+    when(telemetryPolicy.getStructuredList("sources"))
+        .thenReturn(Collections.singletonList(source));
+    when(source.getString("kind")).thenReturn("opamp");
+    when(source.getString("format")).thenReturn("jsonkeyvalue");
+    when(source.getString("location")).thenReturn("vendor");
+    when(source.getStructuredList("mappings")).thenReturn(Collections.singletonList(mapping));
+    when(mapping.getString("policyId")).thenReturn("sampling-rate");
+    when(mapping.getString("policyType")).thenReturn(TraceSamplingRatePolicy.POLICY_TYPE);
+
+    return telemetryPolicy;
+  }
+
+  private static void invokeStaticNoArg(Class<?> targetClass, String methodName) throws Exception {
+    Method method = targetClass.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(null);
+  }
+}


### PR DESCRIPTION
NOTE this is the changeset from https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2881 - I tried out getting cursor to merge from main and do a tiny test fix in that PR, but now I can't get easyCLA working for cursor as co-author, so it's easier to just reapply the diff here.

Note that this PR includes all changes suggested by jackberg that I applied, and as he finished reviewing and approved that PR, I won't re-request his review.

**Description:**

Sorry for the change set being a little larger than normal, but I thought it was better to combine all the declarative config support changes together, rather than adding them piecemeal. I think it may be easier to understand the whole than the parts

This contains
- a `DeclarativeConfigurationCustomizerProvider` that reads top-level `telemetry_policy/development` from declarative config and routes it into `PolicyInit`
- a declarative `ComponentProvider` for `telemetry_policy/development` to add the delagating sampler - initially for the rate sampling policy, but will later make more generic (includes a TODO for that)
- Changes to PolicyInit to support the declarative config and also make it a one-shot execution so that a later/repeated/accidental auto-config pass does not accidentally re-use stale declarative config

**Existing Issue(s):**

part of #2868

**Testing:**

Unit tests added, plus a manual end-to-end test using declarative config was performed 

**Documentation:**

TBD see #2868

**Outstanding items:**

see #2868