### PR TITLE
[dynamic control] remove policy equals/hashcode as they are no longer needed

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -32,25 +32,6 @@ public final class DeletedTelemetryPolicy implements TelemetryPolicy {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof DeletedTelemetryPolicy)) {
-      return false;
-    }
-    DeletedTelemetryPolicy that = (DeletedTelemetryPolicy) obj;
-    return identity.equals(that.identity) && getType().equals(that.getType());
-  }
-
-  @Override
-  public int hashCode() {
-    int result = identity.hashCode();
-    result = 31 * result + getType().hashCode();
-    return result;
-  }
-
-  @Override
   public String toString() {
     return "DeletedTelemetryPolicy{identity=" + identity + ", type='" + getType() + "'}";
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -8,9 +8,9 @@ package io.opentelemetry.contrib.dynamic.policy;
 /**
  * Represents a single telemetry policy with spec-required identity and policy type.
  *
- * <p>Policies are immutable data carriers. Concrete implementations must provide value-based {@code
- * equals} and {@code hashCode} implementations because {@link PolicyStore} deduplicates and detects
- * changes using policy equality.
+ * <p>Policies are immutable data carriers. Store-level identity, deletion detection, and
+ * deduplication are based on {@link #getType()} and {@link #getIdentity()}, not on Java object
+ * equality.
  *
  * @see io.opentelemetry.contrib.dynamic.policy
  */

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -9,8 +9,8 @@ package io.opentelemetry.contrib.dynamic.policy;
  * Represents a single telemetry policy with spec-required identity and policy type.
  *
  * <p>Policies are immutable data carriers. Store-level identity, deletion detection, and
- * deduplication are based on {@link #getType()} and {@link #getIdentity()}, not on Java object
- * equality.
+ * deduplication are based on {@link #getType()} and {@code getIdentity().getId()}, not on Java
+ * object equality.
  *
  * @see io.opentelemetry.contrib.dynamic.policy
  */

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -82,7 +82,7 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
     if (Double.isNaN(probability) || probability < 0.0 || probability > 1.0) {
       throw new IllegalArgumentException("probability must be within [0.0, 1.0]");
     }
-    // Normalize -0.0 to +0.0 so equality/hash behavior stays intuitive.
+    // Normalize -0.0 to +0.0 so idempotent update checks stay intuitive.
     return probability == 0.0 ? 0.0 : probability;
   }
 
@@ -93,24 +93,5 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
 
   static void resetForTest() {
     initializedSampler = null;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof TraceSamplingRatePolicy)) {
-      return false;
-    }
-    TraceSamplingRatePolicy that = (TraceSamplingRatePolicy) obj;
-    return Double.compare(probability, that.probability) == 0 && identity.equals(that.identity);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = identity.hashCode();
-    result = 31 * result + Double.hashCode(probability);
-    return result;
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
@@ -27,30 +27,6 @@ class DeletedTelemetryPolicyTest {
     assertThat(new TestTelemetryPolicy("trace-sampling").isDeleted()).isFalse();
   }
 
-  @Test
-  void equalsAndHashCodeUseIdentityAndType() {
-    DeletedTelemetryPolicy first =
-        new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "trace-sampling");
-    DeletedTelemetryPolicy same =
-        new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "trace-sampling");
-    DeletedTelemetryPolicy differentIdentity =
-        new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("other-trace-sampling", "Other trace sampling rate"),
-            "trace-sampling");
-    DeletedTelemetryPolicy differentType =
-        new DeletedTelemetryPolicy(
-            new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate"), "other-policy");
-
-    assertThat(first).isEqualTo(same);
-    assertThat(first.hashCode()).isEqualTo(same.hashCode());
-    assertThat(first).isNotEqualTo(differentIdentity);
-    assertThat(first).isNotEqualTo(differentType);
-    assertThat(first).isNotEqualTo(null);
-    assertThat(first).isNotEqualTo("not-a-policy");
-  }
-
   private static final class TestTelemetryPolicy implements TelemetryPolicy {
     private final TelemetryPolicyIdentity identity;
     private final String type;

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
@@ -150,24 +150,5 @@ class LinePerPolicyFileProviderTest {
     public String getType() {
       return type;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!(obj instanceof TestTelemetryPolicy)) {
-        return false;
-      }
-      TestTelemetryPolicy that = (TestTelemetryPolicy) obj;
-      return identity.equals(that.identity) && type.equals(that.type);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = identity.hashCode();
-      result = 31 * result + type.hashCode();
-      return result;
-    }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
@@ -34,8 +34,7 @@ class TraceSamplingRatePolicyTest {
     assertThat(negativeZero.getProbability()).isEqualTo(0.0);
     assertThat(Double.doubleToRawLongBits(negativeZero.getProbability()))
         .isEqualTo(Double.doubleToRawLongBits(0.0));
-    assertThat(negativeZero).isEqualTo(positiveZero);
-    assertThat(negativeZero.hashCode()).isEqualTo(positiveZero.hashCode());
+    assertThat(positiveZero.getProbability()).isEqualTo(0.0);
   }
 
   @Test
@@ -49,19 +48,6 @@ class TraceSamplingRatePolicyTest {
     assertThatThrownBy(() -> new TraceSamplingRatePolicy(1.001))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("probability must be within [0.0, 1.0]");
-  }
-
-  @Test
-  void equalsAndHashCodeUseProbability() {
-    TraceSamplingRatePolicy a = new TraceSamplingRatePolicy(0.5);
-    TraceSamplingRatePolicy b = new TraceSamplingRatePolicy(0.5);
-    TraceSamplingRatePolicy c = new TraceSamplingRatePolicy(0.75);
-
-    assertThat(a).isEqualTo(b);
-    assertThat(a.hashCode()).isEqualTo(b.hashCode());
-    assertThat(a).isNotEqualTo(c);
-    assertThat(a).isNotEqualTo(null);
-    assertThat(a).isNotEqualTo("not-a-policy");
   }
 
   @Test


### PR DESCRIPTION
**Description:**

#2960 changed how policies are compared, following which they no longer need to adapt equals/hashcode, so those method overrides are being dropped

**Existing Issue(s):**

#2868

**Testing:**

added

**Documentation:**

n/a

**Outstanding items:**

#2868