### PR TITLE
[dynamic control] Add priority ordering to sources

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKind.java
@@ -25,23 +25,25 @@ import javax.annotation.Nullable;
  */
 public enum SourceKind {
   /** Policies loaded from a local file (e.g. line-per-policy file). */
-  FILE("file", SourceKind::createNoProvider),
+  FILE("file", 3, SourceKind::createNoProvider),
 
   /** Policies delivered via OpAMP (remote management). */
-  OPAMP("opamp", SourceKind::createOpampProvider),
+  OPAMP("opamp", 1, SourceKind::createOpampProvider),
 
   /** Policies fetched from an HTTP/HTTPS endpoint. */
-  HTTP("http", SourceKind::createNoProvider),
+  HTTP("http", 2, SourceKind::createNoProvider),
 
   /** User-defined or extension provider. */
-  CUSTOM("custom", SourceKind::createNoProvider);
+  CUSTOM("custom", 1_000, SourceKind::createNoProvider);
 
   private final String configValue;
+  private final int priority;
   private final ProviderCreator providerCreator;
   private static final Logger logger = Logger.getLogger(SourceKind.class.getName());
 
-  SourceKind(String configValue, ProviderCreator providerCreator) {
+  SourceKind(String configValue, int priority, ProviderCreator providerCreator) {
     this.configValue = configValue;
+    this.priority = priority;
     this.providerCreator = providerCreator;
   }
 
@@ -52,6 +54,21 @@ public enum SourceKind {
    */
   public String configValue() {
     return configValue;
+  }
+
+  /**
+   * Returns the priority used to resolve duplicate policy IDs across providers.
+   *
+   * <p>Lower numbers have higher priority, following the policy specification's OpAMP, HTTP, FILE
+   * ordering.
+   */
+  public int priority() {
+    return priority;
+  }
+
+  public boolean hasHigherPriorityThan(SourceKind other) {
+    Objects.requireNonNull(other, "other cannot be null");
+    return priority < other.priority;
   }
 
   /**

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceKindTest.java
@@ -29,6 +29,35 @@ class SourceKindTest {
   }
 
   @Test
+  void prioritiesEncodeProviderPrecedence() {
+    assertThat(SourceKind.OPAMP.priority()).isLessThan(SourceKind.HTTP.priority());
+    assertThat(SourceKind.HTTP.priority()).isLessThan(SourceKind.FILE.priority());
+    assertThat(SourceKind.FILE.priority()).isLessThan(SourceKind.CUSTOM.priority());
+  }
+
+  @Test
+  void hasHigherPriorityThanUsesProviderPrecedence() {
+    assertThat(SourceKind.OPAMP.hasHigherPriorityThan(SourceKind.HTTP)).isTrue();
+    assertThat(SourceKind.OPAMP.hasHigherPriorityThan(SourceKind.FILE)).isTrue();
+    assertThat(SourceKind.OPAMP.hasHigherPriorityThan(SourceKind.CUSTOM)).isTrue();
+    assertThat(SourceKind.HTTP.hasHigherPriorityThan(SourceKind.FILE)).isTrue();
+    assertThat(SourceKind.HTTP.hasHigherPriorityThan(SourceKind.CUSTOM)).isTrue();
+    assertThat(SourceKind.FILE.hasHigherPriorityThan(SourceKind.CUSTOM)).isTrue();
+
+    assertThat(SourceKind.HTTP.hasHigherPriorityThan(SourceKind.OPAMP)).isFalse();
+    assertThat(SourceKind.FILE.hasHigherPriorityThan(SourceKind.HTTP)).isFalse();
+    assertThat(SourceKind.CUSTOM.hasHigherPriorityThan(SourceKind.FILE)).isFalse();
+    assertThat(SourceKind.OPAMP.hasHigherPriorityThan(SourceKind.OPAMP)).isFalse();
+  }
+
+  @Test
+  void hasHigherPriorityThanRejectsNullInput() {
+    assertThatThrownBy(() -> SourceKind.OPAMP.hasHigherPriorityThan(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("other cannot be null");
+  }
+
+  @Test
   void fromConfigValueParsesCaseInsensitive() {
     assertThat(SourceKind.fromConfigValue("FILE")).isEqualTo(SourceKind.FILE);
     assertThat(SourceKind.fromConfigValue("Opamp")).isEqualTo(SourceKind.OPAMP);


### PR DESCRIPTION
**Description:**

The spec requires opamp > http > file priority of policies so if mergeable policies are received by more than one source in an update, the highest priority policy is retained and the others dropped

**Existing Issue(s):**

#2868

**Testing:**

added

**Documentation:**

n/a

**Outstanding items:**

Still to implement

- retaining source in the policies
- dropping lower priority policies in an update when the policies are otherwise mergeable in an update

Also #2868