### PR TITLE
[dynamic control] Add SourceKind to TelemetryPolicy

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -13,7 +13,7 @@ public final class DeletedTelemetryPolicy implements TelemetryPolicy {
   private final String type;
   private final SourceKind sourceKind;
 
-  // TODO after "source" prioritization handling is complete, make non-default
+  // TODO after "source" prioritization handling is complete, remove this constructor
   public DeletedTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
     this(identity, type, SourceKind.CUSTOM);
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicy.java
@@ -5,15 +5,24 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import java.util.Objects;
 
 public final class DeletedTelemetryPolicy implements TelemetryPolicy {
   private final TelemetryPolicyIdentity identity;
   private final String type;
+  private final SourceKind sourceKind;
 
+  // TODO after "source" prioritization handling is complete, make non-default
   public DeletedTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
+    this(identity, type, SourceKind.CUSTOM);
+  }
+
+  public DeletedTelemetryPolicy(
+      TelemetryPolicyIdentity identity, String type, SourceKind sourceKind) {
     this.identity = Objects.requireNonNull(identity, "identity cannot be null");
     this.type = Objects.requireNonNull(type, "type cannot be null");
+    this.sourceKind = Objects.requireNonNull(sourceKind, "sourceKind cannot be null");
   }
 
   @Override
@@ -27,12 +36,23 @@ public final class DeletedTelemetryPolicy implements TelemetryPolicy {
   }
 
   @Override
+  public SourceKind getSourceKind() {
+    return sourceKind;
+  }
+
+  @Override
   public boolean isDeleted() {
     return true;
   }
 
   @Override
   public String toString() {
-    return "DeletedTelemetryPolicy{identity=" + identity + ", type='" + getType() + "'}";
+    return "DeletedTelemetryPolicy{identity="
+        + identity
+        + ", type='"
+        + getType()
+        + "', sourceKind="
+        + sourceKind
+        + "}";
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/TelemetryPolicy.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+
 /**
  * Represents a single telemetry policy with spec-required identity and policy type.
  *
@@ -34,6 +36,17 @@ public interface TelemetryPolicy {
    * @return the non-null policy type
    */
   String getType();
+
+  /**
+   * Returns the provider source kind that supplied this policy.
+   *
+   * <p>The source is used to resolve duplicate policy IDs across providers. Lower-priority sources
+   * are dropped when a higher-priority source supplies the same policy identity.
+   */
+  // TODO after "source" prioritization handling is complete, make non-default
+  default SourceKind getSourceKind() {
+    return SourceKind.CUSTOM;
+  }
 
   /**
    * Returns whether this policy represents a deleted element.

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -9,6 +9,7 @@ import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
@@ -25,10 +26,17 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
 
   private final TelemetryPolicyIdentity identity;
   private final double probability;
+  private final SourceKind sourceKind;
 
+  // TODO after "source" prioritization handling is complete, remove this constructor
   public TraceSamplingRatePolicy(double probability) {
+    this(probability, SourceKind.CUSTOM);
+  }
+
+  public TraceSamplingRatePolicy(double probability, SourceKind sourceKind) {
     this.identity = DEFAULT_IDENTITY;
     this.probability = normalizeProbability(probability);
+    this.sourceKind = Objects.requireNonNull(sourceKind, "sourceKind cannot be null");
   }
 
   @Override
@@ -39,6 +47,11 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
   @Override
   public String getType() {
     return POLICY_TYPE;
+  }
+
+  @Override
+  public SourceKind getSourceKind() {
+    return sourceKind;
   }
 
   public double getProbability() {


### PR DESCRIPTION
**Description:**

The spec requires opamp > http > file priority of policies so if mergeable policies are received by more than one source in an update, the highest priority policy is retained and the others dropped. This adds source to the policies, but unused and untested for now - the "Still to implement" section shows next steps, tests are added when source starts being used

**Existing Issue(s):**

#2868

**Testing:**

not yet

**Documentation:**

n/a

**Outstanding items:**

Still to implement

- retaining source in the policies
  - add source to validators
  - in providers use new source-enabled validators to create new source aware policies
  - drop now unused methods/constructors/defaults which are not source aware
- dropping lower priority policies in an update when the policies are otherwise mergeable in an update, by changing policy aggregation in the PolicyStore

Also #2868