### PR TITLE
[dynamic control] propagate SourceKind across validation and policy creation

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
@@ -9,7 +9,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.KeyValueSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /** Base validator with common source-dispatch and parse helpers. */
@@ -17,42 +19,44 @@ public abstract class AbstractSourcePolicyValidator implements PolicyValidator {
 
   @Override
   @Nullable
-  public final TelemetryPolicy validate(SourceWrapper source) {
+  public final TelemetryPolicy validate(SourceWrapper source, SourceKind sourceKind) {
     if (source == null) {
       return null;
     }
+    Objects.requireNonNull(sourceKind, "sourceKind cannot be null");
     SourceFormat format = source.getFormat();
     switch (format) {
       case JSONKEYVALUE:
-        return validateJsonSource(((JsonSourceWrapper) source).asJsonNode());
+        return validateJsonSource(((JsonSourceWrapper) source).asJsonNode(), sourceKind);
       case KEYVALUE:
-        return validateKeyValueSource((KeyValueSourceWrapper) source);
+        return validateKeyValueSource((KeyValueSourceWrapper) source, sourceKind);
     }
     return null;
   }
 
   @Nullable
-  private TelemetryPolicy validateJsonSource(JsonNode node) {
+  private TelemetryPolicy validateJsonSource(JsonNode node, SourceKind sourceKind) {
     JsonNode valueNode = node.get(getPolicyType());
     if (valueNode == null) {
       return null;
     }
-    return validateJsonValue(valueNode);
+    return validateJsonValue(valueNode, sourceKind);
   }
 
   @Nullable
-  private TelemetryPolicy validateKeyValueSource(KeyValueSourceWrapper source) {
+  private TelemetryPolicy validateKeyValueSource(
+      KeyValueSourceWrapper source, SourceKind sourceKind) {
     if (!getPolicyType().equals(source.getKey().trim())) {
       return null;
     }
-    return validateKeyValueValue(source.getValue());
+    return validateKeyValueValue(source.getValue(), sourceKind);
   }
 
   @Nullable
-  protected abstract TelemetryPolicy validateJsonValue(JsonNode valueNode);
+  protected abstract TelemetryPolicy validateJsonValue(JsonNode valueNode, SourceKind sourceKind);
 
   @Nullable
-  protected abstract TelemetryPolicy validateKeyValueValue(String value);
+  protected abstract TelemetryPolicy validateKeyValueValue(String value, SourceKind sourceKind);
 
   @Nullable
   protected static Double parseDouble(JsonNode valueNode) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.dynamic.policy;
 
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -85,7 +86,7 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
               if (!policyType.equals(validator.getPolicyType())) {
                 continue;
               }
-              policy = validator.validate(parsedSource);
+              policy = validator.validate(parsedSource, SourceKind.FILE);
               break;
             }
             if (policy == null) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -12,6 +12,7 @@ import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceMappingConfi
 import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.KeyValueSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import io.opentelemetry.opamp.client.OpampClient;
 import io.opentelemetry.opamp.client.OpampClientBuilder;
@@ -279,7 +280,7 @@ public final class OpampPolicyProvider implements PolicyProvider {
         if (!mappedPolicyType.equals(validator.getPolicyType())) {
           continue;
         }
-        TelemetryPolicy policy = validator.validate(normalizedSource);
+        TelemetryPolicy policy = validator.validate(normalizedSource, SourceKind.OPAMP);
         if (policy != null) {
           out.add(policy);
           break;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/PolicyValidator.java
@@ -5,19 +5,21 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import javax.annotation.Nullable;
 
 public interface PolicyValidator {
   /**
-   * Validates a parsed policy configuration source.
+   * Validates a parsed policy configuration source from the supplied provider source kind.
    *
    * @param source parsed source wrapper containing the format and payload
+   * @param sourceKind provider source kind that supplied the policy
    * @return The validated {@link TelemetryPolicy}, or {@code null} if the source does not contain a
    *     valid policy for this validator.
    */
   @Nullable
-  TelemetryPolicy validate(SourceWrapper source);
+  TelemetryPolicy validate(SourceWrapper source, SourceKind sourceKind);
 
   /**
    * Returns the type of the policy this validator handles.

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opentelemetry.contrib.dynamic.policy.AbstractSourcePolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -26,7 +27,7 @@ public final class TraceSamplingValidator extends AbstractSourcePolicyValidator 
 
   @Override
   @Nullable
-  protected TelemetryPolicy validateJsonValue(JsonNode valueNode) {
+  protected TelemetryPolicy validateJsonValue(JsonNode valueNode, SourceKind sourceKind) {
     JsonNode probabilityNode = valueNode;
     if (valueNode.isObject()) {
       probabilityNode = valueNode.get("probability");
@@ -38,23 +39,23 @@ public final class TraceSamplingValidator extends AbstractSourcePolicyValidator 
     if (probability == null) {
       return null;
     }
-    return createPolicy(probability);
+    return createPolicy(probability, sourceKind);
   }
 
   @Override
   @Nullable
-  protected TelemetryPolicy validateKeyValueValue(String value) {
+  protected TelemetryPolicy validateKeyValueValue(String value, SourceKind sourceKind) {
     Double probability = parseDouble(value);
     if (probability == null) {
       return null;
     }
-    return createPolicy(probability);
+    return createPolicy(probability, sourceKind);
   }
 
   @Nullable
-  private static TelemetryPolicy createPolicy(double probability) {
+  private static TelemetryPolicy createPolicy(double probability, SourceKind sourceKind) {
     try {
-      return new TraceSamplingRatePolicy(probability);
+      return new TraceSamplingRatePolicy(probability, sourceKind);
     } catch (IllegalArgumentException e) {
       logger.info(
           "Invalid trace-sampling probability '"

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/DeletedTelemetryPolicyTest.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.dynamic.policy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import org.junit.jupiter.api.Test;
 
 class DeletedTelemetryPolicyTest {
@@ -19,7 +20,20 @@ class DeletedTelemetryPolicyTest {
 
     assertThat(policy.getIdentity()).isEqualTo(identity);
     assertThat(policy.getType()).isEqualTo("trace-sampling");
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
     assertThat(policy.isDeleted()).isTrue();
+  }
+
+  @Test
+  void storesExplicitSourceKind() {
+    TelemetryPolicyIdentity identity =
+        new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
+    DeletedTelemetryPolicy policy =
+        new DeletedTelemetryPolicy(identity, "trace-sampling", SourceKind.OPAMP);
+
+    assertThat(policy.getIdentity()).isEqualTo(identity);
+    assertThat(policy.getType()).isEqualTo("trace-sampling");
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
   }
 
   @Test
@@ -30,10 +44,16 @@ class DeletedTelemetryPolicyTest {
   private static final class TestTelemetryPolicy implements TelemetryPolicy {
     private final TelemetryPolicyIdentity identity;
     private final String type;
+    private final SourceKind sourceKind;
 
     private TestTelemetryPolicy(String type) {
+      this(type, SourceKind.CUSTOM);
+    }
+
+    private TestTelemetryPolicy(String type, SourceKind sourceKind) {
       this.identity = new TelemetryPolicyIdentity(type, "Test policy");
       this.type = type;
+      this.sourceKind = sourceKind;
     }
 
     @Override
@@ -44,6 +64,11 @@ class DeletedTelemetryPolicyTest {
     @Override
     public String getType() {
       return type;
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+      return sourceKind;
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
@@ -8,6 +8,7 @@ package io.opentelemetry.contrib.dynamic.policy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import java.io.IOException;
@@ -46,6 +47,7 @@ class LinePerPolicyFileProviderTest {
 
     assertThat(policies).hasSize(1);
     assertThat(policies.get(0).getType()).isEqualTo(TRACE_SAMPLING_TYPE);
+    assertThat(policies.get(0).getSourceKind()).isEqualTo(SourceKind.FILE);
   }
 
   @Test
@@ -58,6 +60,7 @@ class LinePerPolicyFileProviderTest {
 
     assertThat(policies).hasSize(1);
     assertThat(policies.get(0).getType()).isEqualTo(TRACE_SAMPLING_TYPE);
+    assertThat(policies.get(0).getSourceKind()).isEqualTo(SourceKind.FILE);
   }
 
   @Test
@@ -110,35 +113,38 @@ class LinePerPolicyFileProviderTest {
     }
 
     @Override
-    public TelemetryPolicy validate(SourceWrapper source) {
+    public TelemetryPolicy validate(SourceWrapper source, SourceKind sourceKind) {
       if (source.getFormat() == SourceFormat.JSONKEYVALUE) {
         if (!acceptJson) {
           return null;
         }
-        return testPolicy();
+        return testPolicy(sourceKind);
       }
       if (source.getFormat() == SourceFormat.KEYVALUE) {
         if (!acceptKeyValue) {
           return null;
         }
-        return testPolicy();
+        return testPolicy(sourceKind);
       }
       return null;
     }
   }
 
-  private static TelemetryPolicy testPolicy() {
+  private static TelemetryPolicy testPolicy(SourceKind sourceKind) {
     return new TestTelemetryPolicy(
-        new TelemetryPolicyIdentity("test-policy", "Test policy"), TRACE_SAMPLING_TYPE);
+        new TelemetryPolicyIdentity("test-policy", "Test policy"), TRACE_SAMPLING_TYPE, sourceKind);
   }
 
   private static final class TestTelemetryPolicy implements TelemetryPolicy {
     private final TelemetryPolicyIdentity identity;
     private final String type;
+    private final SourceKind sourceKind;
 
-    private TestTelemetryPolicy(TelemetryPolicyIdentity identity, String type) {
+    private TestTelemetryPolicy(
+        TelemetryPolicyIdentity identity, String type, SourceKind sourceKind) {
       this.identity = identity;
       this.type = type;
+      this.sourceKind = sourceKind;
     }
 
     @Override
@@ -149,6 +155,11 @@ class LinePerPolicyFileProviderTest {
     @Override
     public String getType() {
       return type;
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+      return sourceKind;
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/registry/PolicyInitTest.java
@@ -16,6 +16,7 @@ import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
@@ -164,6 +165,15 @@ class PolicyInitTest {
   private static final class IdempotentTestPolicy implements TelemetryPolicy {
     private static final TelemetryPolicyIdentity IDENTITY =
         new TelemetryPolicyIdentity("test-policy-idempotent", "Test policy idempotent");
+    private final SourceKind sourceKind;
+
+    private IdempotentTestPolicy() {
+      this(SourceKind.CUSTOM);
+    }
+
+    private IdempotentTestPolicy(SourceKind sourceKind) {
+      this.sourceKind = sourceKind;
+    }
 
     @Override
     public TelemetryPolicyIdentity getIdentity() {
@@ -173,6 +183,11 @@ class PolicyInitTest {
     @Override
     public String getType() {
       return "test-policy-idempotent";
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+      return sourceKind;
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementerTest.java
@@ -14,6 +14,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.contrib.dynamic.policy.DeletedTelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
 import io.opentelemetry.sdk.trace.samplers.SamplingResult;
@@ -89,10 +90,16 @@ class TraceSamplingRatePolicyImplementerTest {
   private static final class TestTelemetryPolicy implements TelemetryPolicy {
     private final TelemetryPolicyIdentity identity;
     private final String type;
+    private final SourceKind sourceKind;
 
     private TestTelemetryPolicy(String type) {
+      this(type, SourceKind.CUSTOM);
+    }
+
+    private TestTelemetryPolicy(String type, SourceKind sourceKind) {
       this.identity = new TelemetryPolicyIdentity(type, "Test policy");
       this.type = type;
+      this.sourceKind = sourceKind;
     }
 
     @Override
@@ -103,6 +110,11 @@ class TraceSamplingRatePolicyImplementerTest {
     @Override
     public String getType() {
       return type;
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+      return sourceKind;
     }
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,16 @@ class TraceSamplingRatePolicyTest {
     assertThat(policy.getIdentity()).isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
     assertThat(policy.getProbability()).isEqualTo(0.25);
     assertThat(policy.getType()).isEqualTo(TraceSamplingRatePolicy.POLICY_TYPE);
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
+  }
+
+  @Test
+  void constructorStoresExplicitSourceKind() {
+    TraceSamplingRatePolicy policy = new TraceSamplingRatePolicy(0.25, SourceKind.OPAMP);
+
+    assertThat(policy.getIdentity()).isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
+    assertThat(policy.getProbability()).isEqualTo(0.25);
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
   }
 
   @Test

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.within;
 
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -30,20 +31,33 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_ValidJson() {
     String json = jsonForProbability(0.5);
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
     assertThat(((TraceSamplingRatePolicy) policy).getIdentity())
         .isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
     assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.5, within(1e-9));
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
+  }
+
+  @Test
+  void validateStoresExplicitSourceKind() {
+    String json = jsonForProbability(0.5);
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.OPAMP);
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
   }
 
   @ParameterizedTest
   @ValueSource(doubles = {0.0, 1.0})
   void testValidate_ValidJson_BoundaryValues(double probability) {
     String json = jsonForProbability(probability);
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -59,7 +73,8 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_ValidJson_LegacyObjectShapeWithProbabilityField() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": 0.5}}";
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -73,7 +88,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson_LegacyObjectShape_BoundaryValues(double probability) {
     String json =
         "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": " + probability + "}}";
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability())
         .isCloseTo(probability, within(1e-9));
@@ -86,7 +102,8 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_ValidJson_ProbabilityAsQuotedStringInLegacyObject() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": \"0.625\"}}";
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.625, within(1e-9));
   }
@@ -94,7 +111,8 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_ValidJson_ProbabilityAsQuotedStringFlat() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"0.375\"}";
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.375, within(1e-9));
   }
@@ -102,26 +120,30 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_InvalidJson_MissingPolicyType() {
     String json = "{\"other-policy\": 0.5}";
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)))).isNull();
+    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+        .isNull();
   }
 
   @ParameterizedTest
   @ValueSource(doubles = {-0.1, 1.1})
   void testValidate_InvalidJson_ProbabilityOutOfRange(double probability) {
     String json = jsonForProbability(probability);
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)))).isNull();
+    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+        .isNull();
   }
 
   @Test
   void testValidate_InvalidJson_ValueNotNumber() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"high\"}";
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)))).isNull();
+    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+        .isNull();
   }
 
   @Test
   void testValidate_ValidKeyValue() {
     String keyValue = TRACE_SAMPLING_POLICY_TYPE + "=0.5";
-    TelemetryPolicy policy = validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)));
+    TelemetryPolicy policy =
+        validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -132,13 +154,17 @@ class TraceSamplingValidatorTest {
 
   @Test
   void testValidate_InvalidKeyValue_WrongKey() {
-    assertThat(validator.validate(first(SourceFormat.KEYVALUE.parse("other.key=0.5")))).isNull();
+    assertThat(
+            validator.validate(
+                first(SourceFormat.KEYVALUE.parse("other.key=0.5")), SourceKind.CUSTOM))
+        .isNull();
   }
 
   @Test
   void testValidate_InvalidKeyValue_NotNumber() {
     String keyValue = TRACE_SAMPLING_POLICY_TYPE + "=invalid";
-    assertThat(validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)))).isNull();
+    assertThat(validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)), SourceKind.CUSTOM))
+        .isNull();
   }
 
   private static String jsonForProbability(double probability) {


### PR DESCRIPTION
**Description:**

This PR is mainly the addition of a SourceKind parameter to methods, plus additional tests.

The spec requires opamp > http > file priority of policies so if mergeable policies are received by more than one source in an update, the highest priority policy is retained and the others dropped. This PR propagates the source and starts using the source-aware policies. Dropping the policies is implemented in a following PR

**Existing Issue(s):**

#2868

**Testing:**

not yet

**Documentation:**

n/a

**Outstanding items:**

Still to implement

- retaining source in the policies
  - drop now unused methods/constructors/defaults which are not source aware
- dropping lower priority policies in an update when the policies are otherwise mergeable in an update, by changing policy aggregation in the PolicyStore

Also #2868