### PR TITLE
Submit Gradle dependencies to dependency graph

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,31 @@
+name: Dependency submission
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          dependency-graph: generate-and-submit


### PR DESCRIPTION
Submit resolved Gradle dependencies to GitHub’s dependency graph on each push to main, enabling GitHub to detect vulnerabilities in direct and transitive dependencies.

After merging, the next step is to verify that the workflow successfully populates the dependency graph, then check whether Renovate immediately opens an update for Jackson 2.22.1 from the resulting vulnerability alert. If it does not, follow up by configuring security-only Dependabot updates similar to the [semantic-conventions-genai dependency policy](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/DEPENDENCIES.md) and its [Dependabot configuration](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/dependabot.yml).

Related to https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2927 