### PR TITLE
Configure Dependabot for Gradle security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+    # GitHub does not apply cooldown to security updates. Routine Dependabot updates are disabled
+    # by open-pull-requests-limit: 0 below, so this is retained for zizmor compliance and would
+    # apply only if routine updates are re-enabled.
+      default-days: 7
     open-pull-requests-limit: 0
     groups:
       gradle-security:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Cooldown does not apply to security updates; this value satisfies zizmor.
     cooldown:
-      # GitHub does not apply cooldown to security updates. Routine Dependabot updates are disabled
-      # by open-pull-requests-limit: 0 below, so this is retained for zizmor compliance and would
-      # apply only if routine updates are re-enabled.
       default-days: 7
+    # Disable routine update PRs; security update PRs use a separate limit.
     open-pull-requests-limit: 0
     groups:
       gradle-security:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-    # GitHub does not apply cooldown to security updates. Routine Dependabot updates are disabled
-    # by open-pull-requests-limit: 0 below, so this is retained for zizmor compliance and would
-    # apply only if routine updates are re-enabled.
+      # GitHub does not apply cooldown to security updates. Routine Dependabot updates are disabled
+      # by open-pull-requests-limit: 0 below, so this is retained for zizmor compliance and would
+      # apply only if routine updates are re-enabled.
       default-days: 7
     open-pull-requests-limit: 0
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Security updates are owned by Dependabot, while routine dependency updates remain with Renovate.
+# See https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/DEPENDENCIES.md.
+version: 2
+
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      gradle-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
Configure Dependabot to open grouped Gradle security updates while leaving routine dependency updates to Renovate. This follows the [semantic-conventions-genai dependency policy](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/DEPENDENCIES.md) and [Dependabot configuration](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/.github/dependabot.yml), and uses the current Jackson alert as a test of whether Dependabot can remediate an advisory whose GitHub metadata has no `first_patched_version`.

Related to https://github.com/open-telemetry/opentelemetry-java-contrib/issues/2927