### PR TITLE
Add failure issue notifications

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -53,14 +53,13 @@ jobs:
 
   workflow-notification:
     permissions:
-        contents: read
-        issues: write
+      issues: write
     if: always()
     needs:
       - common
       - lint
       - publish-snapshots
-    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@70659e38ed50e743a5cce6fb40ba336c40154aa1 # v0.3.0
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
     with:
       success: >-
         ${{

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,3 +73,13 @@ jobs:
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - analyze
+    if: always() && github.event_name == 'schedule'
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.analyze.result == 'success' }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -29,3 +29,13 @@ jobs:
         uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           dependency-graph: generate-and-submit
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - submit
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.submit.result == 'success' }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,3 +20,13 @@ jobs:
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}
           team: OpenTelemetry
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - fossa
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.fossa.result == 'success' }}

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -65,3 +65,13 @@ jobs:
           stale-pr-message: >
             This PR has been labeled as stale due to lack of activity.
             It will be automatically closed if there is no further activity over the next 14 days.
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - stale
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.stale.result == 'success' }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -46,3 +46,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - analysis
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.analysis.result == 'success' }}

--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -44,11 +44,10 @@ jobs:
 
   workflow-notification:
     permissions:
-      contents: read
       issues: write
     needs:
       - analyze
     if: always()
-    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@70659e38ed50e743a5cce6fb40ba336c40154aa1 # v0.3.0
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
     with:
       success: ${{ needs.analyze.result == 'success' }}


### PR DESCRIPTION
Add failure issue notifications to scheduled workflows and workflows that run only on pushes to `main`, making failures visible to the full team instead of relying on GitHub’s limited scheduled-workflow notifications.