### PR TITLE
Remove the in development notice of the IBM MQ metrics component and move it to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ feature or via instrumentation, this project is hopefully for you.
 | alpha   | [GCP Authentication Extension](./gcp-auth-extension/README.md)    |
 | beta    | [GCP Resources](./gcp-resources/README.md)                        |
 | beta    | [Inferred Spans](./inferred-spans/README.md)                      |
-| alpha   | [IBM MQ Metrics](./ibm-mq-metrics/README.md)                      |
+| beta    | [IBM MQ Metrics](./ibm-mq-metrics/README.md)                      |
 | alpha   | [JFR Connection](./jfr-connection/README.md)                      |
 | alpha   | [JFR Events](./jfr-events/README.md)                              |
 | alpha   | [JMX Metric Gatherer](./jmx-metrics/README.md)                    |

--- a/ibm-mq-metrics/README.md
+++ b/ibm-mq-metrics/README.md
@@ -2,8 +2,6 @@
 
 [![Maven](https://img.shields.io/maven-central/v/io.opentelemetry.contrib/opentelemetry-ibm-mq-metrics?label=Maven&color=orange)](https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-ibm-mq-metrics)
 
-:warning: This software is under development.
-
 ## Use case
 
 IBM MQ, formerly known as WebSphere MQ (message queue) series, is an IBM software for


### PR DESCRIPTION
This removes the warning displayed in the README saying the component is in development. It also updates the stability of IBM MQ from alpha to beta.
