### PR TITLE
Exclude test configurations from dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -29,6 +29,7 @@ jobs:
         uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           dependency-graph: generate-and-submit
+          dependency-graph-exclude-configurations: ".*[Tt]est(Compile|Runtime)Classpath"
 
   workflow-notification:
     permissions:


### PR DESCRIPTION
Exclude Gradle test compile and runtime classpaths from dependency submission so Dependabot alerts focus on production dependencies. Test-only dependencies will no longer be covered by GitHub alerts.

Enabling Dependabot security update PRs will be handled separately through Terraform in `open-telemetry/admin`.