### PR TITLE
Pin japicmp baseline with apidiff snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           ./gradlew japicmp -PapiBaseVersion=$PRIOR_VERSION -PapiNewVersion=$VERSION
+          # Pin the apidiff baseline to the just-released version.
+          sed -i "s/^val apidiffBaselineVersion = .*/val apidiffBaselineVersion = \"$VERSION\"/" version.gradle.kts
           ./gradlew --refresh-dependencies japicmp
 
       - name: Use CLA approved bot
@@ -290,6 +292,7 @@ jobs:
           git checkout -b $branch
           git add CHANGELOG.md
           git add docs/apidiffs
+          git add version.gradle.kts
           git commit -m "$message"
           git push --set-upstream origin $branch
           gh pr create --title "$message" \

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -12,21 +12,11 @@ plugins {
 }
 
 /**
- * The latest *released* version of the project. Evaluated lazily so the work is only done if necessary.
+ * The baseline version japicmp compares against. Pinned in version.gradle.kts and bumped
+ * atomically with docs/apidiffs/current_vs_latest/ by the post-release PR opened from
+ * .github/workflows/release.yml.
  */
-val latestReleasedVersion: String by lazy {
-  // hack to find the current released version of the project
-  val temp: Configuration = configurations.create("tempConfig") {
-    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
-    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
-  }
-  // pick aws-xray, since it's a stable module that's always there.
-  dependencies.add(temp.name, "io.opentelemetry.contrib:opentelemetry-aws-xray:latest.release")
-  val moduleVersion = configurations["tempConfig"].resolvedConfiguration.firstLevelModuleDependencies.elementAt(0).moduleVersion
-  configurations.remove(temp)
-  logger.debug("Discovered latest release version: " + moduleVersion)
-  moduleVersion
-}
+val apidiffBaselineVersion = rootProject.extra["apidiffBaselineVersion"] as String
 
 class AllowNewAbstractMethodOnAutovalueClasses : AbstractRecordingSeenMembers() {
   override fun maybeAddViolation(member: JApiCompatibility): Violation? {
@@ -97,9 +87,9 @@ if (project.findProperty("otel.stable") == "true" && !project.name.startsWith("b
         // only output changes, not everything
         onlyModified.set(true)
 
-        // the japicmp "old" version is either the user-specified one, or the latest release.
+        // the japicmp "old" version is either the user-specified one, or the pinned baseline.
         val apiBaseVersion: String? by project
-        val baselineVersion = apiBaseVersion ?: latestReleasedVersion
+        val baselineVersion = apiBaseVersion ?: apidiffBaselineVersion
         oldClasspath.from(
           try {
             files(findArtifact(baselineVersion))

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,6 @@
 val stableVersion = "1.59.0-SNAPSHOT"
 val alphaVersion = "1.59.0-alpha-SNAPSHOT"
+val apidiffBaselineVersion = "1.58.0"
 val tagVersion by extra { "v$stableVersion" }
 
 allprojects {
@@ -8,4 +9,5 @@ allprojects {
   } else {
     version = stableVersion
   }
+  extra["apidiffBaselineVersion"] = apidiffBaselineVersion
 }


### PR DESCRIPTION
Pin the API diff baseline in `version.gradle.kts` and update it together with the API diff files after each release. This prevents a new release from breaking API diff checks on open PRs.

Port of open-telemetry/opentelemetry-java-instrumentation#18391.