### PR TITLE
Submit only runtime dependencies to dependency graph

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -29,7 +29,7 @@ jobs:
         uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           dependency-graph: generate-and-submit
-          dependency-graph-exclude-configurations: ".*[Tt]est(Compile|Runtime)Classpath"
+          dependency-graph-include-configurations: "runtimeClasspath"
 
   workflow-notification:
     permissions:


### PR DESCRIPTION
Restrict Gradle dependency submission to each project's production `runtimeClasspath`. This keeps shipped runtime dependencies in GitHub's dependency graph while excluding compile-only, test, annotation-processor, and other build-time configurations that can produce non-runtime Dependabot alerts.