### PR TITLE
Add ID token support to gcp-auth-extension

### DIFF
--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -72,6 +72,41 @@ Here is a list of required and optional configuration available for the extensio
 
   * Can also be configured using `google.otel.auth.target.signals` system property.
 
+* `GOOGLE_OTEL_AUTH_TOKEN_TYPE`: Environment variable that specifies the type
+  of token that the extension attaches to the exported telemetry.
+  Valid values are `access_token` and `id_token`:
+
+  * `access_token` (default): OAuth 2.0 access token retrieved from the
+    Application Default Credentials. Use this to export telemetry to Google
+    Cloud APIs, for example `telemetry.googleapis.com`.
+  * `id_token`: Google-signed OpenID Connect ID token minted from the
+    Application Default Credentials for the configured audience. Use this to
+    export telemetry to OTLP endpoints protected by Google IAM-based
+    authentication - for example, an OpenTelemetry Collector running on
+    [Cloud Run](https://cloud.google.com/run/docs/authenticating/service-to-service)
+    or behind [Identity-Aware Proxy](https://cloud.google.com/iap/docs/authentication-howto).
+    The Application Default Credentials must be able to mint ID tokens. This
+    is the case for service account based credentials - for example, the
+    default service account of a GCP compute environment, a service account
+    key, or impersonated credentials. When `id_token` is used, the
+    `GOOGLE_CLOUD_PROJECT` option is not required and the `gcp.project_id`
+    resource attribute is not added.
+
+  The value names are consistent with the `token_type` option of the
+  [Google Client Auth Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension)
+  for the OpenTelemetry Collector.
+
+  * Can also be configured using `google.otel.auth.token.type` system property.
+
+* `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE`: Environment variable that specifies
+  the audience used when minting Google-signed ID tokens. Required when
+  `GOOGLE_OTEL_AUTH_TOKEN_TYPE` is set to `id_token`, ignored otherwise.
+  For Cloud Run, this is the URL of the receiving service or one of its
+  [custom audiences](https://cloud.google.com/run/docs/configuring/custom-audiences).
+  For Identity-Aware Proxy, this is the OAuth 2.0 client ID.
+
+  * Can also be configured using `google.otel.auth.id.token.audience` system property.
+
 ## Usage
 
 ### With OpenTelemetry Java agent

--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -72,7 +72,7 @@ Here is a list of required and optional configuration available for the extensio
 
   * Can also be configured using `google.otel.auth.target.signals` system property.
 
-* `GOOGLE_OTEL_AUTH_TOKEN_TYPE`: Environment variable that specifies the type
+* `GOOGLE_AUTH_TOKEN_TYPE`: Environment variable that specifies the type
   of token that the extension attaches to the exported telemetry.
   Valid values are `access_token` and `id_token`:
 
@@ -91,20 +91,20 @@ Here is a list of required and optional configuration available for the extensio
     key, or impersonated credentials. When `id_token` is used, the
     `GOOGLE_CLOUD_PROJECT` option is not required and the `gcp.project_id`
     resource attribute is not added.
-  * Can also be configured using `google.otel.auth.token.type` system property.
+  * Can also be configured using `google.auth.token.type` system property.
 
   The value names are consistent with the `token_type` option of the
   [Google Client Auth Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension)
   for the OpenTelemetry Collector.
 
-* `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE`: Environment variable that specifies
+* `GOOGLE_AUTH_ID_TOKEN_AUDIENCE`: Environment variable that specifies
   the audience used when minting Google-signed ID tokens. Required when
-  `GOOGLE_OTEL_AUTH_TOKEN_TYPE` is set to `id_token`, ignored otherwise.
+  `GOOGLE_AUTH_TOKEN_TYPE` is set to `id_token`, ignored otherwise.
   For Cloud Run, this is the URL of the receiving service or one of its
   [custom audiences](https://cloud.google.com/run/docs/configuring/custom-audiences).
   For Identity-Aware Proxy, this is the OAuth 2.0 client ID.
 
-  * Can also be configured using `google.otel.auth.id.token.audience` system property.
+  * Can also be configured using `google.auth.id.token.audience` system property.
 
 ## Usage
 

--- a/gcp-auth-extension/README.md
+++ b/gcp-auth-extension/README.md
@@ -91,12 +91,11 @@ Here is a list of required and optional configuration available for the extensio
     key, or impersonated credentials. When `id_token` is used, the
     `GOOGLE_CLOUD_PROJECT` option is not required and the `gcp.project_id`
     resource attribute is not added.
+  * Can also be configured using `google.otel.auth.token.type` system property.
 
   The value names are consistent with the `token_type` option of the
   [Google Client Auth Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension)
   for the OpenTelemetry Collector.
-
-  * Can also be configured using `google.otel.auth.token.type` system property.
 
 * `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE`: Environment variable that specifies
   the audience used when minting Google-signed ID tokens. Required when

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -54,7 +54,42 @@ enum ConfigurableOption {
    * configured using the environment variable `GOOGLE_OTEL_AUTH_TARGET_SIGNALS` or the system
    * property `google.otel.auth.target.signals`.
    */
-  GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Authentication Extension");
+  GOOGLE_OTEL_AUTH_TARGET_SIGNALS("Target Signals for Google Authentication Extension"),
+
+  /**
+   * Specifies the type of token that the extension attaches to the exported telemetry. Can be
+   * configured using the environment variable `GOOGLE_OTEL_AUTH_TOKEN_TYPE` or the system property
+   * `google.otel.auth.token.type`.
+   *
+   * <p>Valid values are:
+   *
+   * <ul>
+   *   <li>{@code access_token} (default) - OAuth 2.0 access token retrieved from the Application
+   *       Default Credentials. Required for exporting to Google Cloud APIs, for example {@code
+   *       telemetry.googleapis.com}.
+   *   <li>{@code id_token} - Google-signed OpenID Connect ID token minted from the Application
+   *       Default Credentials for the audience configured via {@link
+   *       #GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE}. Required for exporting to OTLP endpoints protected
+   *       by IAM-based authentication, for example an OpenTelemetry Collector running on Cloud Run
+   *       or behind Identity-Aware Proxy.
+   * </ul>
+   *
+   * <p>The value names are consistent with the {@code token_type} option of the <a
+   * href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension">Google
+   * Client Auth Extension for the OpenTelemetry Collector</a>.
+   */
+  GOOGLE_OTEL_AUTH_TOKEN_TYPE("Token Type for Google Authentication Extension"),
+
+  /**
+   * The audience used when minting Google-signed ID tokens. Required when {@link
+   * #GOOGLE_OTEL_AUTH_TOKEN_TYPE} is set to {@code id_token}, ignored otherwise. Can be configured
+   * using the environment variable `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE` or the system property
+   * `google.otel.auth.id.token.audience`.
+   *
+   * <p>For Cloud Run, this is the URL of the receiving service or one of its configured custom
+   * audiences. For Identity-Aware Proxy, this is the OAuth 2.0 client ID.
+   */
+  GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE("Google ID Token Audience");
 
   private final String userReadableName;
   private final String environmentVariableName;

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/ConfigurableOption.java
@@ -58,8 +58,8 @@ enum ConfigurableOption {
 
   /**
    * Specifies the type of token that the extension attaches to the exported telemetry. Can be
-   * configured using the environment variable `GOOGLE_OTEL_AUTH_TOKEN_TYPE` or the system property
-   * `google.otel.auth.token.type`.
+   * configured using the environment variable `GOOGLE_AUTH_TOKEN_TYPE` or the system property
+   * `google.auth.token.type`.
    *
    * <p>Valid values are:
    *
@@ -69,27 +69,27 @@ enum ConfigurableOption {
    *       telemetry.googleapis.com}.
    *   <li>{@code id_token} - Google-signed OpenID Connect ID token minted from the Application
    *       Default Credentials for the audience configured via {@link
-   *       #GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE}. Required for exporting to OTLP endpoints protected
-   *       by IAM-based authentication, for example an OpenTelemetry Collector running on Cloud Run
-   *       or behind Identity-Aware Proxy.
+   *       #GOOGLE_AUTH_ID_TOKEN_AUDIENCE}. Required for exporting to OTLP endpoints protected by
+   *       IAM-based authentication, for example an OpenTelemetry Collector running on Cloud Run or
+   *       behind Identity-Aware Proxy.
    * </ul>
    *
    * <p>The value names are consistent with the {@code token_type} option of the <a
    * href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension">Google
    * Client Auth Extension for the OpenTelemetry Collector</a>.
    */
-  GOOGLE_OTEL_AUTH_TOKEN_TYPE("Token Type for Google Authentication Extension"),
+  GOOGLE_AUTH_TOKEN_TYPE("Token Type for Google Authentication Extension"),
 
   /**
    * The audience used when minting Google-signed ID tokens. Required when {@link
-   * #GOOGLE_OTEL_AUTH_TOKEN_TYPE} is set to {@code id_token}, ignored otherwise. Can be configured
-   * using the environment variable `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE` or the system property
-   * `google.otel.auth.id.token.audience`.
+   * #GOOGLE_AUTH_TOKEN_TYPE} is set to {@code id_token}, ignored otherwise. Can be configured using
+   * the environment variable `GOOGLE_AUTH_ID_TOKEN_AUDIENCE` or the system property
+   * `google.auth.id.token.audience`.
    *
    * <p>For Cloud Run, this is the URL of the receiving service or one of its configured custom
    * audiences. For Identity-Aware Proxy, this is the OAuth 2.0 client ID.
    */
-  GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE("Google ID Token Audience");
+  GOOGLE_AUTH_ID_TOKEN_AUDIENCE("Google ID Token Audience");
 
   private final String userReadableName;
   private final String environmentVariableName;

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -127,7 +127,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   /**
-   * Lazily initializes and caches the {@link GoogleCredentials} used for authentication. The type
+   * Lazily initializes and caches the {@link OAuth2Credentials} used for authentication. The type
    * of the credentials is determined by the configured {@link
    * ConfigurableOption#GOOGLE_OTEL_AUTH_TOKEN_TYPE}.
    */

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -12,6 +12,9 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdTokenCredentials;
+import com.google.auth.oauth2.IdTokenProvider;
+import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.contrib.gcp.auth.GoogleAuthException.Reason;
@@ -35,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -75,6 +77,9 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   static final String SIGNAL_TYPE_ALL = "all";
   static final String SIGNAL_TYPE_NONE = "none";
 
+  static final String TOKEN_TYPE_ACCESS_TOKEN = "access_token";
+  static final String TOKEN_TYPE_ID_TOKEN = "id_token";
+
   /**
    * Customizes the provided {@link AutoConfigurationCustomizer} such that authenticated exports to
    * GCP Telemetry API are possible from the configured OTLP exporter.
@@ -103,22 +108,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    */
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
-    Supplier<GoogleCredentials> credentialsSupplier =
-        new Supplier<GoogleCredentials>() {
-          @Nullable private GoogleCredentials credentials;
-
-          @Override
-          public synchronized GoogleCredentials get() {
-            if (credentials == null) {
-              try {
-                credentials = GoogleCredentials.getApplicationDefault();
-              } catch (IOException e) {
-                throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-              }
-            }
-            return credentials;
-          }
-        };
+    LazyCredentialsSupplier credentialsSupplier = new LazyCredentialsSupplier();
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
@@ -136,12 +126,78 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     return Integer.MAX_VALUE - 1;
   }
 
+  /**
+   * Lazily initializes and caches the {@link GoogleCredentials} used for authentication. The type
+   * of the credentials is determined by the configured {@link
+   * ConfigurableOption#GOOGLE_OTEL_AUTH_TOKEN_TYPE}.
+   */
+  private static class LazyCredentialsSupplier {
+    @Nullable private OAuth2Credentials credentials;
+
+    synchronized OAuth2Credentials get(ConfigProperties configProperties) {
+      if (credentials == null) {
+        credentials = createCredentials(configProperties);
+      }
+      return credentials;
+    }
+  }
+
+  // Creates the credentials used for authentication based on the configured token type. For the
+  // default token type (access_token) the Application Default Credentials are used as-is. For
+  // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
+  // Google-signed ID tokens for the configured audience.
+  private static OAuth2Credentials createCredentials(ConfigProperties configProperties) {
+    GoogleCredentials applicationDefaultCredentials;
+    try {
+      applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+    }
+    if (!isIdTokenType(configProperties)) {
+      return applicationDefaultCredentials;
+    }
+    String audience =
+        ConfigurableOption.GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(configProperties);
+    if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
+      throw new ConfigurationException(
+          String.format(
+              "GCP Authentication Extension not configured properly: the retrieved Application Default Credentials (%s) cannot mint ID tokens. Use a credential type implementing IdTokenProvider - for example the default service account of a GCP compute environment, a service account key, or impersonated credentials (gcloud auth application-default login --impersonate-service-account=<SERVICE_ACCOUNT>).",
+              applicationDefaultCredentials.getClass().getSimpleName()));
+    }
+    return IdTokenCredentials.newBuilder()
+        .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
+        .setTargetAudience(audience)
+        .build();
+  }
+
+  // Checks whether the extension is configured to attach ID tokens instead of access tokens.
+  private static boolean isIdTokenType(ConfigProperties configProperties) {
+    String tokenType =
+        ConfigurableOption.GOOGLE_OTEL_AUTH_TOKEN_TYPE.getConfiguredValueWithFallback(
+            configProperties, () -> TOKEN_TYPE_ACCESS_TOKEN);
+    switch (tokenType) {
+      case TOKEN_TYPE_ID_TOKEN:
+        return true;
+      case TOKEN_TYPE_ACCESS_TOKEN:
+        return false;
+      default:
+        throw new ConfigurationException(
+            String.format(
+                "GCP Authentication Extension not configured properly: %s has unsupported value '%s'. Supported values are '%s' (default) and '%s'.",
+                ConfigurableOption.GOOGLE_OTEL_AUTH_TOKEN_TYPE.getUserReadableName(),
+                tokenType,
+                TOKEN_TYPE_ACCESS_TOKEN,
+                TOKEN_TYPE_ID_TOKEN));
+    }
+  }
+
   private static SpanExporter customizeSpanExporter(
       SpanExporter exporter,
-      Supplier<GoogleCredentials> credentialsSupplier,
+      LazyCredentialsSupplier credentialsSupplier,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
+      return addAuthorizationHeaders(
+          exporter, credentialsSupplier.get(configProperties), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -156,10 +212,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static MetricExporter customizeMetricExporter(
       MetricExporter exporter,
-      Supplier<GoogleCredentials> credentialsSupplier,
+      LazyCredentialsSupplier credentialsSupplier,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
+      return addAuthorizationHeaders(
+          exporter, credentialsSupplier.get(configProperties), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -188,7 +245,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Adds authorization headers to the calls made by the OtlpGrpcSpanExporter and
   // OtlpHttpSpanExporter.
   private static SpanExporter addAuthorizationHeaders(
-      SpanExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
+      SpanExporter exporter, OAuth2Credentials credentials, ConfigProperties configProperties) {
     if (exporter instanceof OtlpHttpSpanExporter) {
       OtlpHttpSpanExporterBuilder builder =
           ((OtlpHttpSpanExporter) exporter)
@@ -206,7 +263,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Adds authorization headers to the calls made by the OtlpGrpcMetricExporter and
   // OtlpHttpMetricExporter.
   private static MetricExporter addAuthorizationHeaders(
-      MetricExporter exporter, GoogleCredentials credentials, ConfigProperties configProperties) {
+      MetricExporter exporter, OAuth2Credentials credentials, ConfigProperties configProperties) {
     if (exporter instanceof OtlpHttpMetricExporter) {
       OtlpHttpMetricExporterBuilder builder =
           ((OtlpHttpMetricExporter) exporter)
@@ -222,7 +279,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   }
 
   private static Map<String, String> getRequiredHeaderMap(
-      GoogleCredentials credentials, ConfigProperties configProperties) {
+      OAuth2Credentials credentials, ConfigProperties configProperties) {
     Map<String, List<String>> gcpHeaders;
     try {
       // this also refreshes the credentials, if required
@@ -241,8 +298,10 @@ public class GcpAuthAutoConfigurationCustomizerProvider
                             .filter(s -> !s.isEmpty()) // Filter empty strings
                             .collect(joining(","))));
     // Add quota user project header if not detected by the auth library and user provided it via
-    // system properties.
-    if (!flattenedHeaders.containsKey(QUOTA_USER_PROJECT_HEADER)) {
+    // system properties. The quota project concept only applies to requests against Google Cloud
+    // APIs authenticated with access tokens, so it is skipped when ID tokens are used.
+    if (!isIdTokenType(configProperties)
+        && !flattenedHeaders.containsKey(QUOTA_USER_PROJECT_HEADER)) {
       Optional<String> maybeConfiguredQuotaProjectId =
           ConfigurableOption.GOOGLE_CLOUD_QUOTA_PROJECT.getConfiguredValueAsOptional(
               configProperties);
@@ -256,17 +315,25 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Updates the current resource with the attributes required for ingesting OTLP data on GCP.
   private static Resource customizeResource(
       Resource resource,
-      Supplier<GoogleCredentials> credentialsSupplier,
+      LazyCredentialsSupplier credentialsSupplier,
       ConfigProperties configProperties) {
     if (!isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)
         && !isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
+      return resource;
+    }
+    // The gcp.project_id resource attribute is only required when ingesting telemetry to the GCP
+    // Telemetry API with access tokens. It is not required for ID token authenticated exports,
+    // which target arbitrary IAM-protected OTLP endpoints.
+    if (isIdTokenType(configProperties)) {
       return resource;
     }
     String gcpProjectId;
     try {
       gcpProjectId = ConfigurableOption.GOOGLE_CLOUD_PROJECT.getConfiguredValue(configProperties);
     } catch (ConfigurationException e) {
-      gcpProjectId = credentialsSupplier.get().getProjectId();
+      // This line is only reachable for the access_token type, for which the supplier always
+      // returns the GoogleCredentials retrieved as Application Default Credentials.
+      gcpProjectId = ((GoogleCredentials) credentialsSupplier.get(configProperties)).getProjectId();
       if (gcpProjectId == null || gcpProjectId.isEmpty()) {
         throw e;
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -147,17 +147,25 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
   // Google-signed ID tokens for the configured audience.
   private static OAuth2Credentials createCredentials(ConfigProperties configProperties) {
+    // Resolve and validate the configuration before any IO, so a misconfiguration (unsupported
+    // token type or missing audience) is reported deterministically instead of being masked by an
+    // Application Default Credentials retrieval failure.
+    boolean useIdToken = isIdTokenType(configProperties);
+    String audience =
+        useIdToken
+            ? ConfigurableOption.GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(
+                configProperties)
+            : null;
+
     GoogleCredentials applicationDefaultCredentials;
     try {
       applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
     } catch (IOException e) {
       throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
     }
-    if (!isIdTokenType(configProperties)) {
+    if (!useIdToken) {
       return applicationDefaultCredentials;
     }
-    String audience =
-        ConfigurableOption.GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(configProperties);
     if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
       throw new ConfigurationException(
           String.format(

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -39,8 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -111,32 +109,17 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    */
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
-    AtomicReference<LazyCredentialsSupplier> supplierRef = new AtomicReference<>();
+    LazyOAuth2CredentialsHolder credentialsHolder = new LazyOAuth2CredentialsHolder();
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
-                customizeSpanExporter(
-                    spanExporter,
-                    getOrCreateSupplier(supplierRef, configProperties),
-                    configProperties))
+                customizeSpanExporter(spanExporter, credentialsHolder, configProperties))
         .addMetricExporterCustomizer(
             (metricExporter, configProperties) ->
-                customizeMetricExporter(
-                    metricExporter,
-                    getOrCreateSupplier(supplierRef, configProperties),
-                    configProperties))
+                customizeMetricExporter(metricExporter, credentialsHolder, configProperties))
         .addResourceCustomizer(
             (resource, configProperties) ->
-                customizeResource(
-                    resource,
-                    getOrCreateSupplier(supplierRef, configProperties),
-                    configProperties));
-  }
-
-  private static LazyCredentialsSupplier getOrCreateSupplier(
-      AtomicReference<LazyCredentialsSupplier> ref, ConfigProperties configProperties) {
-    return ref.updateAndGet(
-        existing -> existing != null ? existing : new LazyCredentialsSupplier(configProperties));
+                customizeResource(resource, credentialsHolder, configProperties));
   }
 
   @Override
@@ -149,18 +132,12 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    * of the credentials is determined by the configured {@link
    * ConfigurableOption#GOOGLE_AUTH_TOKEN_TYPE}.
    */
-  private static class LazyCredentialsSupplier implements Supplier<OAuth2Credentials> {
-    private final ConfigProperties configProperties;
+  private static class LazyOAuth2CredentialsHolder {
     @Nullable private OAuth2Credentials credentials;
 
-    LazyCredentialsSupplier(ConfigProperties configProperties) {
-      this.configProperties = configProperties;
-    }
-
-    @Override
-    public synchronized OAuth2Credentials get() {
+    synchronized OAuth2Credentials get(ConfigProperties configProperties) {
       if (credentials == null) {
-        credentials = createCredentials();
+        credentials = createCredentials(configProperties);
       }
       return credentials;
     }
@@ -169,7 +146,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     // default token type (access_token) the Application Default Credentials are used as-is. For
     // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
     // Google-signed ID tokens for the configured audience.
-    private OAuth2Credentials createCredentials() {
+    private static OAuth2Credentials createCredentials(ConfigProperties configProperties) {
       GoogleCredentials applicationDefaultCredentials;
       try {
         applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
@@ -229,10 +206,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static SpanExporter customizeSpanExporter(
       SpanExporter exporter,
-      Supplier<OAuth2Credentials> credentialsSupplier,
+      LazyOAuth2CredentialsHolder credentialsHolder,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
+      return addAuthorizationHeaders(
+          exporter, credentialsHolder.get(configProperties), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -247,10 +225,11 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static MetricExporter customizeMetricExporter(
       MetricExporter exporter,
-      Supplier<OAuth2Credentials> credentialsSupplier,
+      LazyOAuth2CredentialsHolder credentialsHolder,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
-      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
+      return addAuthorizationHeaders(
+          exporter, credentialsHolder.get(configProperties), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -349,7 +328,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Updates the current resource with the attributes required for ingesting OTLP data on GCP.
   private static Resource customizeResource(
       Resource resource,
-      Supplier<OAuth2Credentials> credentialsSupplier,
+      LazyOAuth2CredentialsHolder credentialsHolder,
       ConfigProperties configProperties) {
     if (!isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)
         && !isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
@@ -365,9 +344,9 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     try {
       gcpProjectId = ConfigurableOption.GOOGLE_CLOUD_PROJECT.getConfiguredValue(configProperties);
     } catch (ConfigurationException e) {
-      // This line is only reachable for the access_token type, for which the supplier always
+      // This line is only reachable for the access_token type, for which the holder always
       // returns the GoogleCredentials retrieved as Application Default Credentials.
-      gcpProjectId = ((GoogleCredentials) credentialsSupplier.get()).getProjectId();
+      gcpProjectId = ((GoogleCredentials) credentialsHolder.get(configProperties)).getProjectId();
       if (gcpProjectId == null || gcpProjectId.isEmpty()) {
         throw e;
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -148,29 +148,38 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
   // Google-signed ID tokens for the configured audience.
   private static OAuth2Credentials createCredentials(ConfigProperties configProperties) {
-    // Resolve and validate the configuration before any IO, so a misconfiguration (unsupported
-    // token type or missing audience) is reported deterministically instead of being masked by an
-    // Application Default Credentials retrieval failure.
-    boolean useIdToken = isIdTokenType(configProperties);
-    String audience =
-        useIdToken
-            ? ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(configProperties)
-            : null;
-
     GoogleCredentials applicationDefaultCredentials;
     try {
       applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
     } catch (IOException e) {
       throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
     }
-    if (!useIdToken) {
+
+    if (!isIdTokenType(configProperties)) {
+      return applicationDefaultCredentials;
+    }
+
+    String audience =
+        ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValueWithFallback(
+            configProperties, () -> "");
+    if (audience.isEmpty()) {
+      String[] params = {
+        ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getEnvironmentVariable(),
+        TOKEN_TYPE_ID_TOKEN,
+        ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getEnvironmentVariable()
+      };
+      logger.log(
+          Level.WARNING,
+          "{0} is set to {1} but {2} is not set; falling back to access tokens.",
+          params);
       return applicationDefaultCredentials;
     }
     if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
-      throw new ConfigurationException(
-          String.format(
-              "GCP Authentication Extension not configured properly: the retrieved Application Default Credentials (%s) cannot mint ID tokens. Use a credential type implementing IdTokenProvider - for example the default service account of a GCP compute environment, a service account key, or impersonated credentials (gcloud auth application-default login --impersonate-service-account=<SERVICE_ACCOUNT>).",
-              applicationDefaultCredentials.getClass().getSimpleName()));
+      logger.log(
+          Level.WARNING,
+          "The retrieved Application Default Credentials ({0}) cannot mint ID tokens; falling back to access tokens. Use a credential type implementing IdTokenProvider, for example the default service account of a GCP compute environment, a service account key, or impersonated credentials.",
+          applicationDefaultCredentials.getClass().getSimpleName());
+      return applicationDefaultCredentials;
     }
     return IdTokenCredentials.newBuilder()
         .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
@@ -184,20 +193,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     String tokenType =
         ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getConfiguredValueWithFallback(
             configProperties, () -> TOKEN_TYPE_ACCESS_TOKEN);
-    switch (tokenType) {
-      case TOKEN_TYPE_ID_TOKEN:
-        return true;
-      case TOKEN_TYPE_ACCESS_TOKEN:
-        return false;
-      default:
-        throw new ConfigurationException(
-            String.format(
-                "GCP Authentication Extension not configured properly: %s has unsupported value '%s'. Supported values are '%s' (default) and '%s'.",
-                ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getUserReadableName(),
-                tokenType,
-                TOKEN_TYPE_ACCESS_TOKEN,
-                TOKEN_TYPE_ID_TOKEN));
-    }
+    return TOKEN_TYPE_ID_TOKEN.equals(tokenType);
   }
 
   private static SpanExporter customizeSpanExporter(

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.contrib.gcp.auth;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -174,6 +175,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     return IdTokenCredentials.newBuilder()
         .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
         .setTargetAudience(audience)
+        .setOptions(singletonList(IdTokenProvider.Option.INCLUDE_EMAIL))
         .build();
   }
 

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -200,10 +200,15 @@ public class GcpAuthAutoConfigurationCustomizerProvider
         return applicationDefaultCredentials;
       }
       if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
+        String[] params = {
+          ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getEnvironmentVariable(),
+          TOKEN_TYPE_ID_TOKEN,
+          applicationDefaultCredentials.getClass().getSimpleName()
+        };
         logger.log(
             Level.WARNING,
-            "The retrieved Application Default Credentials ({0}) cannot mint ID tokens; falling back to access tokens. Use a credential type implementing IdTokenProvider, for example the default service account of a GCP compute environment, a service account key, or impersonated credentials.",
-            applicationDefaultCredentials.getClass().getSimpleName());
+            "{0} is set to {1} but the retrieved Application Default Credentials ({2}) cannot mint ID tokens; falling back to access tokens. Use a credential type implementing IdTokenProvider, for example the default service account of a GCP compute environment, a service account key, or impersonated credentials.",
+            params);
         return applicationDefaultCredentials;
       }
       return IdTokenCredentials.newBuilder()

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -109,17 +111,32 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    */
   @Override
   public void customize(@Nonnull AutoConfigurationCustomizer autoConfiguration) {
-    LazyCredentialsSupplier credentialsSupplier = new LazyCredentialsSupplier();
+    AtomicReference<LazyCredentialsSupplier> supplierRef = new AtomicReference<>();
     autoConfiguration
         .addSpanExporterCustomizer(
             (spanExporter, configProperties) ->
-                customizeSpanExporter(spanExporter, credentialsSupplier, configProperties))
+                customizeSpanExporter(
+                    spanExporter,
+                    getOrCreateSupplier(supplierRef, configProperties),
+                    configProperties))
         .addMetricExporterCustomizer(
             (metricExporter, configProperties) ->
-                customizeMetricExporter(metricExporter, credentialsSupplier, configProperties))
+                customizeMetricExporter(
+                    metricExporter,
+                    getOrCreateSupplier(supplierRef, configProperties),
+                    configProperties))
         .addResourceCustomizer(
             (resource, configProperties) ->
-                customizeResource(resource, credentialsSupplier, configProperties));
+                customizeResource(
+                    resource,
+                    getOrCreateSupplier(supplierRef, configProperties),
+                    configProperties));
+  }
+
+  private static LazyCredentialsSupplier getOrCreateSupplier(
+      AtomicReference<LazyCredentialsSupplier> ref, ConfigProperties configProperties) {
+    return ref.updateAndGet(
+        existing -> existing != null ? existing : new LazyCredentialsSupplier(configProperties));
   }
 
   @Override
@@ -132,60 +149,66 @@ public class GcpAuthAutoConfigurationCustomizerProvider
    * of the credentials is determined by the configured {@link
    * ConfigurableOption#GOOGLE_AUTH_TOKEN_TYPE}.
    */
-  private static class LazyCredentialsSupplier {
+  private static class LazyCredentialsSupplier implements Supplier<OAuth2Credentials> {
+    private final ConfigProperties configProperties;
     @Nullable private OAuth2Credentials credentials;
 
-    synchronized OAuth2Credentials get(ConfigProperties configProperties) {
+    LazyCredentialsSupplier(ConfigProperties configProperties) {
+      this.configProperties = configProperties;
+    }
+
+    @Override
+    public synchronized OAuth2Credentials get() {
       if (credentials == null) {
-        credentials = createCredentials(configProperties);
+        credentials = createCredentials();
       }
       return credentials;
     }
-  }
 
-  // Creates the credentials used for authentication based on the configured token type. For the
-  // default token type (access_token) the Application Default Credentials are used as-is. For
-  // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
-  // Google-signed ID tokens for the configured audience.
-  private static OAuth2Credentials createCredentials(ConfigProperties configProperties) {
-    GoogleCredentials applicationDefaultCredentials;
-    try {
-      applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
-    } catch (IOException e) {
-      throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
-    }
+    // Creates the credentials used for authentication based on the configured token type. For the
+    // default token type (access_token) the Application Default Credentials are used as-is. For
+    // id_token, the Application Default Credentials are wrapped into IdTokenCredentials which mint
+    // Google-signed ID tokens for the configured audience.
+    private OAuth2Credentials createCredentials() {
+      GoogleCredentials applicationDefaultCredentials;
+      try {
+        applicationDefaultCredentials = GoogleCredentials.getApplicationDefault();
+      } catch (IOException e) {
+        throw new GoogleAuthException(Reason.FAILED_ADC_RETRIEVAL, e);
+      }
 
-    if (!isIdTokenType(configProperties)) {
-      return applicationDefaultCredentials;
-    }
+      if (!isIdTokenType(configProperties)) {
+        return applicationDefaultCredentials;
+      }
 
-    String audience =
-        ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValueWithFallback(
-            configProperties, () -> "");
-    if (audience.isEmpty()) {
-      String[] params = {
-        ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getEnvironmentVariable(),
-        TOKEN_TYPE_ID_TOKEN,
-        ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getEnvironmentVariable()
-      };
-      logger.log(
-          Level.WARNING,
-          "{0} is set to {1} but {2} is not set; falling back to access tokens.",
-          params);
-      return applicationDefaultCredentials;
+      String audience =
+          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValueWithFallback(
+              configProperties, () -> "");
+      if (audience.isEmpty()) {
+        String[] params = {
+          ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getEnvironmentVariable(),
+          TOKEN_TYPE_ID_TOKEN,
+          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getEnvironmentVariable()
+        };
+        logger.log(
+            Level.WARNING,
+            "{0} is set to {1} but {2} is not set; falling back to access tokens.",
+            params);
+        return applicationDefaultCredentials;
+      }
+      if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
+        logger.log(
+            Level.WARNING,
+            "The retrieved Application Default Credentials ({0}) cannot mint ID tokens; falling back to access tokens. Use a credential type implementing IdTokenProvider, for example the default service account of a GCP compute environment, a service account key, or impersonated credentials.",
+            applicationDefaultCredentials.getClass().getSimpleName());
+        return applicationDefaultCredentials;
+      }
+      return IdTokenCredentials.newBuilder()
+          .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
+          .setTargetAudience(audience)
+          .setOptions(singletonList(IdTokenProvider.Option.INCLUDE_EMAIL))
+          .build();
     }
-    if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
-      logger.log(
-          Level.WARNING,
-          "The retrieved Application Default Credentials ({0}) cannot mint ID tokens; falling back to access tokens. Use a credential type implementing IdTokenProvider, for example the default service account of a GCP compute environment, a service account key, or impersonated credentials.",
-          applicationDefaultCredentials.getClass().getSimpleName());
-      return applicationDefaultCredentials;
-    }
-    return IdTokenCredentials.newBuilder()
-        .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
-        .setTargetAudience(audience)
-        .setOptions(singletonList(IdTokenProvider.Option.INCLUDE_EMAIL))
-        .build();
   }
 
   // Checks whether the extension is configured to attach ID tokens instead of access tokens.
@@ -198,11 +221,10 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static SpanExporter customizeSpanExporter(
       SpanExporter exporter,
-      LazyCredentialsSupplier credentialsSupplier,
+      Supplier<OAuth2Credentials> credentialsSupplier,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)) {
-      return addAuthorizationHeaders(
-          exporter, credentialsSupplier.get(configProperties), configProperties);
+      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_TRACES, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -217,11 +239,10 @@ public class GcpAuthAutoConfigurationCustomizerProvider
 
   private static MetricExporter customizeMetricExporter(
       MetricExporter exporter,
-      LazyCredentialsSupplier credentialsSupplier,
+      Supplier<OAuth2Credentials> credentialsSupplier,
       ConfigProperties configProperties) {
     if (isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
-      return addAuthorizationHeaders(
-          exporter, credentialsSupplier.get(configProperties), configProperties);
+      return addAuthorizationHeaders(exporter, credentialsSupplier.get(), configProperties);
     } else {
       String[] params = {
         SIGNAL_TYPE_METRICS, SIGNAL_TYPE_NONE, SIGNAL_TARGET_WARNING_FIX_SUGGESTION
@@ -320,7 +341,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Updates the current resource with the attributes required for ingesting OTLP data on GCP.
   private static Resource customizeResource(
       Resource resource,
-      LazyCredentialsSupplier credentialsSupplier,
+      Supplier<OAuth2Credentials> credentialsSupplier,
       ConfigProperties configProperties) {
     if (!isSignalTargeted(SIGNAL_TYPE_TRACES, configProperties)
         && !isSignalTargeted(SIGNAL_TYPE_METRICS, configProperties)) {
@@ -338,7 +359,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     } catch (ConfigurationException e) {
       // This line is only reachable for the access_token type, for which the supplier always
       // returns the GoogleCredentials retrieved as Application Default Credentials.
-      gcpProjectId = ((GoogleCredentials) credentialsSupplier.get(configProperties)).getProjectId();
+      gcpProjectId = ((GoogleCredentials) credentialsSupplier.get()).getProjectId();
       if (gcpProjectId == null || gcpProjectId.isEmpty()) {
         throw e;
       }

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -129,7 +129,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   /**
    * Lazily initializes and caches the {@link OAuth2Credentials} used for authentication. The type
    * of the credentials is determined by the configured {@link
-   * ConfigurableOption#GOOGLE_OTEL_AUTH_TOKEN_TYPE}.
+   * ConfigurableOption#GOOGLE_AUTH_TOKEN_TYPE}.
    */
   private static class LazyCredentialsSupplier {
     @Nullable private OAuth2Credentials credentials;
@@ -153,8 +153,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
     boolean useIdToken = isIdTokenType(configProperties);
     String audience =
         useIdToken
-            ? ConfigurableOption.GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(
-                configProperties)
+            ? ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getConfiguredValue(configProperties)
             : null;
 
     GoogleCredentials applicationDefaultCredentials;
@@ -181,7 +180,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
   // Checks whether the extension is configured to attach ID tokens instead of access tokens.
   private static boolean isIdTokenType(ConfigProperties configProperties) {
     String tokenType =
-        ConfigurableOption.GOOGLE_OTEL_AUTH_TOKEN_TYPE.getConfiguredValueWithFallback(
+        ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getConfiguredValueWithFallback(
             configProperties, () -> TOKEN_TYPE_ACCESS_TOKEN);
     switch (tokenType) {
       case TOKEN_TYPE_ID_TOKEN:
@@ -192,7 +191,7 @@ public class GcpAuthAutoConfigurationCustomizerProvider
         throw new ConfigurationException(
             String.format(
                 "GCP Authentication Extension not configured properly: %s has unsupported value '%s'. Supported values are '%s' (default) and '%s'.",
-                ConfigurableOption.GOOGLE_OTEL_AUTH_TOKEN_TYPE.getUserReadableName(),
+                ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getUserReadableName(),
                 tokenType,
                 TOKEN_TYPE_ACCESS_TOKEN,
                 TOKEN_TYPE_ID_TOKEN));

--- a/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
+++ b/gcp-auth-extension/src/main/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProvider.java
@@ -188,11 +188,14 @@ public class GcpAuthAutoConfigurationCustomizerProvider
         String[] params = {
           ConfigurableOption.GOOGLE_AUTH_TOKEN_TYPE.getEnvironmentVariable(),
           TOKEN_TYPE_ID_TOKEN,
-          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getEnvironmentVariable()
+          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getUserReadableName(),
+          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getEnvironmentVariable(),
+          ConfigurableOption.GOOGLE_AUTH_ID_TOKEN_AUDIENCE.getSystemProperty()
         };
         logger.log(
             Level.WARNING,
-            "{0} is set to {1} but {2} is not set; falling back to access tokens.",
+            "{0} is set to {1} but {2} is not configured; falling back to access tokens."
+                + " Configure it by exporting environment variable {3} or system property {4}.",
             params);
         return applicationDefaultCredentials;
       }

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -1218,7 +1218,6 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           .setHeaders(traceHeaderSupplierCaptor.capture());
       Map<String, String> headers = traceHeaderSupplierCaptor.getValue().get();
       assertThat(headers)
-          .hasSize(1)
           .containsEntry("Authorization", "Bearer " + fakeIdToken)
           .doesNotContainKey(QUOTA_USER_PROJECT_HEADER);
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -17,7 +17,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdToken;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.common.AttributeKey;
@@ -52,10 +54,12 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -75,6 +79,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -1167,6 +1172,152 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
   // Mockito.lenient is used here because this method is used with parameterized tests where based
   @SuppressWarnings("CannotMockMethod")
+  @Test
+  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
+  @SetSystemProperty(
+      key = "google.otel.auth.id.token.audience",
+      value = "https://otelcol.example.com")
+  @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
+  void testTraceCustomizerOtlpHttpWithIdToken() throws IOException {
+    String fakeIdToken = craftFakeIdToken();
+    ComputeEngineCredentials mockComputeEngineCredentials =
+        Mockito.mock(ComputeEngineCredentials.class);
+    Mockito.when(
+            mockComputeEngineCredentials.idTokenWithAudience(
+                Mockito.eq("https://otelcol.example.com"), Mockito.any()))
+        .thenReturn(IdToken.create(fakeIdToken));
+
+    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
+    OtlpHttpSpanExporterBuilder spyOtlpHttpSpanExporterBuilder =
+        Mockito.spy(OtlpHttpSpanExporter.builder());
+    when(spyOtlpHttpSpanExporterBuilder.build()).thenReturn(mockOtlpHttpSpanExporter);
+    when(mockOtlpHttpSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    List<SpanData> exportedSpans = new ArrayList<>();
+    when(mockOtlpHttpSpanExporter.export(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              exportedSpans.addAll(invocationOnMock.getArgument(0));
+              return CompletableResultCode.ofSuccess();
+            });
+    Mockito.when(mockOtlpHttpSpanExporter.toBuilder()).thenReturn(spyOtlpHttpSpanExporterBuilder);
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockComputeEngineCredentials);
+
+      OpenTelemetrySdk sdk = buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter);
+      generateTestSpan(sdk);
+      CompletableResultCode code = sdk.shutdown();
+      CompletableResultCode joinResult = code.join(10, TimeUnit.SECONDS);
+      assertThat(joinResult.isSuccess()).isTrue();
+
+      Mockito.verify(mockOtlpHttpSpanExporter, Mockito.times(1)).toBuilder();
+      Mockito.verify(spyOtlpHttpSpanExporterBuilder, Mockito.times(1))
+          .setHeaders(traceHeaderSupplierCaptor.capture());
+      Map<String, String> headers = traceHeaderSupplierCaptor.getValue().get();
+      assertThat(headers)
+          .hasSize(1)
+          .containsEntry("Authorization", "Bearer " + fakeIdToken)
+          .doesNotContainKey(QUOTA_USER_PROJECT_HEADER);
+
+      Mockito.verify(mockOtlpHttpSpanExporter, Mockito.atLeast(1)).export(Mockito.anyCollection());
+
+      // The gcp.project_id resource attribute is not added in id_token mode and the
+      // GOOGLE_CLOUD_PROJECT option is not required.
+      assertThat(exportedSpans)
+          .hasSizeGreaterThan(0)
+          .allSatisfy(
+              spanData ->
+                  assertThat(spanData.getResource().getAttributes().asMap())
+                      .doesNotContainKey(AttributeKey.stringKey(GCP_USER_PROJECT_ID_KEY)));
+    }
+  }
+
+  @Test
+  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
+  @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
+  @ClearSystemProperty(key = "google.otel.auth.id.token.audience")
+  void testIdTokenWithoutAudienceThrows() {
+    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
+    Mockito.lenient()
+        .when(mockOtlpHttpSpanExporter.shutdown())
+        .thenReturn(CompletableResultCode.ofSuccess());
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockedGoogleCredentials);
+
+      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
+          .isInstanceOf(ConfigurationException.class)
+          .hasMessageContaining("GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE");
+    }
+  }
+
+  @Test
+  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
+  @SetSystemProperty(
+      key = "google.otel.auth.id.token.audience",
+      value = "https://otelcol.example.com")
+  @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
+  void testIdTokenWithNonIdTokenProviderCredentialsThrows() {
+    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
+    Mockito.lenient()
+        .when(mockOtlpHttpSpanExporter.shutdown())
+        .thenReturn(CompletableResultCode.ofSuccess());
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      // The mocked GoogleCredentials does not implement IdTokenProvider
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockedGoogleCredentials);
+
+      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
+          .isInstanceOf(ConfigurationException.class)
+          .hasMessageContaining("cannot mint ID tokens");
+    }
+  }
+
+  @Test
+  @SetSystemProperty(key = "google.otel.auth.token.type", value = "unsupported_token")
+  @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
+  void testUnsupportedTokenTypeThrows() {
+    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
+    Mockito.lenient()
+        .when(mockOtlpHttpSpanExporter.shutdown())
+        .thenReturn(CompletableResultCode.ofSuccess());
+
+    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      googleCredentialsMockedStatic
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mockedGoogleCredentials);
+
+      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
+          .isInstanceOf(ConfigurationException.class)
+          .hasMessageContaining("unsupported value");
+    }
+  }
+
+  // Crafts a syntactically valid, unsigned JWT with a far-future expiration so that it can be
+  // parsed by IdToken.create().
+  private static String craftFakeIdToken() {
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+    String header =
+        encoder.encodeToString(
+            "{\"alg\":\"RS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+    String payload =
+        encoder.encodeToString(
+            "{\"aud\":\"https://otelcol.example.com\",\"exp\":4102444800,\"iat\":1700000000}"
+                .getBytes(StandardCharsets.UTF_8));
+    String signature = encoder.encodeToString("signature".getBytes(StandardCharsets.UTF_8));
+    return header + "." + payload + "." + signature;
+  }
+
   private void prepareMockBehaviorForGoogleCredentials() {
     AccessToken fakeAccessToken = new AccessToken("fake", Date.from(Instant.now()));
     try {

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -1238,55 +1238,43 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   @ClearSystemProperty(key = "google.auth.id.token.audience")
-  void testIdTokenWithoutAudienceThrows() {
-    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
-    Mockito.lenient()
-        .when(mockOtlpHttpSpanExporter.shutdown())
-        .thenReturn(CompletableResultCode.ofSuccess());
-
-    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-        Mockito.mockStatic(GoogleCredentials.class)) {
-      googleCredentialsMockedStatic
-          .when(GoogleCredentials::getApplicationDefault)
-          .thenReturn(mockedGoogleCredentials);
-
-      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
-          .isInstanceOf(ConfigurationException.class)
-          .hasMessageContaining("GOOGLE_AUTH_ID_TOKEN_AUDIENCE");
-    }
+  void testIdTokenWithoutAudienceFallsBackToAccessToken() throws IOException {
+    assertConfiguredCredentialsFallBackToAccessToken();
   }
 
   @Test
   @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
   @SetSystemProperty(key = "google.auth.id.token.audience", value = "https://otelcol.example.com")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
-  void testIdTokenWithNonIdTokenProviderCredentialsThrows() {
-    OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
-    Mockito.lenient()
-        .when(mockOtlpHttpSpanExporter.shutdown())
-        .thenReturn(CompletableResultCode.ofSuccess());
-
-    try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
-        Mockito.mockStatic(GoogleCredentials.class)) {
-      // The mocked GoogleCredentials does not implement IdTokenProvider
-      googleCredentialsMockedStatic
-          .when(GoogleCredentials::getApplicationDefault)
-          .thenReturn(mockedGoogleCredentials);
-
-      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
-          .isInstanceOf(ConfigurationException.class)
-          .hasMessageContaining("cannot mint ID tokens");
-    }
+  void testIdTokenWithNonIdTokenProviderCredentialsFallsBackToAccessToken() throws IOException {
+    // The mocked GoogleCredentials does not implement IdTokenProvider.
+    assertConfiguredCredentialsFallBackToAccessToken();
   }
 
   @Test
   @SetSystemProperty(key = "google.auth.token.type", value = "unsupported_token")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
-  void testUnsupportedTokenTypeThrows() {
+  @SetSystemProperty(key = "google.cloud.project", value = "test-gcp-project")
+  void testUnsupportedTokenTypeFallsBackToAccessToken() throws IOException {
+    assertConfiguredCredentialsFallBackToAccessToken();
+  }
+
+  @SuppressWarnings("CannotMockMethod")
+  private void assertConfiguredCredentialsFallBackToAccessToken() throws IOException {
+    AccessToken fakeAccessToken = new AccessToken("fake-access-token", Date.from(Instant.now()));
+    Mockito.when(mockedGoogleCredentials.getRequestMetadata())
+        .thenReturn(
+            ImmutableMap.of(
+                "Authorization",
+                Collections.singletonList("Bearer " + fakeAccessToken.getTokenValue())));
+
     OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
-    Mockito.lenient()
-        .when(mockOtlpHttpSpanExporter.shutdown())
-        .thenReturn(CompletableResultCode.ofSuccess());
+    OtlpHttpSpanExporterBuilder spyOtlpHttpSpanExporterBuilder =
+        Mockito.spy(OtlpHttpSpanExporter.builder());
+    when(spyOtlpHttpSpanExporterBuilder.build()).thenReturn(mockOtlpHttpSpanExporter);
+    when(mockOtlpHttpSpanExporter.shutdown()).thenReturn(CompletableResultCode.ofSuccess());
+    when(mockOtlpHttpSpanExporter.export(any())).thenReturn(CompletableResultCode.ofSuccess());
+    Mockito.when(mockOtlpHttpSpanExporter.toBuilder()).thenReturn(spyOtlpHttpSpanExporterBuilder);
 
     try (MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
         Mockito.mockStatic(GoogleCredentials.class)) {
@@ -1294,9 +1282,15 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
           .when(GoogleCredentials::getApplicationDefault)
           .thenReturn(mockedGoogleCredentials);
 
-      assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
-          .isInstanceOf(ConfigurationException.class)
-          .hasMessageContaining("unsupported value");
+      OpenTelemetrySdk sdk = buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter);
+      generateTestSpan(sdk);
+      CompletableResultCode joinResult = sdk.shutdown().join(10, TimeUnit.SECONDS);
+      assertThat(joinResult.isSuccess()).isTrue();
+
+      Mockito.verify(spyOtlpHttpSpanExporterBuilder, Mockito.times(1))
+          .setHeaders(traceHeaderSupplierCaptor.capture());
+      Map<String, String> headers = traceHeaderSupplierCaptor.getValue().get();
+      assertThat(headers).containsEntry("Authorization", "Bearer fake-access-token");
     }
   }
 

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -1171,7 +1171,6 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
     }
   }
 
-  // Mockito.lenient is used here because this method is used with parameterized tests where based
   @SuppressWarnings("CannotMockMethod")
   @Test
   @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
@@ -1239,7 +1238,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   @ClearSystemProperty(key = "google.auth.id.token.audience")
   void testIdTokenWithoutAudienceFallsBackToAccessToken() throws IOException {
-    assertConfiguredCredentialsFallBackToAccessToken();
+    assertConfiguredCredentialsForTraceFallbackToAccessToken();
   }
 
   @Test
@@ -1248,7 +1247,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   void testIdTokenWithNonIdTokenProviderCredentialsFallsBackToAccessToken() throws IOException {
     // The mocked GoogleCredentials does not implement IdTokenProvider.
-    assertConfiguredCredentialsFallBackToAccessToken();
+    assertConfiguredCredentialsForTraceFallbackToAccessToken();
   }
 
   @Test
@@ -1256,11 +1255,12 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   @SetSystemProperty(key = "google.cloud.project", value = "test-gcp-project")
   void testUnsupportedTokenTypeFallsBackToAccessToken() throws IOException {
-    assertConfiguredCredentialsFallBackToAccessToken();
+    assertConfiguredCredentialsForTraceFallbackToAccessToken();
   }
 
+  // Asserts a misconfigured id_token setup falls back to access tokens on the trace exporter.
   @SuppressWarnings("CannotMockMethod")
-  private void assertConfiguredCredentialsFallBackToAccessToken() throws IOException {
+  private void assertConfiguredCredentialsForTraceFallbackToAccessToken() throws IOException {
     AccessToken fakeAccessToken = new AccessToken("fake-access-token", Date.from(Instant.now()));
     Mockito.when(mockedGoogleCredentials.getRequestMetadata())
         .thenReturn(
@@ -1309,6 +1309,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
     return header + "." + payload + "." + signature;
   }
 
+  // Mockito.lenient is used here because this method is used with parameterized tests where based
   private void prepareMockBehaviorForGoogleCredentials() {
     AccessToken fakeAccessToken = new AccessToken("fake", Date.from(Instant.now()));
     try {

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -1173,10 +1173,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   // Mockito.lenient is used here because this method is used with parameterized tests where based
   @SuppressWarnings("CannotMockMethod")
   @Test
-  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
-  @SetSystemProperty(
-      key = "google.otel.auth.id.token.audience",
-      value = "https://otelcol.example.com")
+  @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
+  @SetSystemProperty(key = "google.auth.id.token.audience", value = "https://otelcol.example.com")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   void testTraceCustomizerOtlpHttpWithIdToken() throws IOException {
     String fakeIdToken = craftFakeIdToken();
@@ -1235,9 +1233,9 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   }
 
   @Test
-  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
+  @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
-  @ClearSystemProperty(key = "google.otel.auth.id.token.audience")
+  @ClearSystemProperty(key = "google.auth.id.token.audience")
   void testIdTokenWithoutAudienceThrows() {
     OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
     Mockito.lenient()
@@ -1252,15 +1250,13 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
 
       assertThatThrownBy(() -> buildOpenTelemetrySdkWithExporter(mockOtlpHttpSpanExporter))
           .isInstanceOf(ConfigurationException.class)
-          .hasMessageContaining("GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE");
+          .hasMessageContaining("GOOGLE_AUTH_ID_TOKEN_AUDIENCE");
     }
   }
 
   @Test
-  @SetSystemProperty(key = "google.otel.auth.token.type", value = "id_token")
-  @SetSystemProperty(
-      key = "google.otel.auth.id.token.audience",
-      value = "https://otelcol.example.com")
+  @SetSystemProperty(key = "google.auth.token.type", value = "id_token")
+  @SetSystemProperty(key = "google.auth.id.token.audience", value = "https://otelcol.example.com")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   void testIdTokenWithNonIdTokenProviderCredentialsThrows() {
     OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);
@@ -1282,7 +1278,7 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
   }
 
   @Test
-  @SetSystemProperty(key = "google.otel.auth.token.type", value = "unsupported_token")
+  @SetSystemProperty(key = "google.auth.token.type", value = "unsupported_token")
   @SetSystemProperty(key = "google.otel.auth.target.signals", value = "traces")
   void testUnsupportedTokenTypeThrows() {
     OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);

--- a/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
+++ b/gcp-auth-extension/src/test/java/io/opentelemetry/contrib/gcp/auth/GcpAuthAutoConfigurationCustomizerProviderTest.java
@@ -20,6 +20,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdToken;
+import com.google.auth.oauth2.IdTokenProvider;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import io.opentelemetry.api.common.AttributeKey;
@@ -1182,7 +1183,8 @@ class GcpAuthAutoConfigurationCustomizerProviderTest {
         Mockito.mock(ComputeEngineCredentials.class);
     Mockito.when(
             mockComputeEngineCredentials.idTokenWithAudience(
-                Mockito.eq("https://otelcol.example.com"), Mockito.any()))
+                Mockito.eq("https://otelcol.example.com"),
+                Mockito.argThat(options -> options.contains(IdTokenProvider.Option.INCLUDE_EMAIL))))
         .thenReturn(IdToken.create(fakeIdToken));
 
     OtlpHttpSpanExporter mockOtlpHttpSpanExporter = mock(OtlpHttpSpanExporter.class);


### PR DESCRIPTION
**Description:**

Feature addition. `gcp-auth-extension` currently attaches an OAuth 2.0 access token from ADC, which works for Google Cloud endpoints like `telemetry.googleapis.com` but not for OTLP endpoints protected by Google IAM (e.g. a Collector running on Cloud Run, or behind IAP), which require a Google-signed OIDC ID token with a matching `aud`.

This adds two config options:

- `GOOGLE_OTEL_AUTH_TOKEN_TYPE`: `access_token` (default) or `id_token`
- `GOOGLE_OTEL_AUTH_ID_TOKEN_AUDIENCE`: audience for the ID token, required when `id_token`

For `id_token`, the extension wraps ADC in `IdTokenCredentials` for the given audience, and skips the quota-project header and the `gcp.project_id` resource attribute (both specific to the GCP APIs). Default behavior is unchanged, so this is backward compatible. This mirrors the `token_type: id_token` option of the Collector's `googleclientauthextension`.

**Existing Issue(s):**

#2996 

**Testing:**

- Added unit tests covering the `id_token` path (audience present, HTTP/gRPC exporters, missing-audience and non-IdTokenProvider credential errors, unsupported token type).
- Existing tests pass unchanged, confirming backward compatibility.
- Also tested end-to-end against a Collector on Cloud Run over both HTTP and gRPC, including token refresh across the ~1h ID token expiry.

**Documentation:**

- Updated the module README with the two new options and when to use `id_token` (Cloud Run / IAP), including the audience semantics.
