### PR TITLE
Stabilize SamplingProfilerTest

### DIFF
--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
@@ -183,6 +183,9 @@ class SamplingProfilerTest {
           .until(() -> setup.profiler.getProfilingSessions() > currentSession);
       profilingActiveOnThread = setup.profiler.isProfilingActiveOnThread(Thread.currentThread());
       aInferred(tracer);
+      await()
+          .timeout(Duration.ofSeconds(10))
+          .until(() -> setup.profiler.getProfilingSessions() > currentSession + 1);
     } finally {
       tx.end();
     }

--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
@@ -182,10 +182,11 @@ class SamplingProfilerTest {
           .timeout(Duration.ofSeconds(10))
           .until(() -> setup.profiler.getProfilingSessions() > currentSession);
       profilingActiveOnThread = setup.profiler.isProfilingActiveOnThread(Thread.currentThread());
+      int sessionBeforeInferred = setup.profiler.getProfilingSessions();
       aInferred(tracer);
       await()
           .timeout(Duration.ofSeconds(10))
-          .until(() -> setup.profiler.getProfilingSessions() > currentSession + 1);
+          .until(() -> setup.profiler.getProfilingSessions() > sessionBeforeInferred);
     } finally {
       tx.end();
     }

--- a/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
+++ b/inferred-spans/src/test/java/io/opentelemetry/contrib/inferredspans/internal/SamplingProfilerTest.java
@@ -182,11 +182,13 @@ class SamplingProfilerTest {
           .timeout(Duration.ofSeconds(10))
           .until(() -> setup.profiler.getProfilingSessions() > currentSession);
       profilingActiveOnThread = setup.profiler.isProfilingActiveOnThread(Thread.currentThread());
-      int sessionBeforeInferred = setup.profiler.getProfilingSessions();
       aInferred(tracer);
+      // Capture the baseline after inferred work has completed. A session may start while
+      // aInferred() runs, so capturing it before the call could let the wait pass too early.
+      int sessionAfterInferred = setup.profiler.getProfilingSessions();
       await()
           .timeout(Duration.ofSeconds(10))
-          .until(() -> setup.profiler.getProfilingSessions() > sessionBeforeInferred);
+          .until(() -> setup.profiler.getProfilingSessions() > sessionAfterInferred);
     } finally {
       tx.end();
     }


### PR DESCRIPTION
## Summary
- wait for the next profiling session after `aInferred(tracer)` in `SamplingProfilerTest.testProfileTransaction()`
- keep the test assertions unchanged while removing the race between transaction work and session rollover

## Why
`SamplingProfilerTest.testProfileTransaction()` can observe the inferred work before the profiler has advanced into the next session, which makes the test flaky.

Waiting for the next session keeps the existing behavior under test but avoids asserting too early.

## Testing
- `GRADLE_USER_HOME=/tmp/gradle-home-otel-java-contrib ./gradlew --no-build-cache --no-configuration-cache :inferred-spans:test --tests io.opentelemetry.contrib.inferredspans.internal.SamplingProfilerTest`
