### PR TITLE
[dynamic control] fix incorrectly special case parsing

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
  *
  * <p>Empty lines and lines starting with <code>#</code> are ignored.
  */
+// TODO this needs changing to a full provider implementation or deleting
 final class LinePerPolicyFileProvider implements PolicyProvider {
   private static final Logger logger = Logger.getLogger(LinePerPolicyFileProvider.class.getName());
   private final Path file;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -12,8 +12,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -37,11 +40,17 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
   private static final Logger logger = Logger.getLogger(LinePerPolicyFileProvider.class.getName());
   private final Path file;
   private final List<PolicyValidator> validators;
+  private final Set<String> policyIds;
 
   public LinePerPolicyFileProvider(Path file, List<PolicyValidator> validators) {
     Objects.requireNonNull(file, "file cannot be null");
     this.file = file;
     this.validators = new ArrayList<>(validators);
+    Set<String> policyIds = new LinkedHashSet<>();
+    for (PolicyValidator validator : validators) {
+      policyIds.add(validator.getPolicyType());
+    }
+    this.policyIds = Collections.unmodifiableSet(policyIds);
   }
 
   @Override
@@ -69,7 +78,7 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
               logger.info("Unsupported policy line format: " + trimmedLine);
               return;
             }
-            List<SourceWrapper> parsedSources = format.parse(trimmedLine);
+            List<SourceWrapper> parsedSources = format.parse(trimmedLine, policyIds);
             if (parsedSources == null || parsedSources.size() != 1) {
               logger.info("Invalid " + format.configValue() + " policy line: " + trimmedLine);
               return;

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
+import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
@@ -80,7 +81,10 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
               return;
             }
             List<SourceWrapper> parsedSources = format.parse(trimmedLine, policyIds);
-            if (parsedSources == null || parsedSources.size() != 1) {
+            if (parsedSources == null
+                || parsedSources.size() != 1
+                || (format == SourceFormat.JSONKEYVALUE
+                    && !JsonSourceWrapper.isSingleKeyObject(trimmedLine))) {
               logger.info("Invalid " + format.configValue() + " policy line: " + trimmedLine);
               return;
             }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/OpampPolicyProvider.java
@@ -5,11 +5,7 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceMappingConfig;
-import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
@@ -29,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -54,7 +49,6 @@ import opamp.proto.ServerErrorResponse;
  */
 public final class OpampPolicyProvider extends AbstractPolicyProvider {
   private static final Logger logger = Logger.getLogger(OpampPolicyProvider.class.getName());
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final String OPAMP_ENDPOINT = "otel.opamp.service.url";
   private static final String OPAMP_HEADERS = "otel.experimental.opamp.headers";
@@ -240,10 +234,8 @@ public final class OpampPolicyProvider extends AbstractPolicyProvider {
 
   private void parsePolicyText(String key, String policyText, List<TelemetryPolicy> out) {
     logger.info("Received OpAMP policy payload for key '" + key + "': " + policyText);
-    List<SourceWrapper> parsedSources = format.parse(policyText);
-    if (parsedSources == null && format == SourceFormat.JSONKEYVALUE) {
-      parsedSources = parseMappedJsonObject(policyText, sourceConverter.getMappedPolicyIds());
-    }
+    List<SourceWrapper> parsedSources =
+        format.parse(policyText, sourceConverter.getMappedPolicyIds());
     if (parsedSources == null) {
       logger.info("Ignoring invalid OpAMP config entry for key: " + key);
       return;
@@ -374,30 +366,6 @@ public final class OpampPolicyProvider extends AbstractPolicyProvider {
       trimmed += "/v1/opamp";
     }
     return trimmed;
-  }
-
-  @Nullable
-  private static List<SourceWrapper> parseMappedJsonObject(
-      String policyText, Set<String> allowedKeys) {
-    try {
-      JsonNode root = MAPPER.readTree(policyText);
-      if (!root.isObject()) {
-        return null;
-      }
-      List<SourceWrapper> wrappers = new ArrayList<>();
-      for (String key : allowedKeys) {
-        JsonNode value = root.get(key);
-        if (value == null) {
-          continue;
-        }
-        ObjectNode singlePolicy = MAPPER.createObjectNode();
-        singlePolicy.set(key, value);
-        wrappers.add(new JsonSourceWrapper(singlePolicy));
-      }
-      return wrappers;
-    } catch (IOException e) {
-      return null;
-    }
   }
 
   private static RemoteConfigStatus buildStatus(

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -8,18 +8,19 @@ package io.opentelemetry.contrib.dynamic.policy.source;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
- * Source wrapper for policy payloads parsed from JSON text that matches the {@link
- * SourceFormat#JSONKEYVALUE} shape: each policy is a JSON object with exactly one top-level key
- * (the policy type) and one value (the payload). The on-the-wire syntax is standard JSON, not a
- * separate encoding.
+ * Source wrapper for one policy parsed from JSON text that matches the {@link
+ * SourceFormat#JSONKEYVALUE} shape. Each wrapper contains exactly one top-level key (the policy
+ * type) and one value (the payload).
  */
 public final class JsonSourceWrapper implements SourceWrapper {
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -51,14 +52,14 @@ public final class JsonSourceWrapper implements SourceWrapper {
   /**
    * Parses JSON text into one wrapper per policy object.
    *
-   * <p>Input must be valid JSON whose structure matches {@link SourceFormat#JSONKEYVALUE}: either a
-   * single JSON object with exactly one top-level key/value pair, or a JSON array of such objects.
-   * An empty JSON array {@code []} yields an empty list.
+   * <p>Input must be a JSON object containing policy ID/value pairs, or an array of single-policy
+   * objects. Multi-policy objects are split into one wrapper per entry. Entries whose policy ID is
+   * not present in {@code mappedPolicyIds}, or whose shape is invalid, are skipped while valid
+   * entries continue through the pipeline. An empty JSON object or array yields an empty list.
    *
-   * @return an empty list if the source is an empty JSON array {@code []}; a non-empty list of
-   *     wrappers if the source is a valid single-policy object or non-empty array of such objects;
-   *     or {@code null} if the text is not valid JSON or the value shape is not supported for
-   *     {@link SourceFormat#JSONKEYVALUE}.
+   * @return an empty list if the source contains no valid mapped policies; a non-empty list of
+   *     wrappers for valid mapped policies; or {@code null} if the text is not valid JSON or its
+   *     root is neither an object nor an array
    * @param mappedPolicyIds configured policy IDs accepted as JSON object keys
    * @throws NullPointerException if source or mappedPolicyIds is null
    */
@@ -68,40 +69,42 @@ public final class JsonSourceWrapper implements SourceWrapper {
     Objects.requireNonNull(mappedPolicyIds, "mappedPolicyIds cannot be null");
     try {
       JsonNode parsed = MAPPER.readTree(source);
-      if (!isSupportedJsonShape(parsed, mappedPolicyIds)) {
-        return null;
+      if (parsed.isObject()) {
+        return wrapMappedObject(parsed, mappedPolicyIds);
       }
-      return wrapSupportedJson(parsed);
+      if (parsed.isArray()) {
+        return wrapMappedArray(parsed, mappedPolicyIds);
+      }
+      return null;
     } catch (JsonProcessingException e) {
       // the caller is responsible for logging if the source is malformed
       return null;
     }
   }
 
-  private static List<SourceWrapper> wrapSupportedJson(JsonNode parsed) {
-    if (parsed.isObject()) {
-      return Collections.singletonList(new JsonSourceWrapper(parsed));
-    }
+  private static List<SourceWrapper> wrapMappedObject(
+      JsonNode object, Set<String> mappedPolicyIds) {
     List<SourceWrapper> wrappers = new ArrayList<>();
-    for (JsonNode element : parsed) {
-      wrappers.add(new JsonSourceWrapper(element));
+    for (Map.Entry<String, JsonNode> field : object.properties()) {
+      if (!mappedPolicyIds.contains(field.getKey())) {
+        continue;
+      }
+      ObjectNode singlePolicy = MAPPER.createObjectNode();
+      singlePolicy.set(field.getKey(), field.getValue());
+      wrappers.add(new JsonSourceWrapper(singlePolicy));
     }
     return Collections.unmodifiableList(wrappers);
   }
 
-  private static boolean isSupportedJsonShape(JsonNode node, Set<String> mappedPolicyIds) {
-    if (node.isObject()) {
-      return isMappedSinglePolicyObject(node, mappedPolicyIds);
-    }
-    if (!node.isArray()) {
-      return false;
-    }
-    for (JsonNode element : node) {
+  private static List<SourceWrapper> wrapMappedArray(JsonNode array, Set<String> mappedPolicyIds) {
+    List<SourceWrapper> wrappers = new ArrayList<>();
+    for (JsonNode element : array) {
       if (!isMappedSinglePolicyObject(element, mappedPolicyIds)) {
-        return false;
+        continue;
       }
+      wrappers.add(new JsonSourceWrapper(element));
     }
-    return true;
+    return Collections.unmodifiableList(wrappers);
   }
 
   private static boolean isMappedSinglePolicyObject(JsonNode node, Set<String> mappedPolicyIds) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -58,45 +59,54 @@ public final class JsonSourceWrapper implements SourceWrapper {
    *     wrappers if the source is a valid single-policy object or non-empty array of such objects;
    *     or {@code null} if the text is not valid JSON or the value shape is not supported for
    *     {@link SourceFormat#JSONKEYVALUE}.
-   * @throws NullPointerException if source is null
+   * @param mappedPolicyIds configured policy IDs accepted as JSON object keys
+   * @throws NullPointerException if source or mappedPolicyIds is null
    */
   @Nullable
-  public static List<SourceWrapper> parse(String source) {
+  public static List<SourceWrapper> parse(String source, Set<String> mappedPolicyIds) {
     Objects.requireNonNull(source, "source cannot be null");
+    Objects.requireNonNull(mappedPolicyIds, "mappedPolicyIds cannot be null");
     try {
       JsonNode parsed = MAPPER.readTree(source);
-      if (!isSupportedJsonShape(parsed)) {
+      if (!isSupportedJsonShape(parsed, mappedPolicyIds)) {
         return null;
       }
-      if (parsed.isObject()) {
-        return Collections.singletonList(new JsonSourceWrapper(parsed));
-      }
-      List<SourceWrapper> wrappers = new ArrayList<>();
-      for (JsonNode element : parsed) {
-        wrappers.add(new JsonSourceWrapper(element));
-      }
-      return Collections.unmodifiableList(wrappers);
+      return wrapSupportedJson(parsed);
     } catch (JsonProcessingException e) {
+      // the caller is responsible for logging if the source is malformed
       return null;
     }
   }
 
-  private static boolean isSupportedJsonShape(JsonNode node) {
+  private static List<SourceWrapper> wrapSupportedJson(JsonNode parsed) {
+    if (parsed.isObject()) {
+      return Collections.singletonList(new JsonSourceWrapper(parsed));
+    }
+    List<SourceWrapper> wrappers = new ArrayList<>();
+    for (JsonNode element : parsed) {
+      wrappers.add(new JsonSourceWrapper(element));
+    }
+    return Collections.unmodifiableList(wrappers);
+  }
+
+  private static boolean isSupportedJsonShape(JsonNode node, Set<String> mappedPolicyIds) {
     if (node.isObject()) {
-      return isSinglePolicyObject(node);
+      return isMappedSinglePolicyObject(node, mappedPolicyIds);
     }
     if (!node.isArray()) {
       return false;
     }
     for (JsonNode element : node) {
-      if (!isSinglePolicyObject(element)) {
+      if (!isMappedSinglePolicyObject(element, mappedPolicyIds)) {
         return false;
       }
     }
     return true;
   }
 
-  private static boolean isSinglePolicyObject(JsonNode node) {
-    return node.isObject() && node.size() == 1;
+  private static boolean isMappedSinglePolicyObject(JsonNode node, Set<String> mappedPolicyIds) {
+    return node.isObject()
+        && node.size() == 1
+        && mappedPolicyIds.contains(node.fieldNames().next());
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -82,6 +82,27 @@ public final class JsonSourceWrapper implements SourceWrapper {
     }
   }
 
+  /**
+   * Returns {@code true} if {@code source} is valid JSON describing a single top-level object with
+   * exactly one key.
+   *
+   * <p>Unlike {@link #parse(String, Set)}, this does not drop unmapped keys: it reports the shape
+   * of the raw text. Callers that require exactly one policy per entry (for example, a file-backed
+   * provider with one policy per line) use this to reject objects carrying extra keys rather than
+   * silently discarding them.
+   *
+   * @throws NullPointerException if source is null
+   */
+  public static boolean isSingleKeyObject(String source) {
+    Objects.requireNonNull(source, "source cannot be null");
+    try {
+      JsonNode parsed = MAPPER.readTree(source);
+      return parsed.isObject() && parsed.size() == 1;
+    } catch (JsonProcessingException e) {
+      return false;
+    }
+  }
+
   private static List<SourceWrapper> wrapMappedObject(
       JsonNode object, Set<String> mappedPolicyIds) {
     List<SourceWrapper> wrappers = new ArrayList<>();

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -9,12 +9,13 @@ import com.google.errorprone.annotations.Immutable;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Supported source formats and their parser dispatch. */
 public enum SourceFormat {
-  KEYVALUE("keyvalue", KeyValueSourceWrapper::parse),
+  KEYVALUE("keyvalue", (source, mappedPolicyIds) -> KeyValueSourceWrapper.parse(source)),
   JSONKEYVALUE("jsonkeyvalue", JsonSourceWrapper::parse);
 
   private final String configValue;
@@ -52,23 +53,27 @@ public enum SourceFormat {
   }
 
   /**
-   * Parses source text into normalized wrappers for this format.
+   * Parses source text into normalized wrappers, using configured policy mappings when supported by
+   * the format.
    *
+   * @param source source text to parse
+   * @param mappedPolicyIds configured policy IDs accepted by the parser
    * @return an empty list if the source is valid but contains no policies; a non-empty list of
    *     wrappers if one or more policies were parsed successfully; or {@code null} if the source is
-   *     malformed or does not conform to the expected shape for this format.
-   * @throws NullPointerException if source is null
+   *     malformed or does not conform to the expected shape for this format
+   * @throws NullPointerException if source or mappedPolicyIds is null
    */
   @Nullable
-  public List<SourceWrapper> parse(String source) {
+  public List<SourceWrapper> parse(String source, Set<String> mappedPolicyIds) {
     Objects.requireNonNull(source, "source cannot be null");
-    return parser.parse(source);
+    Objects.requireNonNull(mappedPolicyIds, "mappedPolicyIds cannot be null");
+    return parser.parse(source, mappedPolicyIds);
   }
 
   @Immutable
   @FunctionalInterface
   private interface SourceParser {
     @Nullable
-    List<SourceWrapper> parse(String source);
+    List<SourceWrapper> parse(String source, Set<String> mappedPolicyIds);
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormat.java
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
 
 /** Supported source formats and their parser dispatch. */
 public enum SourceFormat {
+  // TODO keyvalue is not fully implemented, ignore mappedPolicyIds until done
   KEYVALUE("keyvalue", (source, mappedPolicyIds) -> KeyValueSourceWrapper.parse(source)),
   JSONKEYVALUE("jsonkeyvalue", JsonSourceWrapper::parse);
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
@@ -76,6 +76,17 @@ class LinePerPolicyFileProviderTest {
   }
 
   @Test
+  void fetchPoliciesRejectsJsonLineWithExtraKeys() throws Exception {
+    Path file = writeLines("{\"trace-sampling\": 0.5, \"typo\": 1}");
+    LinePerPolicyFileProvider provider =
+        new LinePerPolicyFileProvider(file, Collections.singletonList(acceptingValidator()));
+
+    List<TelemetryPolicy> policies = provider.fetchPolicies();
+
+    assertThat(policies).isEmpty();
+  }
+
+  @Test
   void fetchPoliciesSkipsUnknownOrRejectedPolicies() throws Exception {
     PolicyValidator rejectingValidator =
         new TestPolicyValidator(/* acceptJson= */ false, /* acceptKeyValue= */ false);

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
@@ -5,19 +5,26 @@
 
 package io.opentelemetry.contrib.dynamic.policy.source;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class JsonSourceWrapperTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Set<String> MAPPED_POLICY_IDS =
+      new HashSet<>(Arrays.asList("trace-sampling", "other-policy"));
 
   @Test
   void parseSupportsSingleObject() {
-    List<SourceWrapper> parsed = JsonSourceWrapper.parse("{\"trace-sampling\": 0.5}");
+    List<SourceWrapper> parsed =
+        JsonSourceWrapper.parse("{\"trace-sampling\": 0.5}", MAPPED_POLICY_IDS);
 
     assertThat(parsed).hasSize(1);
     assertThat(parsed.get(0)).isInstanceOf(JsonSourceWrapper.class);
@@ -27,7 +34,8 @@ class JsonSourceWrapperTest {
   @Test
   void parseSupportsArrayOfObjects() {
     List<SourceWrapper> parsed =
-        JsonSourceWrapper.parse("[{\"other-policy\": 1}, {\"trace-sampling\": 0.5}]");
+        JsonSourceWrapper.parse(
+            "[{\"other-policy\": 1}, {\"trace-sampling\": 0.5}]", MAPPED_POLICY_IDS);
 
     assertThat(parsed).hasSize(2);
     assertThat(parsed.get(0).getPolicyType()).isEqualTo("other-policy");
@@ -36,12 +44,13 @@ class JsonSourceWrapperTest {
 
   @Test
   void parseSupportsEmptyArray() {
-    assertThat(JsonSourceWrapper.parse("[]")).isEmpty();
+    assertThat(JsonSourceWrapper.parse("[]", emptySet())).isEmpty();
   }
 
   @Test
   void parseArrayResultIsImmutable() {
-    List<SourceWrapper> parsed = JsonSourceWrapper.parse("[{\"trace-sampling\": 0.5}]");
+    List<SourceWrapper> parsed =
+        JsonSourceWrapper.parse("[{\"trace-sampling\": 0.5}]", MAPPED_POLICY_IDS);
 
     assertThatThrownBy(() -> parsed.add(new JsonSourceWrapper(MAPPER.readTree("{\"x\":1}"))))
         .isInstanceOf(UnsupportedOperationException.class);
@@ -56,18 +65,24 @@ class JsonSourceWrapperTest {
 
   @Test
   void parseRejectsUnsupportedJsonShapes() {
-    assertThat(JsonSourceWrapper.parse("{}")).isNull();
-    assertThat(JsonSourceWrapper.parse("{\"a\": 1, \"b\": 2}")).isNull();
-    assertThat(JsonSourceWrapper.parse("[1, 2, 3]")).isNull();
-    assertThat(JsonSourceWrapper.parse("[{\"trace-sampling\": 0.5}, {}]")).isNull();
-    assertThat(JsonSourceWrapper.parse("[{\"a\": 1, \"b\": 2}]")).isNull();
-    assertThat(JsonSourceWrapper.parse("\"text\"")).isNull();
-    assertThat(JsonSourceWrapper.parse("{invalid-json")).isNull();
+    assertThat(JsonSourceWrapper.parse("{}", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("{\"a\": 1, \"b\": 2}", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("[1, 2, 3]", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("[{\"trace-sampling\": 0.5}, {}]", MAPPED_POLICY_IDS))
+        .isNull();
+    assertThat(JsonSourceWrapper.parse("[{\"a\": 1, \"b\": 2}]", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("\"text\"", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("{invalid-json", MAPPED_POLICY_IDS)).isNull();
+  }
+
+  @Test
+  void parseRejectsUnmappedPolicyId() {
+    assertThat(JsonSourceWrapper.parse("{\"unmapped\": 1}", MAPPED_POLICY_IDS)).isNull();
   }
 
   @Test
   void parseRejectsNullInput() {
-    assertThatThrownBy(() -> JsonSourceWrapper.parse(null))
+    assertThatThrownBy(() -> JsonSourceWrapper.parse(null, emptySet()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
@@ -32,6 +32,17 @@ class JsonSourceWrapperTest {
   }
 
   @Test
+  void parseSupportsMultiPolicyObject() {
+    List<SourceWrapper> parsed =
+        JsonSourceWrapper.parse(
+            "{\"trace-sampling\": 0.5, \"other-policy\": true}", MAPPED_POLICY_IDS);
+
+    assertThat(parsed)
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("trace-sampling", "other-policy");
+  }
+
+  @Test
   void parseSupportsArrayOfObjects() {
     List<SourceWrapper> parsed =
         JsonSourceWrapper.parse(
@@ -65,19 +76,28 @@ class JsonSourceWrapperTest {
 
   @Test
   void parseRejectsUnsupportedJsonShapes() {
-    assertThat(JsonSourceWrapper.parse("{}", MAPPED_POLICY_IDS)).isNull();
-    assertThat(JsonSourceWrapper.parse("{\"a\": 1, \"b\": 2}", MAPPED_POLICY_IDS)).isNull();
-    assertThat(JsonSourceWrapper.parse("[1, 2, 3]", MAPPED_POLICY_IDS)).isNull();
+    assertThat(JsonSourceWrapper.parse("{}", MAPPED_POLICY_IDS)).isEmpty();
+    assertThat(JsonSourceWrapper.parse("{\"a\": 1, \"b\": 2}", MAPPED_POLICY_IDS)).isEmpty();
+    assertThat(JsonSourceWrapper.parse("[1, 2, 3]", MAPPED_POLICY_IDS)).isEmpty();
     assertThat(JsonSourceWrapper.parse("[{\"trace-sampling\": 0.5}, {}]", MAPPED_POLICY_IDS))
-        .isNull();
-    assertThat(JsonSourceWrapper.parse("[{\"a\": 1, \"b\": 2}]", MAPPED_POLICY_IDS)).isNull();
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("trace-sampling");
+    assertThat(
+            JsonSourceWrapper.parse(
+                "[{\"trace-sampling\": 1, \"other-policy\": 2}]", MAPPED_POLICY_IDS))
+        .isEmpty();
     assertThat(JsonSourceWrapper.parse("\"text\"", MAPPED_POLICY_IDS)).isNull();
     assertThat(JsonSourceWrapper.parse("{invalid-json", MAPPED_POLICY_IDS)).isNull();
   }
 
   @Test
-  void parseRejectsUnmappedPolicyId() {
-    assertThat(JsonSourceWrapper.parse("{\"unmapped\": 1}", MAPPED_POLICY_IDS)).isNull();
+  void parseSkipsUnmappedPolicyIds() {
+    assertThat(JsonSourceWrapper.parse("{\"unmapped\": 1}", MAPPED_POLICY_IDS)).isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"trace-sampling\": 0.5, \"unmapped\": 1}", MAPPED_POLICY_IDS))
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("trace-sampling");
   }
 
   @Test

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
@@ -101,8 +101,25 @@ class JsonSourceWrapperTest {
   }
 
   @Test
+  void isSingleKeyObjectRecognizesRawShape() {
+    assertThat(JsonSourceWrapper.isSingleKeyObject("{\"trace-sampling\": 0.5}")).isTrue();
+    assertThat(JsonSourceWrapper.isSingleKeyObject("{\"trace-sampling\": 0.5, \"typo\": 1}"))
+        .isFalse();
+    assertThat(JsonSourceWrapper.isSingleKeyObject("{}")).isFalse();
+    assertThat(JsonSourceWrapper.isSingleKeyObject("[{\"trace-sampling\": 0.5}]")).isFalse();
+    assertThat(JsonSourceWrapper.isSingleKeyObject("{invalid-json")).isFalse();
+  }
+
+  @Test
   void parseRejectsNullInput() {
     assertThatThrownBy(() -> JsonSourceWrapper.parse(null, emptySet()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("source cannot be null");
+  }
+
+  @Test
+  void isSingleKeyObjectRejectsNullInput() {
+    assertThatThrownBy(() -> JsonSourceWrapper.isSingleKeyObject(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
@@ -62,9 +62,9 @@ class SourceFormatTest {
   }
 
   @Test
-  void parseRejectsJsonObjectWithUnmappedPolicyId() {
+  void parseSkipsJsonObjectWithUnmappedPolicyId() {
     assertThat(SourceFormat.JSONKEYVALUE.parse("{\"unmapped\": 0.5}", singleton("sampling_rate")))
-        .isNull();
+        .isEmpty();
   }
 
   @Test
@@ -86,12 +86,15 @@ class SourceFormatTest {
   @Test
   void parseReturnsNullForInvalidInput() {
     assertThat(SourceFormat.JSONKEYVALUE.parse("{invalid-json", emptySet())).isNull();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{}", emptySet())).isNull();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}", singleton("a"))).isNull();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{}", emptySet())).isEmpty();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}", singleton("a")))
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("a");
     assertThat(
             SourceFormat.JSONKEYVALUE.parse(
                 "[{\"trace-sampling\": 0.5}, {}]", singleton("trace-sampling")))
-        .isNull();
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("trace-sampling");
     assertThat(SourceFormat.KEYVALUE.parse("not-key-value", emptySet())).isNull();
   }
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.dynamic.policy.source;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -42,7 +44,8 @@ class SourceFormatTest {
 
   @Test
   void parseDelegatesToJsonParser() {
-    List<SourceWrapper> parsed = SourceFormat.JSONKEYVALUE.parse("{\"trace-sampling\": 0.5}");
+    List<SourceWrapper> parsed =
+        SourceFormat.JSONKEYVALUE.parse("{\"trace-sampling\": 0.5}", singleton("trace-sampling"));
 
     assertThat(parsed).hasSize(1);
     assertThat(parsed.get(0)).isInstanceOf(JsonSourceWrapper.class);
@@ -51,7 +54,7 @@ class SourceFormatTest {
 
   @Test
   void parseDelegatesToKeyValueParser() {
-    List<SourceWrapper> parsed = SourceFormat.KEYVALUE.parse("trace-sampling=0.5");
+    List<SourceWrapper> parsed = SourceFormat.KEYVALUE.parse("trace-sampling=0.5", emptySet());
 
     assertThat(parsed).hasSize(1);
     assertThat(parsed.get(0)).isInstanceOf(KeyValueSourceWrapper.class);
@@ -59,25 +62,45 @@ class SourceFormatTest {
   }
 
   @Test
+  void parseRejectsJsonObjectWithUnmappedPolicyId() {
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"unmapped\": 0.5}", singleton("sampling_rate")))
+        .isNull();
+  }
+
+  @Test
+  void parseUsesStandardParserForKeyValue() {
+    List<SourceWrapper> parsed =
+        SourceFormat.KEYVALUE.parse("sampling_rate=0.5", singleton("sampling_rate"));
+
+    assertThat(parsed).hasSize(1);
+    assertThat(parsed.get(0).getPolicyType()).isEqualTo("sampling_rate");
+  }
+
+  @Test
   void parseSupportsEmptyInputAcrossFormats() {
-    assertThat(SourceFormat.JSONKEYVALUE.parse("[]")).isEmpty();
-    assertThat(SourceFormat.KEYVALUE.parse("")).isEmpty();
-    assertThat(SourceFormat.KEYVALUE.parse("\n   \r\n")).isEmpty();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("[]", emptySet())).isEmpty();
+    assertThat(SourceFormat.KEYVALUE.parse("", emptySet())).isEmpty();
+    assertThat(SourceFormat.KEYVALUE.parse("\n   \r\n", emptySet())).isEmpty();
   }
 
   @Test
   void parseReturnsNullForInvalidInput() {
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{invalid-json")).isNull();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{}")).isNull();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}")).isNull();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("[{\"trace-sampling\": 0.5}, {}]")).isNull();
-    assertThat(SourceFormat.KEYVALUE.parse("not-key-value")).isNull();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{invalid-json", emptySet())).isNull();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{}", emptySet())).isNull();
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}", singleton("a"))).isNull();
+    assertThat(
+            SourceFormat.JSONKEYVALUE.parse(
+                "[{\"trace-sampling\": 0.5}, {}]", singleton("trace-sampling")))
+        .isNull();
+    assertThat(SourceFormat.KEYVALUE.parse("not-key-value", emptySet())).isNull();
   }
 
   @Test
   void parseReturnsImmutableListsAcrossFormats() {
-    List<SourceWrapper> jsonParsed = SourceFormat.JSONKEYVALUE.parse("{\"trace-sampling\": 0.5}");
-    List<SourceWrapper> keyValueParsed = SourceFormat.KEYVALUE.parse("trace-sampling=0.5");
+    List<SourceWrapper> jsonParsed =
+        SourceFormat.JSONKEYVALUE.parse("{\"trace-sampling\": 0.5}", singleton("trace-sampling"));
+    List<SourceWrapper> keyValueParsed =
+        SourceFormat.KEYVALUE.parse("trace-sampling=0.5", emptySet());
 
     assertThatThrownBy(() -> jsonParsed.add(parsed("other-policy", "1.0")))
         .isInstanceOf(UnsupportedOperationException.class);
@@ -87,10 +110,10 @@ class SourceFormatTest {
 
   @Test
   void parseRejectsNullInputAcrossFormats() {
-    assertThatThrownBy(() -> SourceFormat.JSONKEYVALUE.parse(null))
+    assertThatThrownBy(() -> SourceFormat.JSONKEYVALUE.parse(null, emptySet()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
-    assertThatThrownBy(() -> SourceFormat.KEYVALUE.parse(null))
+    assertThatThrownBy(() -> SourceFormat.KEYVALUE.parse(null, emptySet()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
@@ -12,7 +12,10 @@ import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -20,6 +23,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 class TraceSamplingValidatorTest {
 
   private static final String TRACE_SAMPLING_POLICY_TYPE = TraceSamplingRatePolicy.POLICY_TYPE;
+  private static final Set<String> MAPPED_POLICY_IDS =
+      new HashSet<>(Arrays.asList(TRACE_SAMPLING_POLICY_TYPE, "other-policy", "other.key"));
 
   private final TraceSamplingValidator validator = new TraceSamplingValidator();
 
@@ -32,7 +37,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson() {
     String json = jsonForProbability(0.5);
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -46,7 +52,8 @@ class TraceSamplingValidatorTest {
   void validateStoresExplicitSourceKind() {
     String json = jsonForProbability(0.5);
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.OPAMP);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.OPAMP);
 
     assertThat(policy).isNotNull();
     assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
@@ -57,7 +64,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson_BoundaryValues(double probability) {
     String json = jsonForProbability(probability);
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -74,7 +82,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson_LegacyObjectShapeWithProbabilityField() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": 0.5}}";
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -89,7 +98,8 @@ class TraceSamplingValidatorTest {
     String json =
         "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": " + probability + "}}";
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability())
         .isCloseTo(probability, within(1e-9));
@@ -103,7 +113,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson_ProbabilityAsQuotedStringInLegacyObject() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": \"0.625\"}}";
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.625, within(1e-9));
   }
@@ -112,7 +123,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidJson_ProbabilityAsQuotedStringFlat() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"0.375\"}";
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.375, within(1e-9));
   }
@@ -120,7 +132,9 @@ class TraceSamplingValidatorTest {
   @Test
   void testValidate_InvalidJson_MissingPolicyType() {
     String json = "{\"other-policy\": 0.5}";
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+    assertThat(
+            validator.validate(
+                first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM))
         .isNull();
   }
 
@@ -128,14 +142,18 @@ class TraceSamplingValidatorTest {
   @ValueSource(doubles = {-0.1, 1.1})
   void testValidate_InvalidJson_ProbabilityOutOfRange(double probability) {
     String json = jsonForProbability(probability);
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+    assertThat(
+            validator.validate(
+                first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM))
         .isNull();
   }
 
   @Test
   void testValidate_InvalidJson_ValueNotNumber() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"high\"}";
-    assertThat(validator.validate(first(SourceFormat.JSONKEYVALUE.parse(json)), SourceKind.CUSTOM))
+    assertThat(
+            validator.validate(
+                first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM))
         .isNull();
   }
 
@@ -143,7 +161,8 @@ class TraceSamplingValidatorTest {
   void testValidate_ValidKeyValue() {
     String keyValue = TRACE_SAMPLING_POLICY_TYPE + "=0.5";
     TelemetryPolicy policy =
-        validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)), SourceKind.CUSTOM);
+        validator.validate(
+            first(SourceFormat.KEYVALUE.parse(keyValue, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
@@ -156,14 +175,17 @@ class TraceSamplingValidatorTest {
   void testValidate_InvalidKeyValue_WrongKey() {
     assertThat(
             validator.validate(
-                first(SourceFormat.KEYVALUE.parse("other.key=0.5")), SourceKind.CUSTOM))
+                first(SourceFormat.KEYVALUE.parse("other.key=0.5", MAPPED_POLICY_IDS)),
+                SourceKind.CUSTOM))
         .isNull();
   }
 
   @Test
   void testValidate_InvalidKeyValue_NotNumber() {
     String keyValue = TRACE_SAMPLING_POLICY_TYPE + "=invalid";
-    assertThat(validator.validate(first(SourceFormat.KEYVALUE.parse(keyValue)), SourceKind.CUSTOM))
+    assertThat(
+            validator.validate(
+                first(SourceFormat.KEYVALUE.parse(keyValue, MAPPED_POLICY_IDS)), SourceKind.CUSTOM))
         .isNull();
   }
 


### PR DESCRIPTION
**Description:**

There was a special case parsing in OpampPolicyProvider, `if ( ... format == SourceFormat.JSONKEYVALUE)`, on reviewing the code  this clearly shouldn't be there, any parsing should exist within the format parsing and the provider should delegate all cases to there. This PR fixes this code smell.

Note the `LinePerPolicyFileProvider.java` and the `keyvalue` format are not fully implemented for now, they're pending later changes when the file provider is more fully specified

**Existing Issue(s):**

#2868

**Testing:**

changed as needed

**Documentation:**

not needed for this tech debt fix

**Outstanding items:**

#2868