### PR TITLE
Update post-release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,10 @@ jobs:
           body="Post-release updates for \`$VERSION\`."
           branch="otelbot/update-apidiff-baseline-to-released-version-${VERSION}"
 
+          # the main branch was checked out with persist-credentials: false, so
+          # authenticate origin with the otelbot app token before pushing
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           git checkout -b $branch
           git add CHANGELOG.md
           git add docs/apidiffs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-          persist-credentials: false
+          # zizmor: ignore[artipacked] Credentials are required by the branch push below.
+          persist-credentials: true
 
       - name: Merge change log to main
         env:
@@ -293,10 +294,6 @@ jobs:
           message="Post-release updates for $VERSION"
           body="Post-release updates for \`$VERSION\`."
           branch="otelbot/update-apidiff-baseline-to-released-version-${VERSION}"
-
-          # the main branch was checked out with persist-credentials: false, so
-          # authenticate origin with the otelbot app token before pushing
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git checkout -b $branch
           git add CHANGELOG.md


### PR DESCRIPTION
Post release step is currently broken: https://github.com/open-telemetry/opentelemetry-java-contrib/actions/runs/30115900119/job/89562895290

```
Run message="Post-release updates for $VERSION"
Switched to a new branch 'otelbot/update-apidiff-baseline-to-released-version-1.59.0'
[otelbot/update-apidiff-baseline-to-released-version-1.59.0 3acfa7c] Post-release updates for 1.59.0
 3 files changed, 4 insertions(+), 2 deletions(-)
 create mode 100644 docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-aws-xray.txt
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```

This reverts an update from #3009
