### PR TITLE
Post-release updates for 1.59.0

### DIFF
--- a/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-aws-xray.txt
+++ b/docs/apidiffs/1.59.0_vs_1.58.0/opentelemetry-aws-xray.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-aws-xray-1.59.0.jar against opentelemetry-aws-xray-1.58.0.jar
+No changes.

--- a/docs/apidiffs/current_vs_latest/opentelemetry-aws-xray.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-aws-xray.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-aws-xray-1.60.0-SNAPSHOT.jar against opentelemetry-aws-xray-1.58.0.jar
+Comparing source compatibility of opentelemetry-aws-xray-1.60.0-SNAPSHOT.jar against opentelemetry-aws-xray-1.59.0.jar
 No changes.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,6 +1,6 @@
 val stableVersion = "1.60.0-SNAPSHOT"
 val alphaVersion = "1.60.0-alpha-SNAPSHOT"
-val apidiffBaselineVersion = "1.58.0"
+val apidiffBaselineVersion = "1.59.0"
 val tagVersion by extra { "v$stableVersion" }
 
 allprojects {


### PR DESCRIPTION
Post-release updates for `1.59.0`.

Run manually due to a [failing job](https://github.com/open-telemetry/opentelemetry-java-contrib/actions/runs/30115900119/job/89562895290) that should be fixed by #3019