### PR TITLE
[dynamic control] support the current spec structure

### DIFF
--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -159,7 +159,6 @@ Each source must specify:
     finding the value at the key given by `location`. The contents of that value are parseable by
     the capability given in `format`
 * `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
-  (note protobuf and yaml are expected to be supported in future)
   * `keyvalue`: expects the contents to be convertible as a string into one or more line-separated
     `key=value` pairs (for example, a properties file)
   * `jsonkeyvalue`: expects the contents to be convertible as a string into a single simple JSON

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -128,7 +128,12 @@ to specify the file containing a YAML configuration of the policies,
 or `otel.java.experimental.telemetry.policy.init.json`
 (or OTEL_JAVA_EXPERIMENTAL_TELEMETRY_POLICY_INIT_JSON environment variable)
 to specify the file containing a JSON configuration of the policies.
-For example `java -Dotel.javaagent.extensions=/path/to/jar -Dotel.java.experimental.telemetry.policy.init.yaml=/path/to/yaml ...`
+For example:
+
+```text
+java -Dotel.javaagent.extensions=/path/to/jar -Dotel.java.experimental.telemetry.policy.init.yaml=/path/to/yaml ...
+```
+
 where /path/to/yaml is a file containing the config. eg
 
 ```yaml
@@ -151,11 +156,17 @@ Each source must specify:
 * `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
   (currently only `opamp` creates an active provider, the others are no-op providers)
   * `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
-    finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
+    finding the value at the key given by `location`. The contents of that value are parseable by
+    the capability given in `format`
 * `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
-  * `keyvalue`: expects the contents to be convertible as a string into one or more line separated 'key=value' pairs (eg a properties file)
-  * `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of simple json objects that are key and value, eg '{ "policyId": value}' or '[{ "policyId1": value1}, { "policyId2": value2}]' It also accepts full policy objects, or arrays mixing the two forms. A full policy requires a non-empty `id` and `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`
-  array, and a target `keep` value. The `id` must match a configured `policyId`. For example:
+  * `keyvalue`: expects the contents to be convertible as a string into one or more line-separated
+    `key=value` pairs (for example, a properties file)
+  * `jsonkeyvalue`: expects the contents to be convertible as a string into a single simple JSON
+    object or an array of simple JSON objects that are key and value, for example
+    `{ "policyId": value}` or `[{ "policyId1": value1}, { "policyId2": value2}]`. It also accepts
+    full policy objects or arrays mixing the two forms. A full policy requires a non-empty `id` and
+    `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`
+    array, and a target `keep` value. The `id` must match a configured `policyId`. For example:
 
 ```json
 {
@@ -194,10 +205,10 @@ sources:
 
 * `trace-sampling`
   * IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
- and a consistent sampling sampler is installed
- (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
+    and a consistent sampling sampler is installed
+    (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
   * Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
-  to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
+    to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
 
 ### Config example
 
@@ -246,10 +257,10 @@ Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
 * `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
 * `policyType` selects the Java policy implementation for that mapped policy ID. For example,
- `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
- sampling policies and deliver them to the trace sampling implementer.
+  `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
+  sampling policies and deliver them to the trace sampling implementer.
 * `id` identifies one policy instance within a policy type. It is used to distinguish updates,
- removals, and duplicate policies of the same type.
+  removals, and duplicate policies of the same type.
 * `name` is a human-readable description of the policy identified by `id`.
 
 An example helps to understand the differences between these fields. `trace-sampling` is an existing

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -159,6 +159,7 @@ Each source must specify:
     finding the value at the key given by `location`. The contents of that value are parseable by
     the capability given in `format`
 * `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
+   (note protobuf and yaml are expected to be supported in future)
   * `keyvalue`: expects the contents to be convertible as a string into one or more line-separated
     `key=value` pairs (for example, a properties file)
   * `jsonkeyvalue`: expects the contents to be convertible as a string into a single simple JSON

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -1,6 +1,6 @@
 # Dynamic Control
 
-[Maven](https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-dynamic-control)
+[![Maven](https://img.shields.io/maven-central/v/io.opentelemetry.contrib/opentelemetry-dynamic-control?label=Maven&color=orange)](https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-dynamic-control)
 
 Adding dynamic control of some specific features of the Java agent.
 
@@ -29,7 +29,6 @@ A concrete example helps to understand this flow:
 1. Message: A message is added (to OpAMP data structure) to specify a change to the trace "sampling rate"
 2. Provider: The OpampPolicyProvider reads the message from the OpAMP data structure received via OpAMP protocol
 3. Policy: The message is converted into a TraceSamplingRatePolicy, ie the policy that changes the sampling rate,
-
 with the target "traceid rate"
 4. Policy aggregator: The policy is combined with any other policy changes already applied or pending,
 handling source priority and potential merges of policies
@@ -55,8 +54,6 @@ echo "      - policyId: sampling_rate" >> config.yaml
 echo "        policyType: trace-sampling" >> config.yaml
 java -Dotel.javaagent.extensions=./opentelemetry-dynamic-control-all.jar -Dotel.java.experimental.telemetry.policy.init.yaml=./config.yaml -Dotel.opamp.service.url=http://127.0.0.1:4320/v1/opamp -javaagent:path/to/opentelemetry-javaagent.jar -Dotel.service.name=my-service -jar myapp.jar
 ```
-
-
 
 ## Building
 
@@ -123,8 +120,6 @@ telemetry_policy/development:
 
 ```
 
-
-
 ### Using as an auto-configured extension
 
 You can use either `otel.java.experimental.telemetry.policy.init.yaml`
@@ -147,21 +142,19 @@ sources:
 
 ```
 
-
-
 ### Config Available
 
 The config tree starts with `sources`. You can configure multiple sources.
 
 Each source must specify:
 
-- `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
+* `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
 (currently only `opamp` creates an active provider, the others are no-op providers)
   - `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
   finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
-- `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
-  - `keyvalue`: expects the contents to be convertible as a string into one or more line separated 'key=value' pairs (eg a properties file)
-  - `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of simple json objects that are key and value, eg '{ "policyId": value}' or '[{ "policyId1": value1}, { "policyId2": value2}]' It also accepts full policy objects, or arrays mixing the two forms. A full policy requires a non-empty `id` and `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`
+* `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
+  * `keyvalue`: expects the contents to be convertible as a string into one or more line separated 'key=value' pairs (eg a properties file)
+  * `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of simple json objects that are key and value, eg '{ "policyId": value}' or '[{ "policyId1": value1}, { "policyId2": value2}]' It also accepts full policy objects, or arrays mixing the two forms. A full policy requires a non-empty `id` and `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`
   array, and a target `keep` value. The `id` must match a configured `policyId`. For example:
 
 ```json
@@ -175,14 +168,14 @@ Each source must specify:
 }
 ```
 
-- `mappings`: one or more mappings from policy IDs to dynamic-control policy types
-- `location`: optional source-specific selector. For `opamp`, this is the OpAMP config map key, for example `vendor`
+* `mappings`: one or more mappings from policy IDs to dynamic-control policy types
+* `location`: optional source-specific selector. For `opamp`, this is the OpAMP config map key, for example `vendor`
 
 Each mapping must specify:
 
-- `policyId`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
+* `policyId`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
 by the user or already being used/sent from some source)
-- `policyType`: the dynamic-control policy type to update, currently only `trace-sampling` is valid
+* `policyType`: the dynamic-control policy type to update, currently only `trace-sampling` is valid
 
 Currently supported values in summary
 
@@ -197,15 +190,13 @@ sources:
 
 ```
 
-
-
 ### Policies supported
 
-- `trace-sampling`
-  - IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
+* `trace-sampling`
+  * IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
   and a consistent sampling sampler is installed
   (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
-  - Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
+  * Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
   to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
 
 
@@ -255,13 +246,13 @@ at the same time, the opamp change would be applied and the file change dropped.
 
 Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
-- `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
-- `policyType` selects the Java policy implementation for that mapped policy ID. For example,
+* `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
+* `policyType` selects the Java policy implementation for that mapped policy ID. For example,
 `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
 sampling policies and deliver them to the trace sampling implementer.
-- `id` identifies one policy instance within a policy type. It is used to distinguish updates,
+* `id` identifies one policy instance within a policy type. It is used to distinguish updates,
 removals, and duplicate policies of the same type.
-- `name` is a human-readable description of the policy identified by `id`.
+* `name` is a human-readable description of the policy identified by `id`.
 
 An example helps to understand the differences between these fields. `trace-sampling` is an existing
 policy type, detailed above, and because it uses a sampling rate applied globally, the id for it
@@ -324,7 +315,7 @@ the responsibility of the sender/updater to manage the IDs and matchers consiste
 
 ## Component owners
 
-- [Jack Shirazi](https://github.com/jackshirazi), Elastic
-- [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
+* [Jack Shirazi](https://github.com/jackshirazi), Elastic
+* [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -194,12 +194,10 @@ sources:
 
 * `trace-sampling`
   * IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
-  and a consistent sampling sampler is installed
-  (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
+ and a consistent sampling sampler is installed
+ (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
   * Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
   to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
-
-
 
 ### Config example
 
@@ -248,10 +246,10 @@ Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
 * `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
 * `policyType` selects the Java policy implementation for that mapped policy ID. For example,
-`policyType: trace-sampling` tells dynamic control to validate matching source values as trace
-sampling policies and deliver them to the trace sampling implementer.
+ `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
+ sampling policies and deliver them to the trace sampling implementer.
 * `id` identifies one policy instance within a policy type. It is used to distinguish updates,
-removals, and duplicate policies of the same type.
+ removals, and duplicate policies of the same type.
 * `name` is a human-readable description of the policy identified by `id`.
 
 An example helps to understand the differences between these fields. `trace-sampling` is an existing

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -149,9 +149,9 @@ The config tree starts with `sources`. You can configure multiple sources.
 Each source must specify:
 
 * `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
-(currently only `opamp` creates an active provider, the others are no-op providers)
-  - `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
-  finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
+  (currently only `opamp` creates an active provider, the others are no-op providers)
+  * `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
+    finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
 * `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
   * `keyvalue`: expects the contents to be convertible as a string into one or more line separated 'key=value' pairs (eg a properties file)
   * `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of simple json objects that are key and value, eg '{ "policyId": value}' or '[{ "policyId1": value1}, { "policyId2": value2}]' It also accepts full policy objects, or arrays mixing the two forms. A full policy requires a non-empty `id` and `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -159,7 +159,7 @@ Each source must specify:
     finding the value at the key given by `location`. The contents of that value are parseable by
     the capability given in `format`
 * `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
-   (note protobuf and yaml are expected to be supported in future)
+  (note protobuf and yaml are expected to be supported in future)
   * `keyvalue`: expects the contents to be convertible as a string into one or more line-separated
     `key=value` pairs (for example, a properties file)
   * `jsonkeyvalue`: expects the contents to be convertible as a string into a single simple JSON

--- a/dynamic-control/README.md
+++ b/dynamic-control/README.md
@@ -1,6 +1,6 @@
 # Dynamic Control
 
-[![Maven](https://img.shields.io/maven-central/v/io.opentelemetry.contrib/opentelemetry-dynamic-control?label=Maven&color=orange)](https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-dynamic-control)
+[Maven](https://central.sonatype.com/artifact/io.opentelemetry.contrib/opentelemetry-dynamic-control)
 
 Adding dynamic control of some specific features of the Java agent.
 
@@ -29,6 +29,7 @@ A concrete example helps to understand this flow:
 1. Message: A message is added (to OpAMP data structure) to specify a change to the trace "sampling rate"
 2. Provider: The OpampPolicyProvider reads the message from the OpAMP data structure received via OpAMP protocol
 3. Policy: The message is converted into a TraceSamplingRatePolicy, ie the policy that changes the sampling rate,
+
 with the target "traceid rate"
 4. Policy aggregator: The policy is combined with any other policy changes already applied or pending,
 handling source priority and potential merges of policies
@@ -54,6 +55,8 @@ echo "      - policyId: sampling_rate" >> config.yaml
 echo "        policyType: trace-sampling" >> config.yaml
 java -Dotel.javaagent.extensions=./opentelemetry-dynamic-control-all.jar -Dotel.java.experimental.telemetry.policy.init.yaml=./config.yaml -Dotel.opamp.service.url=http://127.0.0.1:4320/v1/opamp -javaagent:path/to/opentelemetry-javaagent.jar -Dotel.service.name=my-service -jar myapp.jar
 ```
+
+
 
 ## Building
 
@@ -120,6 +123,8 @@ telemetry_policy/development:
 
 ```
 
+
+
 ### Using as an auto-configured extension
 
 You can use either `otel.java.experimental.telemetry.policy.init.yaml`
@@ -128,8 +133,7 @@ to specify the file containing a YAML configuration of the policies,
 or `otel.java.experimental.telemetry.policy.init.json`
 (or OTEL_JAVA_EXPERIMENTAL_TELEMETRY_POLICY_INIT_JSON environment variable)
 to specify the file containing a JSON configuration of the policies.
-For example `java -Dotel.javaagent.extensions=/path/to/jar
--Dotel.java.experimental.telemetry.policy.init.yaml=/path/to/yaml ...`
+For example `java -Dotel.javaagent.extensions=/path/to/jar -Dotel.java.experimental.telemetry.policy.init.yaml=/path/to/yaml ...`
 where /path/to/yaml is a file containing the config. eg
 
 ```yaml
@@ -143,29 +147,42 @@ sources:
 
 ```
 
+
+
 ### Config Available
 
 The config tree starts with `sources`. You can configure multiple sources.
 
 Each source must specify:
 
-* `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
+- `kind`: where policy updates come from. Supported values: `opamp`, `file`, `http` and `custom`
 (currently only `opamp` creates an active provider, the others are no-op providers)
-  * `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
-finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
-* `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
-  * `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of
-simple json objects that are key and value, eg '{ "key": value}' or '[{ "key1": value1}, { "key2": value2}]'
-  * `keyvalue`: expects the contents to be convertible as a string into one or more
-line separated 'key=value' pairs (eg a properties file)
-* `mappings`: one or more mappings from policy IDs to dynamic-control policy types
-* `location`: optional source-specific selector. For `opamp`, this is the OpAMP config map key, for example `vendor`
+  - `opamp`: the implemented OpAMP provider expects to read the OpAMP config map,
+  finding the value at the key given by `location`. The contents of that value are parseable by the capability given in `format`
+- `format`: how the source payload is parsed. Supported values currently are `jsonkeyvalue` and `keyvalue`
+  - `keyvalue`: expects the contents to be convertible as a string into one or more line separated 'key=value' pairs (eg a properties file)
+  - `jsonkeyvalue`: expects the contents to be convertible as a string into a single or an array of simple json objects that are key and value, eg '{ "policyId": value}' or '[{ "policyId1": value1}, { "policyId2": value2}]' It also accepts full policy objects, or arrays mixing the two forms. A full policy requires a non-empty `id` and `name`, exactly one target (`log`, `metric`, `profile`, or `trace`), a non-empty target `match`
+  array, and a target `keep` value. The `id` must match a configured `policyId`. For example:
+
+```json
+{
+  "id": "trace-sampling",
+  "name": "Trace sampling rate",
+  "trace": {
+    "match": [{"trace_field": "trace_id", "exists": true}],
+    "keep": {"probability": 0.1}
+  }
+}
+```
+
+- `mappings`: one or more mappings from policy IDs to dynamic-control policy types
+- `location`: optional source-specific selector. For `opamp`, this is the OpAMP config map key, for example `vendor`
 
 Each mapping must specify:
 
-* `policyId`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
+- `policyId`: the key in the source payload, for example `sampling_rate` (this is an arbitrary string defined
 by the user or already being used/sent from some source)
-* `policyType`: the dynamic-control policy type to update, currently only `trace-sampling` is valid
+- `policyType`: the dynamic-control policy type to update, currently only `trace-sampling` is valid
 
 Currently supported values in summary
 
@@ -180,14 +197,18 @@ sources:
 
 ```
 
+
+
 ### Policies supported
 
-* `trace-sampling`
-  * IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
-and a consistent sampling sampler is installed
-(technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
-  * Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
-to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
+- `trace-sampling`
+  - IMPORTANT: if this policy is included in the config, then the sampler installed is overridden
+  and a consistent sampling sampler is installed
+  (technically the ComposableSampler.parentThreshold(ComposableSampler.probability()) sampler)
+  - Expects a value between 0.0 and 1.0 (including both end values), and will apply that sampling rate
+  to the agent's sampler where 0.0 is 0% head sampling and 1.0 is 100% sampling
+
+
 
 ### Config example
 
@@ -234,13 +255,13 @@ at the same time, the opamp change would be applied and the file change dropped.
 
 Telemetry policy uses `policyType`, `id`, and `name` for different purposes:
 
-* `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
-* `policyType` selects the Java policy implementation for that mapped policy ID. For example,
-  `policyType: trace-sampling` tells dynamic control to validate matching source values as trace
-  sampling policies and deliver them to the trace sampling implementer.
-* `id` identifies one policy instance within a policy type. It is used to distinguish updates,
-  removals, and duplicate policies of the same type.
-* `name` is a human-readable description of the policy identified by `id`.
+- `policyId` in the pipeline initialization identifies the source payload key for a policy mapping.
+- `policyType` selects the Java policy implementation for that mapped policy ID. For example,
+`policyType: trace-sampling` tells dynamic control to validate matching source values as trace
+sampling policies and deliver them to the trace sampling implementer.
+- `id` identifies one policy instance within a policy type. It is used to distinguish updates,
+removals, and duplicate policies of the same type.
+- `name` is a human-readable description of the policy identified by `id`.
 
 An example helps to understand the differences between these fields. `trace-sampling` is an existing
 policy type, detailed above, and because it uses a sampling rate applied globally, the id for it
@@ -303,7 +324,7 @@ the responsibility of the sender/updater to manage the IDs and matchers consiste
 
 ## Component owners
 
-* [Jack Shirazi](https://github.com/jackshirazi), Elastic
-* [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
+- [Jack Shirazi](https://github.com/jackshirazi), Elastic
+- [Cesar Munoz](https://github.com/LikeTheSalad), Elastic
 
 Learn more about component owners in [component_owners.yml](../.github/component_owners.yml).

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidator.java
@@ -27,7 +27,7 @@ public abstract class AbstractSourcePolicyValidator implements PolicyValidator {
     SourceFormat format = source.getFormat();
     switch (format) {
       case JSONKEYVALUE:
-        return validateJsonSource(((JsonSourceWrapper) source).asJsonNode(), sourceKind);
+        return validateJsonSource((JsonSourceWrapper) source, sourceKind);
       case KEYVALUE:
         return validateKeyValueSource((KeyValueSourceWrapper) source, sourceKind);
     }
@@ -35,12 +35,12 @@ public abstract class AbstractSourcePolicyValidator implements PolicyValidator {
   }
 
   @Nullable
-  private TelemetryPolicy validateJsonSource(JsonNode node, SourceKind sourceKind) {
-    JsonNode valueNode = node.get(getPolicyType());
-    if (valueNode == null) {
+  private TelemetryPolicy validateJsonSource(JsonSourceWrapper source, SourceKind sourceKind) {
+    if (!getPolicyType().equals(source.getPolicyType())) {
       return null;
     }
-    return validateJsonValue(valueNode, sourceKind);
+    JsonNode valueNode = source.getPolicyValue();
+    return valueNode == null ? null : validateJsonValue(valueNode, sourceKind);
   }
 
   @Nullable

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProvider.java
@@ -29,8 +29,8 @@ import java.util.stream.Stream;
  *
  * <ul>
  *   <li><b>{@link SourceFormat#JSONKEYVALUE JSONKEYVALUE}:</b> Lines starting with <code>{</code>
- *       use {@link SourceFormat#JSONKEYVALUE}: JSON text for a single top-level object with exactly
- *       one key (the policy type) and one value (the policy payload).
+ *       use {@link SourceFormat#JSONKEYVALUE}: JSON text for one keyed policy entry or one full
+ *       policy object with an {@code id}.
  *   <li><b>{@link SourceFormat#KEYVALUE KEYVALUE}:</b> Lines containing <code>=</code> are parsed
  *       as {@code policyType=value} and validated against the registered {@link PolicyValidator}s.
  * </ul>
@@ -84,7 +84,7 @@ final class LinePerPolicyFileProvider implements PolicyProvider {
             if (parsedSources == null
                 || parsedSources.size() != 1
                 || (format == SourceFormat.JSONKEYVALUE
-                    && !JsonSourceWrapper.isSingleKeyObject(trimmedLine))) {
+                    && !JsonSourceWrapper.isSinglePolicyObject(trimmedLine))) {
               logger.info("Invalid " + format.configValue() + " policy line: " + trimmedLine);
               return;
             }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/MappedPolicySourceConverter.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/MappedPolicySourceConverter.java
@@ -5,12 +5,7 @@
 
 package io.opentelemetry.contrib.dynamic.policy;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceMappingConfig;
-import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
-import io.opentelemetry.contrib.dynamic.policy.source.KeyValueSourceWrapper;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
 import java.util.ArrayList;
@@ -26,8 +21,6 @@ import javax.annotation.Nullable;
  * Converts parsed source policy entries into validated telemetry policies using source mappings.
  */
 final class MappedPolicySourceConverter {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
   private final Map<String, String> policyIdToPolicyType;
   private final List<PolicyValidator> validators;
 
@@ -77,7 +70,7 @@ final class MappedPolicySourceConverter {
     if (policyType == null) {
       return null;
     }
-    SourceWrapper normalizedSource = remapSourcePolicyType(source, policyType);
+    SourceWrapper normalizedSource = source.withPolicyType(policyType);
     if (normalizedSource == null) {
       return null;
     }
@@ -101,25 +94,5 @@ final class MappedPolicySourceConverter {
       mapping.put(item.getPolicyId(), item.getPolicyType());
     }
     return mapping;
-  }
-
-  @Nullable
-  private static SourceWrapper remapSourcePolicyType(
-      SourceWrapper source, String mappedPolicyType) {
-    if (source instanceof JsonSourceWrapper) {
-      JsonNode node = ((JsonSourceWrapper) source).asJsonNode();
-      if (!node.isObject() || node.size() != 1) {
-        return null;
-      }
-      JsonNode value = node.elements().next();
-      ObjectNode remappedNode = MAPPER.createObjectNode();
-      remappedNode.set(mappedPolicyType, value);
-      return new JsonSourceWrapper(remappedNode);
-    }
-    if (source instanceof KeyValueSourceWrapper) {
-      KeyValueSourceWrapper keyValue = (KeyValueSourceWrapper) source;
-      return new KeyValueSourceWrapper(mappedPolicyType, keyValue.getValue());
-    }
-    return source;
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -294,7 +295,7 @@ public final class JsonSourceWrapper implements SourceWrapper {
   }
 
   private static void logDroppedObject(JsonNode object) {
-    if (logger.isLoggable(java.util.logging.Level.FINE)) {
+    if (logger.isLoggable(Level.FINE)) {
       logger.fine("Ignoring invalid or unmapped JSON policy object: " + object);
     }
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -10,20 +10,45 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
  * Source wrapper for one policy parsed from JSON text that matches the {@link
- * SourceFormat#JSONKEYVALUE} shape. Each wrapper contains exactly one top-level key (the policy
- * type) and one value (the payload).
+ * SourceFormat#JSONKEYVALUE} shape: either one keyed policy entry or a full policy object with an
+ * {@code id} field. Examples of the two supported JSON structures are:
+ *
+ * <pre>{@code
+ * {
+ *   "policy-id": my-value
+ * }
+ * }</pre>
+ *
+ * and
+ *
+ * <pre>{@code
+ * {
+ *   "id": "policy-id",
+ *   "name": "Description of the policy",
+ *   "trace": {
+ *     "match": [{"field1": "match1", "field2": "match2"}],
+ *     "keep": {
+ *       "target-to-change": my-value
+ *     }
+ *   }
+ * }
+ * }</pre>
  */
 public final class JsonSourceWrapper implements SourceWrapper {
+  private static final Logger logger = Logger.getLogger(JsonSourceWrapper.class.getName());
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final List<String> TARGET_FIELD_NAMES =
+      Collections.unmodifiableList(Arrays.asList("log", "metric", "profile", "trace"));
   private final JsonNode source;
 
   public JsonSourceWrapper(JsonNode source) {
@@ -39,10 +64,36 @@ public final class JsonSourceWrapper implements SourceWrapper {
   @Nullable
   public String getPolicyType() {
     JsonNode node = asJsonNode();
-    if (!node.isObject() || node.size() != 1) {
+    if (!node.isObject()) {
+      return null;
+    }
+    JsonNode id = node.get("id");
+    if (id != null) {
+      return isStructurallyValidFullPolicy(node) ? id.asText() : null;
+    }
+    if (node.size() != 1) {
       return null;
     }
     return node.fieldNames().next();
+  }
+
+  @Override
+  @Nullable
+  public SourceWrapper withPolicyType(String policyType) {
+    Objects.requireNonNull(policyType, "policyType cannot be null");
+    JsonNode node = asJsonNode();
+    if (isFullPolicyObject()) {
+      ObjectNode remappedNode = ((ObjectNode) node).deepCopy();
+      remappedNode.put("id", policyType);
+      return new JsonSourceWrapper(remappedNode);
+    }
+    JsonNode value = getPolicyValue();
+    if (value == null) {
+      return null;
+    }
+    ObjectNode remappedNode = MAPPER.createObjectNode();
+    remappedNode.set(policyType, value);
+    return new JsonSourceWrapper(remappedNode);
   }
 
   public JsonNode asJsonNode() {
@@ -50,17 +101,43 @@ public final class JsonSourceWrapper implements SourceWrapper {
   }
 
   /**
+   * Returns the policy-specific value to validate.
+   *
+   * <p>For a keyed entry this is its mapped value. For a full policy object this is the target's
+   * {@code keep} value, after the common policy envelope has been validated.
+   */
+  @Nullable
+  public JsonNode getPolicyValue() {
+    JsonNode node = asJsonNode();
+    if (!node.isObject()) {
+      return null;
+    }
+    if (node.has("id")) {
+      JsonNode target = getFullPolicyTarget(node);
+      return target == null ? null : target.get("keep");
+    }
+    return node.size() == 1 ? node.elements().next() : null;
+  }
+
+  /** Returns whether this wrapper contains a structurally valid full policy object. */
+  public boolean isFullPolicyObject() {
+    return isStructurallyValidFullPolicy(asJsonNode());
+  }
+
+  /**
    * Parses JSON text into one wrapper per policy object.
    *
-   * <p>Input must be a JSON object containing policy ID/value pairs, or an array of single-policy
-   * objects. Multi-policy objects are split into one wrapper per entry. Entries whose policy ID is
-   * not present in {@code mappedPolicyIds}, or whose shape is invalid, are skipped while valid
-   * entries continue through the pipeline. An empty JSON object or array yields an empty list.
+   * <p>Input must be a JSON object containing policy ID/value pairs, a full policy object with an
+   * {@code id} field, or an array of single-policy objects. A full policy must have a non-empty
+   * {@code id} and {@code name}, exactly one supported target, a non-empty target {@code match}
+   * array, and a target {@code keep} value. Entries whose policy ID is not present in {@code
+   * mappedPolicyIds}, or whose shape is invalid, are skipped while valid entries continue through
+   * the pipeline. An empty JSON object or array yields an empty list.
    *
    * @return an empty list if the source contains no valid mapped policies; a non-empty list of
    *     wrappers for valid mapped policies; or {@code null} if the text is not valid JSON or its
    *     root is neither an object nor an array
-   * @param mappedPolicyIds configured policy IDs accepted as JSON object keys
+   * @param mappedPolicyIds configured policy IDs accepted as JSON object keys or full policy IDs
    * @throws NullPointerException if source or mappedPolicyIds is null
    */
   @Nullable
@@ -70,7 +147,11 @@ public final class JsonSourceWrapper implements SourceWrapper {
     try {
       JsonNode parsed = MAPPER.readTree(source);
       if (parsed.isObject()) {
-        return wrapMappedObject(parsed, mappedPolicyIds);
+        SourceWrapper wrapper = wrapMappedObject(parsed, mappedPolicyIds);
+        if (wrapper == null) {
+          logDroppedObject(parsed);
+        }
+        return wrapper == null ? Collections.emptyList() : Collections.singletonList(wrapper);
       }
       if (parsed.isArray()) {
         return wrapMappedArray(parsed, mappedPolicyIds);
@@ -103,27 +184,51 @@ public final class JsonSourceWrapper implements SourceWrapper {
     }
   }
 
-  private static List<SourceWrapper> wrapMappedObject(
-      JsonNode object, Set<String> mappedPolicyIds) {
-    List<SourceWrapper> wrappers = new ArrayList<>();
-    for (Map.Entry<String, JsonNode> field : object.properties()) {
-      if (!mappedPolicyIds.contains(field.getKey())) {
-        continue;
+  /**
+   * Returns {@code true} if {@code source} is a single keyed policy object or a full policy object
+   * with a non-empty textual {@code id}.
+   *
+   * @throws NullPointerException if source is null
+   */
+  public static boolean isSinglePolicyObject(String source) {
+    Objects.requireNonNull(source, "source cannot be null");
+    try {
+      JsonNode parsed = MAPPER.readTree(source);
+      if (!parsed.isObject()) {
+        return false;
       }
-      ObjectNode singlePolicy = MAPPER.createObjectNode();
-      singlePolicy.set(field.getKey(), field.getValue());
-      wrappers.add(new JsonSourceWrapper(singlePolicy));
+      if (parsed.has("id")) {
+        return isStructurallyValidFullPolicy(parsed);
+      }
+      return parsed.size() == 1;
+    } catch (JsonProcessingException e) {
+      return false;
     }
-    return Collections.unmodifiableList(wrappers);
+  }
+
+  @Nullable
+  private static SourceWrapper wrapMappedObject(JsonNode object, Set<String> mappedPolicyIds) {
+    if (object.has("id")) {
+      if (isMappedFullPolicyObject(object, mappedPolicyIds)) {
+        return new JsonSourceWrapper(object);
+      }
+      return null;
+    }
+    if (isMappedSinglePolicyObject(object, mappedPolicyIds)) {
+      return new JsonSourceWrapper(object);
+    }
+    return null;
   }
 
   private static List<SourceWrapper> wrapMappedArray(JsonNode array, Set<String> mappedPolicyIds) {
     List<SourceWrapper> wrappers = new ArrayList<>();
     for (JsonNode element : array) {
-      if (!isMappedSinglePolicyObject(element, mappedPolicyIds)) {
-        continue;
+      if (isMappedFullPolicyObject(element, mappedPolicyIds)
+          || isMappedSinglePolicyObject(element, mappedPolicyIds)) {
+        wrappers.add(new JsonSourceWrapper(element));
+      } else if (element.isObject()) {
+        logDroppedObject(element);
       }
-      wrappers.add(new JsonSourceWrapper(element));
     }
     return Collections.unmodifiableList(wrappers);
   }
@@ -132,5 +237,63 @@ public final class JsonSourceWrapper implements SourceWrapper {
     return node.isObject()
         && node.size() == 1
         && mappedPolicyIds.contains(node.fieldNames().next());
+  }
+
+  private static boolean isMappedFullPolicyObject(JsonNode node, Set<String> mappedPolicyIds) {
+    JsonNode id = node.get("id");
+    return id != null
+        && mappedPolicyIds.contains(id.asText())
+        && isStructurallyValidFullPolicy(node);
+  }
+
+  private static boolean isStructurallyValidFullPolicy(JsonNode node) {
+    return node.isObject()
+        && hasRequiredText(node, "id")
+        && hasRequiredText(node, "name")
+        && getFullPolicyTarget(node) != null;
+  }
+
+  @Nullable
+  // The details of the structure are not yet fully specced, so this is just enforcing a minimal
+  // shape
+  private static JsonNode getFullPolicyTarget(JsonNode policyNode) {
+    JsonNode target = null;
+    for (String fieldName : TARGET_FIELD_NAMES) {
+      JsonNode candidate = policyNode.get(fieldName);
+      if (candidate == null) {
+        continue;
+      }
+      // A full policy must contain exactly one target field.
+      if (target != null) {
+        return null;
+      }
+      target = candidate;
+    }
+    if (target == null || !target.isObject()) {
+      return null;
+    }
+    JsonNode match = target.get("match");
+    if (match == null || !match.isArray() || match.isEmpty()) {
+      return null;
+    }
+    for (JsonNode matcher : match) {
+      if (!matcher.isObject() || matcher.isEmpty()) {
+        return null;
+      }
+    }
+    JsonNode keep = target.get("keep");
+    return keep == null || keep.isNull() ? null : target;
+  }
+
+  private static boolean hasRequiredText(JsonNode node, String fieldName) {
+    return hasNonEmptyText(node.get(fieldName));
+  }
+
+  private static boolean hasNonEmptyText(@Nullable JsonNode value) {
+    return value != null && value.isTextual() && !value.asText().trim().isEmpty();
+  }
+
+  private static void logDroppedObject(JsonNode object) {
+    logger.fine("Ignoring invalid or unmapped JSON policy object: " + object);
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -127,12 +127,12 @@ public final class JsonSourceWrapper implements SourceWrapper {
   /**
    * Parses JSON text into one wrapper per policy object.
    *
-   * <p>Input must be a JSON object containing policy ID/value pairs, a full policy object with an
-   * {@code id} field, or an array of single-policy objects. A full policy must have a non-empty
-   * {@code id} and {@code name}, exactly one supported target, a non-empty target {@code match}
-   * array, and a target {@code keep} value. Entries whose policy ID is not present in {@code
-   * mappedPolicyIds}, or whose shape is invalid, are skipped while valid entries continue through
-   * the pipeline. An empty JSON object or array yields an empty list.
+   * <p>Input must be a single-policy JSON object containing either exactly one policy ID/value
+   * pair, or a full policy object with an {@code id} field, or an array of single-policy objects. A
+   * full policy must have a non-empty {@code id} and {@code name}, exactly one supported target, a
+   * non-empty target {@code match} array, and a target {@code keep} value. Entries whose policy ID
+   * is not present in {@code mappedPolicyIds}, or whose shape is invalid, are skipped while valid
+   * entries continue through the pipeline. An empty JSON object or array yields an empty list.
    *
    * @return an empty list if the source contains no valid mapped policies; a non-empty list of
    *     wrappers for valid mapped policies; or {@code null} if the text is not valid JSON or its

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -294,6 +294,8 @@ public final class JsonSourceWrapper implements SourceWrapper {
   }
 
   private static void logDroppedObject(JsonNode object) {
-    logger.fine("Ignoring invalid or unmapped JSON policy object: " + object);
+    if (logger.isLoggable(java.util.logging.Level.FINE)) {
+      logger.fine("Ignoring invalid or unmapped JSON policy object: " + object);
+    }
   }
 }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapper.java
@@ -165,27 +165,6 @@ public final class JsonSourceWrapper implements SourceWrapper {
   }
 
   /**
-   * Returns {@code true} if {@code source} is valid JSON describing a single top-level object with
-   * exactly one key.
-   *
-   * <p>Unlike {@link #parse(String, Set)}, this does not drop unmapped keys: it reports the shape
-   * of the raw text. Callers that require exactly one policy per entry (for example, a file-backed
-   * provider with one policy per line) use this to reject objects carrying extra keys rather than
-   * silently discarding them.
-   *
-   * @throws NullPointerException if source is null
-   */
-  public static boolean isSingleKeyObject(String source) {
-    Objects.requireNonNull(source, "source cannot be null");
-    try {
-      JsonNode parsed = MAPPER.readTree(source);
-      return parsed.isObject() && parsed.size() == 1;
-    } catch (JsonProcessingException e) {
-      return false;
-    }
-  }
-
-  /**
    * Returns {@code true} if {@code source} is a single keyed policy object or a full policy object
    * with a non-empty textual {@code id}.
    *

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/KeyValueSourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/KeyValueSourceWrapper.java
@@ -35,6 +35,12 @@ public final class KeyValueSourceWrapper implements SourceWrapper {
     return key;
   }
 
+  @Override
+  public SourceWrapper withPolicyType(String policyType) {
+    return new KeyValueSourceWrapper(
+        Objects.requireNonNull(policyType, "policyType cannot be null"), value);
+  }
+
   public String getKey() {
     return key;
   }

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceWrapper.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/source/SourceWrapper.java
@@ -13,4 +13,12 @@ public interface SourceWrapper {
 
   @Nullable
   String getPolicyType();
+
+  /**
+   * Returns a copy of this source with its policy identifier replaced by {@code policyType}.
+   *
+   * @return the remapped source, or {@code null} if this source cannot be remapped
+   */
+  @Nullable
+  SourceWrapper withPolicyType(String policyType);
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/AbstractSourcePolicyValidatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class AbstractSourcePolicyValidatorTest {
+
+  @Test
+  void fullPolicyPassesOnlyGenericKeepValueToConcreteValidator() {
+    List<SourceWrapper> sources =
+        SourceFormat.JSONKEYVALUE.parse(
+            "{\"id\":\"metric-exporter-stop\",\"name\":\"Stop metric export\","
+                + "\"metric\":{\"match\":[{\"metric_field\":\"name\",\"exists\":true}],"
+                + "\"keep\":false}}",
+            Collections.singleton("metric-exporter-stop"));
+    RecordingMetricValidator validator = new RecordingMetricValidator();
+
+    TelemetryPolicy policy = validator.validate(sources.get(0), SourceKind.CUSTOM);
+
+    assertThat(policy).isNotNull();
+    assertThat(validator.receivedValue).isNotNull();
+    assertThat(validator.receivedValue.isBoolean()).isTrue();
+    assertThat(validator.receivedValue.asBoolean()).isFalse();
+  }
+
+  private static final class RecordingMetricValidator extends AbstractSourcePolicyValidator {
+    @Nullable private JsonNode receivedValue;
+
+    @Override
+    public String getPolicyType() {
+      return "metric-exporter-stop";
+    }
+
+    @Override
+    protected TelemetryPolicy validateJsonValue(JsonNode valueNode, SourceKind sourceKind) {
+      receivedValue = valueNode;
+      return mock(TelemetryPolicy.class);
+    }
+
+    @Override
+    protected TelemetryPolicy validateKeyValueValue(String value, SourceKind sourceKind) {
+      return null;
+    }
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/LinePerPolicyFileProviderTest.java
@@ -76,6 +76,22 @@ class LinePerPolicyFileProviderTest {
   }
 
   @Test
+  void fetchPoliciesParsesFullJsonPolicyLines() throws Exception {
+    Path file =
+        writeLines(
+            "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+                + "\"keep\":{\"probability\":0.1}}}");
+    LinePerPolicyFileProvider provider =
+        new LinePerPolicyFileProvider(file, Collections.singletonList(acceptingValidator()));
+
+    List<TelemetryPolicy> policies = provider.fetchPolicies();
+
+    assertThat(policies).hasSize(1);
+    assertThat(policies.get(0).getType()).isEqualTo(TRACE_SAMPLING_TYPE);
+  }
+
+  @Test
   void fetchPoliciesRejectsJsonLineWithExtraKeys() throws Exception {
     Path file = writeLines("{\"trace-sampling\": 0.5, \"typo\": 1}");
     LinePerPolicyFileProvider provider =

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/MappedPolicySourceConverterTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/MappedPolicySourceConverterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicySourceMappingConfig;
+import io.opentelemetry.contrib.dynamic.policy.source.JsonSourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingRatePolicy;
+import io.opentelemetry.contrib.dynamic.policy.tracesampling.TraceSamplingValidator;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MappedPolicySourceConverterTest {
+
+  @Test
+  void convertsAndRemapsFullPolicyObjectWithoutMutatingSource() {
+    MappedPolicySourceConverter converter =
+        MappedPolicySourceConverter.create(
+            Collections.singletonList(
+                new PolicySourceMappingConfig("external-trace-policy", "trace-sampling")),
+            Collections.singletonList(new TraceSamplingValidator()));
+    List<SourceWrapper> sources =
+        SourceFormat.JSONKEYVALUE.parse(
+            "{"
+                + "\"id\":\"external-trace-policy\","
+                + "\"name\":\"Trace sampling rate\","
+                + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+                + "\"keep\":{\"probability\":0.1}}"
+                + "}",
+            converter.getMappedPolicyIds());
+
+    TelemetryPolicy converted = converter.convert(sources.get(0), SourceKind.OPAMP);
+
+    assertThat(converted).isInstanceOf(TraceSamplingRatePolicy.class);
+    assertThat(((TraceSamplingRatePolicy) converted).getProbability()).isCloseTo(0.1, within(1e-9));
+    assertThat(((JsonSourceWrapper) sources.get(0)).asJsonNode().get("id").asText())
+        .isEqualTo("external-trace-policy");
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
@@ -10,16 +10,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 class JsonSourceWrapperTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Set<String> MAPPED_POLICY_IDS =
-      new HashSet<>(Arrays.asList("trace-sampling", "other-policy"));
+      new HashSet<>(Arrays.asList("trace-sampling", "metric-exporter-stop", "other-policy"));
 
   @Test
   void parseSupportsSingleObject() {
@@ -32,14 +37,136 @@ class JsonSourceWrapperTest {
   }
 
   @Test
-  void parseSupportsMultiPolicyObject() {
+  void parseRejectsMultiPolicyObject() {
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"trace-sampling\": 0.5, \"other-policy\": true}", MAPPED_POLICY_IDS))
+        .isEmpty();
+  }
+
+  @Test
+  void parseLogsDroppedObjectsAtDebugLevel() {
+    Logger logger = Logger.getLogger(JsonSourceWrapper.class.getName());
+    Level previousLevel = logger.getLevel();
+    List<LogRecord> records = new ArrayList<>();
+    Handler handler =
+        new Handler() {
+          @Override
+          public void publish(LogRecord record) {
+            records.add(record);
+          }
+
+          @Override
+          public void flush() {}
+
+          @Override
+          public void close() {}
+        };
+    handler.setLevel(Level.FINE);
+    logger.setLevel(Level.FINE);
+    logger.addHandler(handler);
+    try {
+      JsonSourceWrapper.parse("{\"trace-sampling\":0.5,\"other-policy\":true}", MAPPED_POLICY_IDS);
+      JsonSourceWrapper.parse(
+          "[{\"trace-sampling\":0.5},{\"unmapped\":true},42]", MAPPED_POLICY_IDS);
+    } finally {
+      logger.removeHandler(handler);
+      logger.setLevel(previousLevel);
+    }
+
+    assertThat(records).extracting(LogRecord::getLevel).containsOnly(Level.FINE);
+    assertThat(records)
+        .extracting(LogRecord::getMessage)
+        .containsExactly(
+            "Ignoring invalid or unmapped JSON policy object: "
+                + "{\"trace-sampling\":0.5,\"other-policy\":true}",
+            "Ignoring invalid or unmapped JSON policy object: {\"unmapped\":true}");
+  }
+
+  @Test
+  void parseKeepsFullPolicyObjectTogether() {
+    List<SourceWrapper> parsed =
+        JsonSourceWrapper.parse(fullTraceSamplingPolicy(), MAPPED_POLICY_IDS);
+
+    assertThat(parsed).hasSize(1);
+    assertThat(parsed.get(0).getPolicyType()).isEqualTo("trace-sampling");
+    assertThat(((JsonSourceWrapper) parsed.get(0)).asJsonNode().get("name").asText())
+        .isEqualTo("Trace sampling rate");
+  }
+
+  @Test
+  void parseValidatesCommonFullPolicyEnvelope() {
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"trace-sampling\",\"trace\":{\"match\":[{\"exists\":true}],"
+                    + "\"keep\":{\"probability\":0.1}}}",
+                MAPPED_POLICY_IDS))
+        .isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                    + "\"trace\":{\"match\":[],\"keep\":{\"probability\":0.1}}}",
+                MAPPED_POLICY_IDS))
+        .isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                    + "\"trace\":{\"match\":[{}],\"keep\":{\"probability\":0.1}}}",
+                MAPPED_POLICY_IDS))
+        .isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                    + "\"trace\":{\"match\":[{\"exists\":true}]}}",
+                MAPPED_POLICY_IDS))
+        .isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                    + "\"trace\":{\"match\":[{\"exists\":true}],\"keep\":{\"probability\":0.1}},"
+                    + "\"metric\":{\"match\":[{\"exists\":true}],\"keep\":false}}",
+                MAPPED_POLICY_IDS))
+        .isEmpty();
+  }
+
+  @Test
+  void parseAndUnwrapFullPolicyWithoutPolicySpecificKnowledge() {
     List<SourceWrapper> parsed =
         JsonSourceWrapper.parse(
-            "{\"trace-sampling\": 0.5, \"other-policy\": true}", MAPPED_POLICY_IDS);
+            "{\"id\":\"metric-exporter-stop\",\"name\":\"Stop metric export\","
+                + "\"metric\":{\"match\":[{\"metric_field\":\"name\",\"exists\":true}],"
+                + "\"keep\":false}}",
+            MAPPED_POLICY_IDS);
 
-    assertThat(parsed)
-        .extracting(SourceWrapper::getPolicyType)
-        .containsExactly("trace-sampling", "other-policy");
+    assertThat(parsed).hasSize(1);
+    JsonSourceWrapper policy = (JsonSourceWrapper) parsed.get(0);
+    assertThat(policy.getPolicyType()).isEqualTo("metric-exporter-stop");
+    assertThat(policy.getPolicyValue().isBoolean()).isTrue();
+    assertThat(policy.getPolicyValue().asBoolean()).isFalse();
+  }
+
+  @Test
+  void getPolicyValueUnwrapsKeyedAndFullPolicies() throws Exception {
+    JsonSourceWrapper keyed = new JsonSourceWrapper(MAPPER.readTree("{\"trace-sampling\":0.25}"));
+    JsonSourceWrapper full = new JsonSourceWrapper(MAPPER.readTree(fullTraceSamplingPolicy()));
+
+    assertThat(keyed.getPolicyValue().asDouble()).isEqualTo(0.25);
+    assertThat(full.getPolicyValue().get("probability").asDouble()).isEqualTo(0.1);
+  }
+
+  @Test
+  void withPolicyTypeRemapsKeyedAndFullPoliciesWithoutMutatingSources() throws Exception {
+    JsonSourceWrapper keyed = new JsonSourceWrapper(MAPPER.readTree("{\"external\":0.25}"));
+    JsonSourceWrapper full = new JsonSourceWrapper(MAPPER.readTree(fullTraceSamplingPolicy()));
+
+    JsonSourceWrapper remappedKeyed = (JsonSourceWrapper) keyed.withPolicyType("trace-sampling");
+    JsonSourceWrapper remappedFull = (JsonSourceWrapper) full.withPolicyType("mapped-trace");
+
+    assertThat(remappedKeyed.getPolicyType()).isEqualTo("trace-sampling");
+    assertThat(remappedKeyed.getPolicyValue().asDouble()).isEqualTo(0.25);
+    assertThat(keyed.getPolicyType()).isEqualTo("external");
+    assertThat(remappedFull.getPolicyType()).isEqualTo("mapped-trace");
+    assertThat(full.getPolicyType()).isEqualTo("trace-sampling");
   }
 
   @Test
@@ -51,6 +178,17 @@ class JsonSourceWrapperTest {
     assertThat(parsed).hasSize(2);
     assertThat(parsed.get(0).getPolicyType()).isEqualTo("other-policy");
     assertThat(parsed.get(1).getPolicyType()).isEqualTo("trace-sampling");
+  }
+
+  @Test
+  void parseSupportsArrayMixingKeyedAndFullPolicyObjects() {
+    List<SourceWrapper> parsed =
+        JsonSourceWrapper.parse(
+            "[{\"other-policy\":1}," + fullTraceSamplingPolicy() + "]", MAPPED_POLICY_IDS);
+
+    assertThat(parsed)
+        .extracting(SourceWrapper::getPolicyType)
+        .containsExactly("other-policy", "trace-sampling");
   }
 
   @Test
@@ -75,6 +213,13 @@ class JsonSourceWrapperTest {
   }
 
   @Test
+  void getPolicyTypeUsesFullPolicyId() throws Exception {
+    JsonSourceWrapper wrapper = new JsonSourceWrapper(MAPPER.readTree(fullTraceSamplingPolicy()));
+
+    assertThat(wrapper.getPolicyType()).isEqualTo("trace-sampling");
+  }
+
+  @Test
   void parseRejectsUnsupportedJsonShapes() {
     assertThat(JsonSourceWrapper.parse("{}", MAPPED_POLICY_IDS)).isEmpty();
     assertThat(JsonSourceWrapper.parse("{\"a\": 1, \"b\": 2}", MAPPED_POLICY_IDS)).isEmpty();
@@ -96,8 +241,11 @@ class JsonSourceWrapperTest {
     assertThat(
             JsonSourceWrapper.parse(
                 "{\"trace-sampling\": 0.5, \"unmapped\": 1}", MAPPED_POLICY_IDS))
-        .extracting(SourceWrapper::getPolicyType)
-        .containsExactly("trace-sampling");
+        .isEmpty();
+    assertThat(
+            JsonSourceWrapper.parse(
+                "{\"id\":\"unmapped\",\"trace-sampling\":0.5}", MAPPED_POLICY_IDS))
+        .isEmpty();
   }
 
   @Test
@@ -108,6 +256,18 @@ class JsonSourceWrapperTest {
     assertThat(JsonSourceWrapper.isSingleKeyObject("{}")).isFalse();
     assertThat(JsonSourceWrapper.isSingleKeyObject("[{\"trace-sampling\": 0.5}]")).isFalse();
     assertThat(JsonSourceWrapper.isSingleKeyObject("{invalid-json")).isFalse();
+  }
+
+  @Test
+  void isSinglePolicyObjectRecognizesKeyedAndFullShapes() {
+    assertThat(JsonSourceWrapper.isSinglePolicyObject("{\"trace-sampling\":0.5}")).isTrue();
+    assertThat(JsonSourceWrapper.isSinglePolicyObject(fullTraceSamplingPolicy())).isTrue();
+    assertThat(
+            JsonSourceWrapper.isSinglePolicyObject(
+                "{\"trace-sampling\":0.5,\"other-policy\":true}"))
+        .isFalse();
+    assertThat(JsonSourceWrapper.isSinglePolicyObject("{\"id\":\" \"}")).isFalse();
+    assertThat(JsonSourceWrapper.isSinglePolicyObject("[]")).isFalse();
   }
 
   @Test
@@ -122,5 +282,29 @@ class JsonSourceWrapperTest {
     assertThatThrownBy(() -> JsonSourceWrapper.isSingleKeyObject(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
+  }
+
+  @Test
+  void isSinglePolicyObjectRejectsNullInput() {
+    assertThatThrownBy(() -> JsonSourceWrapper.isSinglePolicyObject(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("source cannot be null");
+  }
+
+  private static String fullTraceSamplingPolicy() {
+    return "{"
+        + "\"id\":\"trace-sampling\","
+        + "\"name\":\"Trace sampling rate\","
+        + "\"description\":\"Set the global trace sampling rate to 10%.\","
+        + "\"enabled\":true,"
+        + "\"created_at_unix_nano\":\"1718890000000000000\","
+        + "\"modified_at_unix_nano\":\"1718893600000000000\","
+        + "\"labels\":[{\"key\":\"policy.scope\","
+        + "\"value\":{\"string_value\":\"global\"}}],"
+        + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true,"
+        + "\"negate\":false,\"case_insensitive\":false}],"
+        + "\"keep\":{\"probability\":0.1,\"mode\":\"proportional\","
+        + "\"sampling_precision\":6,\"hash_seed\":0,\"fail_closed\":false}}"
+        + "}";
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/JsonSourceWrapperTest.java
@@ -249,16 +249,6 @@ class JsonSourceWrapperTest {
   }
 
   @Test
-  void isSingleKeyObjectRecognizesRawShape() {
-    assertThat(JsonSourceWrapper.isSingleKeyObject("{\"trace-sampling\": 0.5}")).isTrue();
-    assertThat(JsonSourceWrapper.isSingleKeyObject("{\"trace-sampling\": 0.5, \"typo\": 1}"))
-        .isFalse();
-    assertThat(JsonSourceWrapper.isSingleKeyObject("{}")).isFalse();
-    assertThat(JsonSourceWrapper.isSingleKeyObject("[{\"trace-sampling\": 0.5}]")).isFalse();
-    assertThat(JsonSourceWrapper.isSingleKeyObject("{invalid-json")).isFalse();
-  }
-
-  @Test
   void isSinglePolicyObjectRecognizesKeyedAndFullShapes() {
     assertThat(JsonSourceWrapper.isSinglePolicyObject("{\"trace-sampling\":0.5}")).isTrue();
     assertThat(JsonSourceWrapper.isSinglePolicyObject(fullTraceSamplingPolicy())).isTrue();
@@ -273,13 +263,6 @@ class JsonSourceWrapperTest {
   @Test
   void parseRejectsNullInput() {
     assertThatThrownBy(() -> JsonSourceWrapper.parse(null, emptySet()))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage("source cannot be null");
-  }
-
-  @Test
-  void isSingleKeyObjectRejectsNullInput() {
-    assertThatThrownBy(() -> JsonSourceWrapper.isSingleKeyObject(null))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("source cannot be null");
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/KeyValueSourceWrapperTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/KeyValueSourceWrapperTest.java
@@ -26,6 +26,18 @@ class KeyValueSourceWrapperTest {
   }
 
   @Test
+  void withPolicyTypeRemapsKeyWithoutMutatingSource() {
+    KeyValueSourceWrapper source = new KeyValueSourceWrapper("external", "0.5");
+
+    KeyValueSourceWrapper remapped =
+        (KeyValueSourceWrapper) source.withPolicyType("trace-sampling");
+
+    assertThat(remapped.getKey()).isEqualTo("trace-sampling");
+    assertThat(remapped.getValue()).isEqualTo("0.5");
+    assertThat(source.getKey()).isEqualTo("external");
+  }
+
+  @Test
   void parseSupportsMultipleLinesAndSkipsBlanks() {
     String source = "\ntrace-sampling=0.5\r\nother-policy=1.0\n   \n";
 

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/source/SourceFormatTest.java
@@ -87,9 +87,7 @@ class SourceFormatTest {
   void parseReturnsNullForInvalidInput() {
     assertThat(SourceFormat.JSONKEYVALUE.parse("{invalid-json", emptySet())).isNull();
     assertThat(SourceFormat.JSONKEYVALUE.parse("{}", emptySet())).isEmpty();
-    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}", singleton("a")))
-        .extracting(SourceWrapper::getPolicyType)
-        .containsExactly("a");
+    assertThat(SourceFormat.JSONKEYVALUE.parse("{\"a\": 1, \"b\": 2}", singleton("a"))).isEmpty();
     assertThat(
             SourceFormat.JSONKEYVALUE.parse(
                 "[{\"trace-sampling\": 0.5}, {}]", singleton("trace-sampling")))

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidatorTest.java
@@ -73,54 +73,51 @@ class TraceSamplingValidatorTest {
         .isCloseTo(probability, within(1e-9));
   }
 
-  /**
-   * Regression: {@link TraceSamplingValidator#validateJsonValue} still accepts the legacy nested
-   * object shape {@code {"trace-sampling": {"probability": <n>}}} used before flat numeric values
-   * were introduced.
-   */
   @Test
-  void testValidate_ValidJson_LegacyObjectShapeWithProbabilityField() {
-    String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": 0.5}}";
-    TelemetryPolicy policy =
-        validator.validate(
-            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
+  void testValidate_ValidJson_FullPolicyStruct() {
+    TelemetryPolicy policy = validateJson(fullPolicyStructForRatio("0.1"));
+
     assertThat(policy).isNotNull();
     assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
     assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
-    assertThat(((TraceSamplingRatePolicy) policy).getIdentity())
-        .isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
-    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.5, within(1e-9));
+    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.1, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_FullPolicyStructWithOptionalFields() {
+    String json =
+        "{"
+            + "\"id\":\"trace-sampling\","
+            + "\"name\":\"Trace sampling rate\","
+            + "\"description\":\"Set the global trace sampling rate to 10%.\","
+            + "\"enabled\":true,"
+            + "\"created_at_unix_nano\":\"1718890000000000000\","
+            + "\"modified_at_unix_nano\":\"1718893600000000000\","
+            + "\"labels\":[{\"key\":\"policy.scope\","
+            + "\"value\":{\"string_value\":\"global\"}}],"
+            + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true,"
+            + "\"negate\":false,\"case_insensitive\":false}],"
+            + "\"keep\":{\"probability\":0.1,\"mode\":\"proportional\","
+            + "\"sampling_precision\":6,\"hash_seed\":0,\"fail_closed\":false}}"
+            + "}";
+
+    TelemetryPolicy policy = validateJson(json);
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.1, within(1e-9));
   }
 
   @ParameterizedTest
   @ValueSource(doubles = {0.0, 1.0})
-  void testValidate_ValidJson_LegacyObjectShape_BoundaryValues(double probability) {
-    String json =
-        "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": " + probability + "}}";
-    TelemetryPolicy policy =
-        validator.validate(
-            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
-    assertThat(policy).isNotNull();
-    assertThat(((TraceSamplingRatePolicy) policy).getProbability())
-        .isCloseTo(probability, within(1e-9));
-  }
+  void testValidate_ValidJson_FullPolicyStructRatioBoundaries(double ratio) {
+    TelemetryPolicy policy = validateJson(fullPolicyStructForRatio(Double.toString(ratio)));
 
-  /**
-   * String probabilities in JSON (object or flat) are accepted via {@code parseDouble} on textual
-   * nodes — keeps migration-compatible configs that quote numeric values.
-   */
-  @Test
-  void testValidate_ValidJson_ProbabilityAsQuotedStringInLegacyObject() {
-    String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": \"0.625\"}}";
-    TelemetryPolicy policy =
-        validator.validate(
-            first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
     assertThat(policy).isNotNull();
-    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.625, within(1e-9));
+    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(ratio, within(1e-9));
   }
 
   @Test
-  void testValidate_ValidJson_ProbabilityAsQuotedStringFlat() {
+  void testValidate_ValidJson_RatioAsQuotedStringFlat() {
     String json = "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"0.375\"}";
     TelemetryPolicy policy =
         validator.validate(
@@ -146,6 +143,34 @@ class TraceSamplingValidatorTest {
             validator.validate(
                 first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM))
         .isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"-0.1", "1.1"})
+  void testValidate_InvalidJson_FullPolicyRatioOutOfRange(String ratio) {
+    assertThat(validateJson(fullPolicyStructForRatio(ratio))).isNull();
+  }
+
+  @Test
+  void testValidate_InvalidJson_FullPolicyMissingRatio() {
+    assertThat(
+            validateJson(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                    + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+                    + "\"keep\":{}}}"))
+        .isNull();
+  }
+
+  @Test
+  void testValidate_ValidJson_DoesNotInterpretGenericMatchConcern() {
+    TelemetryPolicy policy =
+        validateJson(
+            "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling rate\","
+                + "\"trace\":{\"match\":[{\"span_attribute\":[\"db.system\"],\"exists\":true}],"
+                + "\"keep\":{\"probability\":0.1}}}");
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingRatePolicy) policy).getProbability()).isCloseTo(0.1, within(1e-9));
   }
 
   @Test
@@ -191,6 +216,24 @@ class TraceSamplingValidatorTest {
 
   private static String jsonForProbability(double probability) {
     return "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": " + probability + "}";
+  }
+
+  private TelemetryPolicy validateJson(String json) {
+    return validator.validate(
+        first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
+  }
+
+  private static String fullPolicyStructForRatio(String ratio) {
+    return "{"
+        + "\"id\":\""
+        + TRACE_SAMPLING_POLICY_TYPE
+        + "\","
+        + "\"name\":\"Trace sampling rate\","
+        + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+        + "\"keep\":{\"probability\":"
+        + ratio
+        + "}}"
+        + "}";
   }
 
   private static SourceWrapper first(List<SourceWrapper> parsedSources) {


### PR DESCRIPTION
**Description:**

Align to spec, supporting the [fuller message structure](https://github.com/open-telemetry/opentelemetry-specification/pull/4738#issuecomment-4766896657) for JSON structures.

Primarily this adds parsing in the JsonSourceWrapper, and some smaller changes in other classes that use that source wrapper supported by a new interface method. Plus a bunch of tests

**Existing Issue(s):**

#2868

**Testing:**

changed as needed

**Documentation:**

changed as needed

**Outstanding items:**

#2868