### PR TITLE
Prefer Lambda X-Ray trace header from carrier

### DIFF
--- a/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayLambdaPropagator.java
+++ b/aws-xray-propagator/src/main/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayLambdaPropagator.java
@@ -13,6 +13,7 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -38,6 +39,8 @@ public final class AwsXrayLambdaPropagator implements TextMapPropagator {
 
   private static final String AWS_TRACE_HEADER_ENV_KEY = "_X_AMZN_TRACE_ID";
   private static final String AWS_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
+  private static final String AWS_TRACE_HEADER_PROP_LOWERCASE =
+      AWS_TRACE_HEADER_PROP.toLowerCase(Locale.ROOT);
   private final AwsXrayPropagator xrayPropagator = AwsXrayPropagator.getInstance();
   private static final AwsXrayLambdaPropagator INSTANCE = new AwsXrayLambdaPropagator();
 
@@ -67,7 +70,10 @@ public final class AwsXrayLambdaPropagator implements TextMapPropagator {
       return xrayContext;
     }
 
-    String traceHeader = System.getProperty(AWS_TRACE_HEADER_PROP);
+    String traceHeader = getTraceHeaderFromCarrier(carrier, getter);
+    if (isEmptyOrNull(traceHeader)) {
+      traceHeader = System.getProperty(AWS_TRACE_HEADER_PROP);
+    }
     if (isEmptyOrNull(traceHeader)) {
       traceHeader = System.getenv(AWS_TRACE_HEADER_ENV_KEY);
     }
@@ -83,6 +89,18 @@ public final class AwsXrayLambdaPropagator implements TextMapPropagator {
   @Override
   public String toString() {
     return "AwsXrayLambdaPropagator";
+  }
+
+  @Nullable
+  private static <C> String getTraceHeaderFromCarrier(
+      @Nullable C carrier, TextMapGetter<C> getter) {
+    if (carrier == null || getter == null) {
+      return null;
+    }
+    String traceHeader = getter.get(carrier, AWS_TRACE_HEADER_PROP);
+    return !isEmptyOrNull(traceHeader)
+        ? traceHeader
+        : getter.get(carrier, AWS_TRACE_HEADER_PROP_LOWERCASE);
   }
 
   private static boolean isEmptyOrNull(@Nullable String value) {

--- a/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayLambdaPropagatorTest.java
+++ b/aws-xray-propagator/src/test/java/io/opentelemetry/contrib/awsxray/propagator/AwsXrayLambdaPropagatorTest.java
@@ -19,6 +19,7 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.LinkData;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,6 +99,44 @@ class AwsXrayLambdaPropagatorTest extends AwsXrayPropagatorTest {
   }
 
   @Test
+  void extract_carrierTraceHeaderBeforeSystemPropertyAndEnvironmentVariable() {
+    Map<String, String> carrier =
+        Collections.singletonMap(
+            "com.amazonaws.xray.traceHeader",
+            "Root=1-00000003-240000000000000000000003;Parent=1600000000000003;Sampled=1;Foo=Qux");
+    environmentVariables.set(
+        "_X_AMZN_TRACE_ID",
+        "Root=1-00000001-240000000000000000000001;Parent=1600000000000001;Sampled=1;Foo=Bar");
+    systemProperties.set(
+        "com.amazonaws.xray.traceHeader",
+        "Root=1-00000002-240000000000000000000002;Parent=1600000000000002;Sampled=1;Foo=Baz");
+
+    assertThat(getSpanContext(propagator().extract(Context.current(), carrier, GETTER)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                "00000003240000000000000000000003",
+                "1600000000000003",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+  }
+
+  @Test
+  void extract_lowercaseCarrierTraceHeader() {
+    Map<String, String> carrier =
+        Collections.singletonMap(
+            "com.amazonaws.xray.traceheader",
+            "Root=1-00000003-240000000000000000000003;Parent=1600000000000003;Sampled=1;Foo=Qux");
+
+    assertThat(getSpanContext(propagator().extract(Context.current(), carrier, GETTER)))
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                "00000003240000000000000000000003",
+                "1600000000000003",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+  }
+
+  @Test
   void addLink_SystemProperty() {
     Map<String, String> carrier =
         Collections.singletonMap(
@@ -107,6 +146,45 @@ class AwsXrayLambdaPropagatorTest extends AwsXrayPropagatorTest {
         "_X_AMZN_TRACE_ID",
         "Root=1-00000002-240000000000000000000002;Parent=1600000000000002;Sampled=1;Foo=Bar");
     systemProperties.set(
+        "com.amazonaws.xray.traceHeader",
+        "Root=1-00000003-240000000000000000000003;Parent=1600000000000003;Sampled=1;Foo=Baz");
+
+    Context extract = propagator().extract(Context.current(), carrier, GETTER);
+    ReadableSpan span =
+        (ReadableSpan)
+            tracer
+                .spanBuilder("test")
+                .setParent(extract)
+                .addLink(
+                    Span.fromContext(propagator().extract(extract, carrier, GETTER))
+                        .getSpanContext())
+                .startSpan();
+    assertThat(span.getParentSpanContext())
+        .isEqualTo(
+            SpanContext.createFromRemoteParent(
+                "00000003240000000000000000000003",
+                "1600000000000003",
+                TraceFlags.getSampled(),
+                TraceState.getDefault()));
+
+    assertThat(span.toSpanData().getLinks())
+        .isEqualTo(
+            Collections.singletonList(
+                LinkData.create(
+                    SpanContext.createFromRemoteParent(
+                        "00000001240000000000000000000001",
+                        "1600000000000001",
+                        TraceFlags.getSampled(),
+                        TraceState.getDefault()))));
+  }
+
+  @Test
+  void addLink_CarrierTraceHeader() {
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put(
+        TRACE_HEADER_KEY,
+        "Root=1-00000001-240000000000000000000001;Parent=1600000000000001;Sampled=1");
+    carrier.put(
         "com.amazonaws.xray.traceHeader",
         "Root=1-00000003-240000000000000000000003;Parent=1600000000000003;Sampled=1;Foo=Baz");
 


### PR DESCRIPTION
## Summary
- read `com.amazonaws.xray.traceHeader` from the extraction carrier before falling back to the system property and `_X_AMZN_TRACE_ID`
- keep existing request `X-Amzn-Trace-Id` extraction behavior so it can still be used as a span link when active tracing provides the parent
- handle the lowercase carrier key used by the Java instrumentation map getter

Refs open-telemetry/opentelemetry-java-instrumentation#15517
Companion instrumentation PR: open-telemetry/opentelemetry-java-instrumentation#19438

## Testing
- `./gradlew :aws-xray-propagator:test --tests io.opentelemetry.contrib.awsxray.propagator.AwsXrayLambdaPropagatorTest`
- `./gradlew :aws-xray-propagator:spotlessCheck`
- `git diff --check`
