### PR TITLE
[dynamic control] refactor TraceSamplingRatePolicy to allow percent and ratio

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
+import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Shared representation and runtime wiring for trace sampling policies. */
+public abstract class AbstractTraceSamplingPolicy implements TelemetryPolicy {
+  @Nullable private static volatile DelegatingSampler initializedSampler;
+
+  private final TelemetryPolicyIdentity identity;
+  private final double samplingProbability;
+  private final SourceKind sourceKind;
+
+  protected AbstractTraceSamplingPolicy(
+      TelemetryPolicyIdentity identity, double samplingProbability, SourceKind sourceKind) {
+    this.identity = Objects.requireNonNull(identity, "identity cannot be null");
+    this.samplingProbability = normalizeProbability(samplingProbability);
+    this.sourceKind = Objects.requireNonNull(sourceKind, "sourceKind cannot be null");
+  }
+
+  @Override
+  public final TelemetryPolicyIdentity getIdentity() {
+    return identity;
+  }
+
+  @Override
+  public final SourceKind getSourceKind() {
+    return sourceKind;
+  }
+
+  /** Returns this policy value converted to an SDK sampling probability in {@code [0.0, 1.0]}. */
+  public final double getSamplingProbability() {
+    return samplingProbability;
+  }
+
+  protected static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
+    Objects.requireNonNull(autoConfiguration, "autoConfiguration cannot be null");
+    DelegatingSampler delegatingSampler = new DelegatingSampler(createSampler(1.0));
+    initializedSampler = delegatingSampler;
+    autoConfiguration.addSamplerCustomizer((sampler, config) -> delegatingSampler);
+    return new TraceSamplingRatePolicyImplementer(delegatingSampler);
+  }
+
+  /**
+   * Creates the composed sampler used for a normalized sampling probability.
+   *
+   * @param probability sampling probability in the inclusive range {@code [0.0, 1.0]}
+   */
+  public static Sampler createSampler(double probability) {
+    probability = normalizeProbability(probability);
+    return CompositeSampler.wrap(
+        ComposableSampler.parentThreshold(ComposableSampler.probability(probability)));
+  }
+
+  protected static double normalizeProbability(double probability) {
+    if (Double.isNaN(probability) || probability < 0.0 || probability > 1.0) {
+      throw new IllegalArgumentException("probability must be within [0.0, 1.0]");
+    }
+    // handle -0.0
+    return probability == 0.0 ? 0.0 : probability;
+  }
+
+  @Nullable
+  public static DelegatingSampler getInitializedSampler() {
+    return initializedSampler;
+  }
+
+  static void resetForTest() {
+    initializedSampler = null;
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -6,47 +6,28 @@
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
-import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
-import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
-import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
-import java.util.Objects;
 import javax.annotation.Nullable;
 
-public final class TraceSamplingRatePolicy implements TelemetryPolicy {
+public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
   public static final String POLICY_TYPE = "trace-sampling";
   public static final TelemetryPolicyIdentity DEFAULT_IDENTITY =
       new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
 
-  @Nullable private static volatile DelegatingSampler initializedSampler;
-
-  private final TelemetryPolicyIdentity identity;
   private final double probability;
-  private final SourceKind sourceKind;
 
   public TraceSamplingRatePolicy(double probability, SourceKind sourceKind) {
-    this.identity = DEFAULT_IDENTITY;
-    this.probability = normalizeProbability(probability);
-    this.sourceKind = Objects.requireNonNull(sourceKind, "sourceKind cannot be null");
-  }
-
-  @Override
-  public TelemetryPolicyIdentity getIdentity() {
-    return identity;
+    super(DEFAULT_IDENTITY, probability, sourceKind);
+    this.probability = getSamplingProbability();
   }
 
   @Override
   public String getType() {
     return POLICY_TYPE;
-  }
-
-  @Override
-  public SourceKind getSourceKind() {
-    return sourceKind;
   }
 
   public double getProbability() {
@@ -60,12 +41,7 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
    * overrides any other sampler
    */
   public static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
-    Objects.requireNonNull(autoConfiguration, "autoConfiguration cannot be null");
-    Sampler initialDelegate = createSampler(1.0);
-    DelegatingSampler delegatingSampler = new DelegatingSampler(initialDelegate);
-    initializedSampler = delegatingSampler;
-    autoConfiguration.addSamplerCustomizer((sampler, config) -> delegatingSampler);
-    return new TraceSamplingRatePolicyImplementer(delegatingSampler);
+    return AbstractTraceSamplingPolicy.initialize(autoConfiguration);
   }
 
   public static void registerPolicyType() {
@@ -81,25 +57,15 @@ public final class TraceSamplingRatePolicy implements TelemetryPolicy {
    * @throws IllegalArgumentException if probability is NaN or outside {@code [0.0, 1.0]}
    */
   public static Sampler createSampler(double probability) {
-    probability = normalizeProbability(probability);
-    return CompositeSampler.wrap(
-        ComposableSampler.parentThreshold(ComposableSampler.probability(probability)));
-  }
-
-  private static double normalizeProbability(double probability) {
-    if (Double.isNaN(probability) || probability < 0.0 || probability > 1.0) {
-      throw new IllegalArgumentException("probability must be within [0.0, 1.0]");
-    }
-    // Normalize -0.0 to +0.0 so idempotent update checks stay intuitive.
-    return probability == 0.0 ? 0.0 : probability;
+    return AbstractTraceSamplingPolicy.createSampler(probability);
   }
 
   @Nullable
   public static DelegatingSampler getInitializedSampler() {
-    return initializedSampler;
+    return AbstractTraceSamplingPolicy.getInitializedSampler();
   }
 
   static void resetForTest() {
-    initializedSampler = null;
+    AbstractTraceSamplingPolicy.resetForTest();
   }
 }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
@@ -14,9 +14,15 @@ import static org.mockito.Mockito.verify;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class TraceSamplingRatePolicyTest {
+
+  @AfterEach
+  void tearDown() {
+    TraceSamplingRatePolicy.resetForTest();
+  }
 
   @Test
   void constructorStoresProbabilityAndType() {
@@ -24,6 +30,7 @@ class TraceSamplingRatePolicyTest {
 
     assertThat(policy.getIdentity()).isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
     assertThat(policy.getProbability()).isEqualTo(0.25);
+    assertThat(policy.getSamplingProbability()).isEqualTo(0.25);
     assertThat(policy.getType()).isEqualTo(TraceSamplingRatePolicy.POLICY_TYPE);
     assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
   }


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the first step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- THIS PR: trace sampling policy refactored to abstract superclass and concrete class
- validator refactored to abstract superclass and concrete class
- integrate the validators to policy wiring
- create/convert the ratio/percentage policy concrete classes
- add docs

also #2868