### PR TITLE
Limit Gradle cache writers and converge Develocity caches

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -6,6 +6,7 @@ on:
       cache-read-only:
         type: boolean
         required: false
+        default: true
       no-build-cache:
         type: boolean
         required: false
@@ -37,7 +38,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Spotless
         run: ./gradlew spotlessCheck ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
@@ -61,6 +62,8 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: ${{ inputs.cache-read-only }}
+          gradle-home-cache-excludes: >-
+            ${{ !inputs.cache-read-only && secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && 'caches/build-cache-1' || '' }}
 
       - name: Build
         run: ./gradlew build -x spotlessCheck -PskipTests=true ${{ inputs.no-build-cache && '--no-build-cache' || '' }}
@@ -123,7 +126,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ inputs.cache-read-only }}
+          cache-read-only: true
 
       - name: Test
         shell: bash

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -13,6 +13,7 @@ jobs:
   common:
     uses: ./.github/workflows/build-common.yml
     with:
+      cache-read-only: true
       no-build-cache: true
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -39,6 +40,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build and publish snapshots
         # Disable parallel due to Sonatype's HTTP 429 rate limiting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   common:
     uses: ./.github/workflows/build-common.yml
+    with:
+      cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,8 @@ jobs:
         # but does not build or publish release artifacts.
         if: matrix.language == 'java'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build project and download dependencies
         run: ./gradlew build -x test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   common:
     uses: ./.github/workflows/build-common.yml
+    with:
+      cache-read-only: true
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -97,6 +99,8 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build and publish artifacts
         if: ${{ !inputs.already-published }}
@@ -262,6 +266,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Update apidiff baseline
         env:

--- a/.github/workflows/sonatype-guide-dependency-audit-daily.yml
+++ b/.github/workflows/sonatype-guide-dependency-audit-daily.yml
@@ -26,6 +26,8 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - id: audit
         # --no-parallel is needed to avoid OverlappingFileLockException on the shared OSS Index cache

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,9 @@ dependencyResolutionManagement {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
+val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
+val shouldDisableLocalBuildCache =
+  isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 develocity {
   if (develocityAccessKey.isNotEmpty()) {
@@ -58,9 +61,16 @@ develocity {
 }
 
 buildCache {
-  remote(HttpBuildCache::class) {
-    url = uri("$develocityServer/cache/")
-    isPush = isCI && develocityAccessKey.isNotEmpty()
+  // A task loaded from the local build cache is never pushed to the remote build cache, so on main
+  // builds that write the remote cache the local cache is disabled, otherwise everything that
+  // doesn't change is served locally, never re-executed, and never reaches the remote cache.
+  local {
+    isEnabled = !shouldDisableLocalBuildCache
+  }
+
+  remote(develocity.buildCache) {
+    server = develocityServer
+    isPush = isRemoteBuildCachePushEnabled
   }
 }
 


### PR DESCRIPTION
Applies the cache fixes from [opentelemetry-java-instrumentation#19532](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19532) and [opentelemetry-java-instrumentation#19533](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19533) to reduce GitHub Actions cache pressure and improve Develocity remote cache coverage.