### PR TITLE
Group weekly minor Renovate updates into the patch PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
     {
       // reduces the number of Renovate PRs
       // (patch updates are typically non-breaking)
-      groupName: 'all patch versions',
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
       ],
@@ -32,10 +32,23 @@
       ],
     },
     {
-      // avoids these Renovate PRs from trickling in throughout the week
-      // (consolidating the review process)
+      // group minor updates into the same weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding updates land individually)
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'minor',
+      ],
+      schedule: [
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry:**',
+        '!io.opentelemetry.*:**',
+      ],
+    },
+    {
+      // majors stay individual, but arrive on the weekly schedule
+      matchUpdateTypes: [
         'major',
       ],
       schedule: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
     {
       // reduces the number of Renovate PRs
       // (patch updates are typically non-breaking)
+      // (OpenTelemetry updates are excluded so that dogfooding updates land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -30,10 +31,15 @@
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
+      matchPackageNames: [
+        '!io.opentelemetry:**',
+        '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
+      ],
     },
     {
       // group minor updates into the same weekly PR
-      // (OpenTelemetry artifacts are excluded so that dogfooding updates land individually)
+      // (OpenTelemetry updates are excluded so that dogfooding updates land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'minor',
@@ -44,6 +50,7 @@
       matchPackageNames: [
         '!io.opentelemetry:**',
         '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
       ],
     },
     {
@@ -57,6 +64,7 @@
       matchPackageNames: [
         '!io.opentelemetry:**',
         '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
       ],
     },
     {


### PR DESCRIPTION
Minor dependency updates were already scheduled for Tuesday mornings, but they had no `groupName`, so every one of them opened its own pull request. That turns the weekly window into a burst of roughly 37 separate pull requests per 90 days. This change gives minor updates the same group as patch updates, renamed to `all patch and minor versions`, so that burst becomes a single pull request.

Major updates keep their own pull request each, and they stay on the same weekly schedule.

OpenTelemetry updates keep arriving individually and immediately, across patch, minor, and major. All three scheduling rules now exclude the Maven coordinates `io.opentelemetry:**` and `io.opentelemetry.*:**` along with GitHub-sourced dependencies under `open-telemetry/**`, so dogfooding and cascaded releases are never batched.

Extending that exclusion to patch updates is a small deliberate change to how things work today. Patch updates currently carry no exclusion at all, which means OpenTelemetry patches get grouped. That contradicts the intent, so this fixes it.

Two side effects worth knowing about. Docker tag bumps for `otel/opentelemetry-collector-contrib` and `otel/weaver` will join the weekly group, which is intended, since they are test infrastructure rather than cascaded releases. Minor `flint-managed linter updates` will also fold into the weekly group, because this repository's `packageRules` are applied after the `grafana/flint` preset.