### PR TITLE
Group weekly minor Renovate updates into the patch PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
     {
       // reduces the number of Renovate PRs
       // (patch updates are typically non-breaking)
-      groupName: 'all patch versions',
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
       ],
@@ -32,10 +32,23 @@
       ],
     },
     {
-      // avoids these Renovate PRs from trickling in throughout the week
-      // (consolidating the review process)
+      // group minor updates into the same weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding updates land individually)
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'minor',
+      ],
+      schedule: [
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry:**',
+        '!io.opentelemetry.*:**',
+      ],
+    },
+    {
+      // majors stay individual, but arrive on the weekly schedule
+      matchUpdateTypes: [
         'major',
       ],
       schedule: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
     {
       // reduces the number of Renovate PRs
       // (patch updates are typically non-breaking)
+      // (OpenTelemetry updates are excluded so that dogfooding updates land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -30,10 +31,15 @@
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
       ],
+      matchPackageNames: [
+        '!io.opentelemetry:**',
+        '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
+      ],
     },
     {
       // group minor updates into the same weekly PR
-      // (OpenTelemetry artifacts are excluded so that dogfooding updates land individually)
+      // (OpenTelemetry updates are excluded so that dogfooding updates land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'minor',
@@ -44,6 +50,7 @@
       matchPackageNames: [
         '!io.opentelemetry:**',
         '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
       ],
     },
     {
@@ -57,6 +64,7 @@
       matchPackageNames: [
         '!io.opentelemetry:**',
         '!io.opentelemetry.*:**',
+        '!open-telemetry/**',
       ],
     },
     {


### PR DESCRIPTION
Minor dependency updates were already scheduled for Tuesday mornings, but they had no `groupName`, so each one opened its own pull request, roughly 37 per 90 days all arriving in the same window. They now share the patch group, renamed `all patch and minor versions`, so that burst becomes a single pull request.

Major updates still get their own pull request each, on the same weekly schedule.

OpenTelemetry updates keep arriving individually and immediately, across patch, minor, and major, so dogfooding and cascaded releases are never batched. Patch updates carried no exclusion before, which meant OpenTelemetry patches were grouped against the intent; that is fixed here.

`otel/opentelemetry-collector-contrib` and `otel/weaver` image bumps join the weekly group deliberately, since they are test infrastructure rather than cascaded releases.
