### PR TITLE
[dynamic control] Trace sampling validator refactored to abstract superclass and concrete class

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.contrib.dynamic.policy.AbstractSourcePolicyValidator;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import javax.annotation.Nullable;
+
+/** Shared parsing for numeric trace sampling policy values. */
+abstract class AbstractTraceSamplingValidator extends AbstractSourcePolicyValidator {
+  private final String valueKeyword;
+
+  AbstractTraceSamplingValidator(String valueKeyword) {
+    this.valueKeyword = valueKeyword;
+  }
+
+  @Override
+  @Nullable
+  protected final TelemetryPolicy validateJsonValue(JsonNode valueNode, SourceKind sourceKind) {
+    JsonNode numericNode = valueNode;
+    if (valueNode.isObject()) {
+      numericNode = valueNode.get(valueKeyword);
+      if (numericNode == null) {
+        return null;
+      }
+    }
+    Double value = parseDouble(numericNode);
+    return value == null ? null : createPolicy(value, sourceKind);
+  }
+
+  @Override
+  @Nullable
+  protected final TelemetryPolicy validateKeyValueValue(String value, SourceKind sourceKind) {
+    Double numericValue = parseDouble(value);
+    return numericValue == null ? null : createPolicy(numericValue, sourceKind);
+  }
+
+  @Nullable
+  protected abstract TelemetryPolicy createPolicy(double value, SourceKind sourceKind);
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingValidator.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import io.opentelemetry.contrib.dynamic.policy.AbstractSourcePolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import java.util.logging.Logger;
@@ -17,8 +15,12 @@ import javax.annotation.Nullable;
  *
  * <p>This validator handles the "trace-sampling" policy type.
  */
-public final class TraceSamplingValidator extends AbstractSourcePolicyValidator {
+public final class TraceSamplingValidator extends AbstractTraceSamplingValidator {
   private static final Logger logger = Logger.getLogger(TraceSamplingValidator.class.getName());
+
+  public TraceSamplingValidator() {
+    super("probability");
+  }
 
   @Override
   public String getPolicyType() {
@@ -27,33 +29,7 @@ public final class TraceSamplingValidator extends AbstractSourcePolicyValidator 
 
   @Override
   @Nullable
-  protected TelemetryPolicy validateJsonValue(JsonNode valueNode, SourceKind sourceKind) {
-    JsonNode probabilityNode = valueNode;
-    if (valueNode.isObject()) {
-      probabilityNode = valueNode.get("probability");
-      if (probabilityNode == null) {
-        return null;
-      }
-    }
-    Double probability = parseDouble(probabilityNode);
-    if (probability == null) {
-      return null;
-    }
-    return createPolicy(probability, sourceKind);
-  }
-
-  @Override
-  @Nullable
-  protected TelemetryPolicy validateKeyValueValue(String value, SourceKind sourceKind) {
-    Double probability = parseDouble(value);
-    if (probability == null) {
-      return null;
-    }
-    return createPolicy(probability, sourceKind);
-  }
-
-  @Nullable
-  private static TelemetryPolicy createPolicy(double probability, SourceKind sourceKind) {
+  protected TelemetryPolicy createPolicy(double probability, SourceKind sourceKind) {
     try {
       return new TraceSamplingRatePolicy(probability, sourceKind);
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the second step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- DONE: trace sampling policy refactored to abstract superclass and concrete class #3050
- THIS PR: validator refactored to abstract superclass and concrete class
- integrate the validators to policy wiring
- create/convert the ratio/percentage policy concrete classes
- add docs
- cleanup (a bit of renaming)

also #2868