### PR TITLE
[dynamic control] Integrate the validators to policy wiring

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
@@ -13,6 +14,7 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.ComposableSampler;
 import io.opentelemetry.sdk.extension.incubator.trace.samplers.CompositeSampler;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
+import java.util.Collections;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -46,12 +48,18 @@ public abstract class AbstractTraceSamplingPolicy implements TelemetryPolicy {
     return samplingProbability;
   }
 
-  protected static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
+  protected static synchronized PolicyImplementer initialize(
+      AutoConfigurationCustomizer autoConfiguration, PolicyValidator validator) {
     Objects.requireNonNull(autoConfiguration, "autoConfiguration cannot be null");
-    DelegatingSampler delegatingSampler = new DelegatingSampler(createSampler(1.0));
-    initializedSampler = delegatingSampler;
-    autoConfiguration.addSamplerCustomizer((sampler, config) -> delegatingSampler);
-    return new TraceSamplingRatePolicyImplementer(delegatingSampler);
+    Objects.requireNonNull(validator, "validator cannot be null");
+    if (initializedSampler == null) {
+      DelegatingSampler delegatingSampler = new DelegatingSampler(createSampler(1.0));
+      initializedSampler = delegatingSampler;
+      autoConfiguration.addSamplerCustomizer((sampler, config) -> delegatingSampler);
+    }
+    return new TraceSamplingRatePolicyImplementer(
+        Objects.requireNonNull(initializedSampler, "initializedSampler cannot be null"),
+        Collections.singletonList(validator));
   }
 
   /**

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -41,7 +41,7 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
    * overrides any other sampler
    */
   public static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
-    return AbstractTraceSamplingPolicy.initialize(autoConfiguration);
+    return initialize(autoConfiguration, new TraceSamplingValidator());
   }
 
   public static void registerPolicyType() {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyImplementer.java
@@ -8,23 +8,17 @@ package io.opentelemetry.contrib.dynamic.policy.tracesampling;
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.PolicyValidator;
 import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
 
 /**
- * Implements the {@code trace-sampling} policy by updating a {@link DelegatingSampler}.
+ * Implements trace sampling policies by updating a {@link DelegatingSampler}.
  *
- * <p>This implementer listens for validated {@link TelemetryPolicy} updates of type {@code
- * "trace-sampling"} and applies {@link TraceSamplingRatePolicy#getProbability()} to the delegate
- * sampler via {@link TraceSamplingRatePolicy#createSampler(double)}.
- *
- * <p>If a deleted policy of type {@code "trace-sampling"} is received, it is treated as policy
- * removal and the delegate is reset using {@code TraceSamplingRatePolicy.createSampler(1.0)}.
- *
- * <p>Validation is performed by {@link TraceSamplingValidator}; this implementer only consumes
- * policies produced by that validator.
+ * <p>Policy representations are converted to a normalized sampling probability before being
+ * applied.
  *
  * <p>This class is thread-safe. Calls to {@link #onPoliciesChanged(List)} can occur concurrently
  * with sampling operations on the associated {@link DelegatingSampler}.
@@ -37,6 +31,7 @@ public final class TraceSamplingRatePolicyImplementer implements PolicyImplement
       Collections.<PolicyValidator>singletonList(new TraceSamplingValidator());
 
   private final DelegatingSampler delegatingSampler;
+  private final List<PolicyValidator> validators;
 
   /**
    * Creates a new implementer that updates the provided {@link DelegatingSampler}.
@@ -44,31 +39,48 @@ public final class TraceSamplingRatePolicyImplementer implements PolicyImplement
    * @param delegatingSampler the sampler to update when policies change
    */
   public TraceSamplingRatePolicyImplementer(DelegatingSampler delegatingSampler) {
-    Objects.requireNonNull(delegatingSampler, "delegatingSampler cannot be null");
-    this.delegatingSampler = delegatingSampler;
+    this(delegatingSampler, VALIDATORS);
+  }
+
+  TraceSamplingRatePolicyImplementer(
+      DelegatingSampler delegatingSampler, List<PolicyValidator> validators) {
+    this.delegatingSampler =
+        Objects.requireNonNull(delegatingSampler, "delegatingSampler cannot be null");
+    this.validators =
+        Collections.unmodifiableList(
+            new ArrayList<>(Objects.requireNonNull(validators, "validators cannot be null")));
   }
 
   @Override
   public List<PolicyValidator> getValidators() {
-    return VALIDATORS;
+    return validators;
   }
 
   @Override
   public void onPoliciesChanged(List<TelemetryPolicy> policies) {
     for (TelemetryPolicy policy : policies) {
-      if (!TraceSamplingRatePolicy.POLICY_TYPE.equals(policy.getType())) {
+      if (!supports(policy.getType())) {
         continue;
       }
       if (policy.isDeleted()) {
         applySamplingProbability(1.0, "reset");
         continue;
       }
-      if (!(policy instanceof TraceSamplingRatePolicy)) {
+      if (!(policy instanceof AbstractTraceSamplingPolicy)) {
         continue;
       }
-      double ratio = ((TraceSamplingRatePolicy) policy).getProbability();
-      applySamplingProbability(ratio, "update");
+      double probability = ((AbstractTraceSamplingPolicy) policy).getSamplingProbability();
+      applySamplingProbability(probability, "update");
     }
+  }
+
+  private boolean supports(String policyType) {
+    for (PolicyValidator validator : validators) {
+      if (validator.getPolicyType().equals(policyType)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void applySamplingProbability(double probability, String action) {


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the third step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- DONE: trace sampling policy refactored to abstract superclass and concrete class #3050
- DONE: validator refactored to abstract superclass and concrete class #3070 
- THIS PR: integrate the validators to policy wiring
- create/convert the ratio/percentage policy concrete classes
- add docs
- cleanup (a bit of renaming)

also #2868