### PR TITLE
Override vulnerable lz4-java dependency

### DIFF
--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -54,9 +54,6 @@ dependencies {
     api("org.bouncycastle:bcprov-jdk18on:1.85.2")
     api("org.junit-pioneer:junit-pioneer:1.9.1")
     api("org.skyscreamer:jsonassert:1.5.3")
-    api("at.yawk.lz4:lz4-java:1.11.2") {
-      because("CVE-2026-59949")
-    }
     api("org.apache.kafka:kafka-clients:4.3.1")
     api("org.testcontainers:testcontainers-kafka:2.0.5")
     api("org.jctools:jctools-core:4.0.7")

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
     api("org.bouncycastle:bcprov-jdk18on:1.85.2")
     api("org.junit-pioneer:junit-pioneer:1.9.1")
     api("org.skyscreamer:jsonassert:1.5.3")
+    api("at.yawk.lz4:lz4-java:1.11.2") {
+      because("CVE-2026-59949")
+    }
     api("org.apache.kafka:kafka-clients:4.3.1")
     api("org.testcontainers:testcontainers-kafka:2.0.5")
     api("org.jctools:jctools-core:4.0.7")

--- a/kafka-exporter/build.gradle.kts
+++ b/kafka-exporter/build.gradle.kts
@@ -24,7 +24,9 @@ dependencies {
 
   runtimeOnly("com.fasterxml.jackson.core:jackson-core")
   runtimeOnly("com.fasterxml.jackson.core:jackson-databind")
-  runtimeOnly("at.yawk.lz4:lz4-java")
+  runtimeOnly("at.yawk.lz4:lz4-java:1.11.2") {
+    because("CVE-2026-59949")
+  }
 
   implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
   implementation("com.google.protobuf:protobuf-java")

--- a/kafka-exporter/build.gradle.kts
+++ b/kafka-exporter/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
   runtimeOnly("com.fasterxml.jackson.core:jackson-core")
   runtimeOnly("com.fasterxml.jackson.core:jackson-databind")
+  runtimeOnly("at.yawk.lz4:lz4-java")
 
   implementation("io.opentelemetry:opentelemetry-exporter-otlp-common")
   implementation("com.google.protobuf:protobuf-java")


### PR DESCRIPTION
Overrides Kafka client's transitive `lz4-java` dependency with `1.11.2`, addressing CVE-2026-59949.

The override is scoped to `opentelemetry-kafka-exporter` and published as a runtime dependency, so Maven and Gradle consumers resolve the fixed version while future higher versions remain compatible.

Related to https://github.com/open-telemetry/opentelemetry-java-contrib/issues/3021