### PR TITLE
Ensure RuleBasedRoutingSampler can use number valued attributes

### DIFF
--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
@@ -69,7 +69,8 @@ public final class RuleBasedRoutingSampler implements Sampler {
       if (samplingRule.attributeKey.getKey().equals(THREAD_NAME.getKey())) {
         attributeValue = Thread.currentThread().getName();
       } else {
-        attributeValue = attributes.get(samplingRule.attributeKey);
+        Object value = attributes.get(samplingRule.attributeKey);
+        attributeValue = value == null ? null : String.valueOf(value);
       }
       if (attributeValue == null) {
         continue;

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java
@@ -66,7 +66,8 @@ public final class RuleBasedRoutingSampler implements Sampler {
     }
     for (SamplingRule samplingRule : rules) {
       String attributeValue;
-      if (samplingRule.attributeKey.getKey().equals(THREAD_NAME.getKey())) {
+      if (samplingRule.attributeKey.getKey().equals(THREAD_NAME.getKey())
+          && samplingRule.attributeKey.getType() == THREAD_NAME.getType()) {
         attributeValue = Thread.currentThread().getName();
       } else {
         Object value = attributes.get(samplingRule.attributeKey);

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
@@ -27,6 +27,11 @@ public final class RuleBasedRoutingSamplerBuilder {
   /**
    * Drop all spans when the value of the provided {@link AttributeKey} matches the provided
    * pattern.
+   *
+   * <p>Non-string attribute values are converted to a string using {@link String#valueOf(Object)}
+   * before the pattern is applied. Consequently, list or array-valued attributes are matched
+   * against their {@link String#valueOf(Object)} representation rather than their individual
+   * elements.
    */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder drop(AttributeKey<?> attributeKey, String pattern) {
@@ -36,6 +41,11 @@ public final class RuleBasedRoutingSamplerBuilder {
   /**
    * Use the provided sampler when the value of the provided {@link AttributeKey} matches the
    * provided pattern.
+   *
+   * <p>Non-string attribute values are converted to a string using {@link String#valueOf(Object)}
+   * before the pattern is applied. Consequently, list or array-valued attributes are matched
+   * against their {@link String#valueOf(Object)} representation rather than their individual
+   * elements.
    */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder customize(
@@ -51,6 +61,11 @@ public final class RuleBasedRoutingSamplerBuilder {
   /**
    * Record and sample all spans when the value of the provided {@link AttributeKey} matches the
    * provided pattern.
+   *
+   * <p>Non-string attribute values are converted to a string using {@link String#valueOf(Object)}
+   * before the pattern is applied. Consequently, list or array-valued attributes are matched
+   * against their {@link String#valueOf(Object)} representation rather than their individual
+   * elements.
    */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder recordAndSample(

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerBuilder.java
@@ -29,7 +29,7 @@ public final class RuleBasedRoutingSamplerBuilder {
    * pattern.
    */
   @CanIgnoreReturnValue
-  public RuleBasedRoutingSamplerBuilder drop(AttributeKey<String> attributeKey, String pattern) {
+  public RuleBasedRoutingSamplerBuilder drop(AttributeKey<?> attributeKey, String pattern) {
     return customize(attributeKey, pattern, Sampler.alwaysOff());
   }
 
@@ -39,7 +39,7 @@ public final class RuleBasedRoutingSamplerBuilder {
    */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder customize(
-      AttributeKey<String> attributeKey, String pattern, Sampler sampler) {
+      AttributeKey<?> attributeKey, String pattern, Sampler sampler) {
     rules.add(
         new SamplingRule(
             requireNonNull(attributeKey, "attributeKey must not be null"),
@@ -54,7 +54,7 @@ public final class RuleBasedRoutingSamplerBuilder {
    */
   @CanIgnoreReturnValue
   public RuleBasedRoutingSamplerBuilder recordAndSample(
-      AttributeKey<String> attributeKey, String pattern) {
+      AttributeKey<?> attributeKey, String pattern) {
     return customize(attributeKey, pattern, Sampler.alwaysOn());
   }
 

--- a/samplers/src/main/java/io/opentelemetry/contrib/sampler/SamplingRule.java
+++ b/samplers/src/main/java/io/opentelemetry/contrib/sampler/SamplingRule.java
@@ -12,11 +12,11 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 class SamplingRule {
-  final AttributeKey<String> attributeKey;
+  final AttributeKey<?> attributeKey;
   final Sampler delegate;
   final Pattern pattern;
 
-  SamplingRule(AttributeKey<String> attributeKey, String pattern, Sampler delegate) {
+  SamplingRule(AttributeKey<?> attributeKey, String pattern, Sampler delegate) {
     this.attributeKey = attributeKey;
     this.pattern = Pattern.compile(pattern);
     this.delegate = delegate;

--- a/samplers/src/test/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerTest.java
+++ b/samplers/src/test/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSamplerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
@@ -196,6 +197,28 @@ class RuleBasedRoutingSamplerTest {
     SamplingResult samplingResult =
         sampler.shouldSample(parentContext, traceId, SPAN_NAME, SPAN_KIND, attributes, emptyList());
     assertThat(samplingResult.getDecision()).isEqualTo(SamplingDecision.DROP);
+  }
+
+  @Test
+  void testDropOnLongAttribute() {
+    AttributeKey<Long> statusCode = AttributeKey.longKey("http.response.status_code");
+    RuleBasedRoutingSampler sampler =
+        RuleBasedRoutingSampler.builder(SPAN_KIND, delegate).drop(statusCode, "404").build();
+    Attributes attributes = Attributes.of(statusCode, 404L);
+    SamplingResult samplingResult =
+        sampler.shouldSample(parentContext, traceId, SPAN_NAME, SPAN_KIND, attributes, emptyList());
+    assertThat(samplingResult.getDecision()).isEqualTo(SamplingDecision.DROP);
+  }
+
+  @Test
+  void testRecordAndSampleOnLongAttribute() {
+    AttributeKey<Long> port = AttributeKey.longKey("server.port");
+    RuleBasedRoutingSampler sampler =
+        RuleBasedRoutingSampler.builder(SPAN_KIND, delegate).recordAndSample(port, "8080").build();
+    Attributes attributes = Attributes.of(port, 8080L);
+    SamplingResult samplingResult =
+        sampler.shouldSample(parentContext, traceId, SPAN_NAME, SPAN_KIND, attributes, emptyList());
+    assertThat(samplingResult.getDecision()).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE);
   }
 
   private SamplingResult shouldSample(Sampler sampler, String url) {


### PR DESCRIPTION
**Description:**

Trying to use declarative configuration to remove spans on spring boot management server using port filtering it fails cause value is not a string.

**Existing Issue(s):**

-

**Testing:**

mainly unit tests


