### PR TITLE
Add Azure App Service account and resource group attributes

### DIFF
--- a/azure-resources/README.md
+++ b/azure-resources/README.md
@@ -8,6 +8,7 @@ The following OpenTelemetry semantic conventions will be detected:
 
 | Resource attribute          | VM       | Functions       | App Service       | Containers           |
 | --------------------------- | -------- | --------------- | ----------------- | -------------------- |
+| cloud.account.id            |          |                 | auto              |                      |
 | cloud.platform              | azure.vm | azure.functions | azure.app_service | azure.container_apps |
 | cloud.provider              | azure    | azure           | azure             | azure                |
 | cloud.resource_id           | auto     |                 | auto              |                      |
@@ -24,6 +25,7 @@ The following OpenTelemetry semantic conventions will be detected:
 | service.version             |          |                 |                   | auto                 |
 | service.instance.id         |          |                 | auto              | auto                 |
 | azure.app.service.stamp     |          |                 | auto              |                      |
+| azure.resource_group.name   |          |                 | auto              |                      |
 | faas.name                   |          | auto            |                   |                      |
 | faas.version                |          | auto            |                   |                      |
 | faas.instance               |          | auto            |                   |                      |

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.azure.resource;
 
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_REGION;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_RESOURCE_ID;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CloudPlatformIncubatingValues.AZURE_APP_SERVICE;
@@ -72,7 +74,17 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
     AttributesBuilder builder = AzureVmResourceProvider.azureAttributeBuilder(AZURE_APP_SERVICE);
     builder.put(SERVICE_NAME, name);
 
-    String resourceUri = resourceUri(name);
+    String websiteResourceGroup = env.get(WEBSITE_RESOURCE_GROUP);
+    if (!StringUtils.isNullOrEmpty(websiteResourceGroup)) {
+      builder.put(AZURE_RESOURCE_GROUP_NAME, websiteResourceGroup);
+    }
+
+    String subscriptionId = subscriptionId();
+    if (!StringUtils.isNullOrEmpty(subscriptionId)) {
+      builder.put(CLOUD_ACCOUNT_ID, subscriptionId);
+    }
+
+    String resourceUri = resourceUri(name, websiteResourceGroup, subscriptionId);
     if (resourceUri != null) {
       builder.put(CLOUD_RESOURCE_ID, resourceUri);
     }
@@ -83,17 +95,17 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
   }
 
   @Nullable
-  private String resourceUri(String websiteName) {
-    String websiteResourceGroup = env.get(WEBSITE_RESOURCE_GROUP);
+  private String subscriptionId() {
     String websiteOwnerName = env.get(WEBSITE_OWNER_NAME);
-
-    String subscriptionId;
     if (websiteOwnerName != null && websiteOwnerName.contains("+")) {
-      subscriptionId = websiteOwnerName.substring(0, websiteOwnerName.indexOf("+"));
-    } else {
-      subscriptionId = websiteOwnerName;
+      return websiteOwnerName.substring(0, websiteOwnerName.indexOf("+"));
     }
+    return websiteOwnerName;
+  }
 
+  @Nullable
+  private static String resourceUri(
+      String websiteName, @Nullable String websiteResourceGroup, @Nullable String subscriptionId) {
     if (StringUtils.isNullOrEmpty(websiteResourceGroup)
         || StringUtils.isNullOrEmpty(subscriptionId)) {
       return null;

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/IncubatingAttributes.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/IncubatingAttributes.java
@@ -10,7 +10,13 @@ import io.opentelemetry.api.common.AttributeKey;
 // copied from opentelemetry-semconv-incubating
 final class IncubatingAttributes {
 
+  // azure attributes
+  public static final AttributeKey<String> AZURE_RESOURCE_GROUP_NAME =
+      AttributeKey.stringKey("azure.resource_group.name");
+
   // cloud attributes
+  public static final AttributeKey<String> CLOUD_ACCOUNT_ID =
+      AttributeKey.stringKey("cloud.account.id");
   public static final AttributeKey<String> CLOUD_PLATFORM =
       AttributeKey.stringKey("cloud.platform");
   public static final AttributeKey<String> CLOUD_PROVIDER =

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.contrib.azure.resource;
 
-import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
-import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.semconv.DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.AzureIncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PLATFORM;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PROVIDER;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_REGION;

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.contrib.azure.resource;
 
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.semconv.DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_INSTANCE_ID;
@@ -49,6 +51,8 @@ class AzureAppServiceResourceProviderTest {
         .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(CLOUD_PROVIDER, "azure")
         .containsEntry(CLOUD_PLATFORM, "azure.app_service")
+        .containsEntry(CLOUD_ACCOUNT_ID, TEST_WEBSITE_OWNER_NAME)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
         .containsEntry(
             CLOUD_RESOURCE_ID,
             "/subscriptions/TEST_WEBSITE_OWNER_NAME/resourceGroups/TEST_WEBSITE_RESOURCE_GROUP/providers/Microsoft.Web/sites/TEST_WEBSITE_SITE_NAME")
@@ -67,17 +71,32 @@ class AzureAppServiceResourceProviderTest {
     map.put("WEBSITE_OWNER_NAME", "foo+bar");
 
     createResource(map)
+        .containsEntry(CLOUD_ACCOUNT_ID, "foo")
         .containsEntry(
             CLOUD_RESOURCE_ID,
             "/subscriptions/foo/resourceGroups/TEST_WEBSITE_RESOURCE_GROUP/providers/Microsoft.Web/sites/TEST_WEBSITE_SITE_NAME");
   }
 
   @Test
-  void noResourceId() {
+  void noResourceGroup() {
     HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
     map.remove("WEBSITE_RESOURCE_GROUP");
 
-    createResource(map).doesNotContainKey(CLOUD_RESOURCE_ID);
+    createResource(map)
+        .containsEntry(CLOUD_ACCOUNT_ID, TEST_WEBSITE_OWNER_NAME)
+        .doesNotContainKey(AZURE_RESOURCE_GROUP_NAME)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
+  }
+
+  @Test
+  void noOwner() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.remove("WEBSITE_OWNER_NAME");
+
+    createResource(map)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .doesNotContainKey(CLOUD_ACCOUNT_ID)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
   }
 
   @Test


### PR DESCRIPTION
**Description:**

Update the Azure App Service resource detector to emit:
* `cloud.account.id` - from `WEBSITE_OWNER_NAME` [[sem-conv](https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/#cloud-account-id)]
* `azure.resource_group.name` - from `WEBSITE_RESOURCE_GROUP` [[sem-conv](https://opentelemetry.io/docs/specs/semconv/registry/attributes/azure/#azure-resource-group-name)]

Updated `resourceUri` to take the above values as parameters.

Goal: Align the Java detector with the Azure App Service mapping tracked in [collector-contrib #49616](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49616) and implemented for the Collector in [collector-contrib #50287](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50287).

**AI Disclosure:** Pi Coding Agent was used to draft this PR, but I wrote this PR description and can explain all changes.

**Existing Issue(s):** n/a

**Testing:**

- [x] Unit Tests
- Added assertions for the standalone account and resource-group attributes.
- Added coverage for parsing the subscription ID before `+` in `WEBSITE_OWNER_NAME`.
- Added coverage for independently missing owner and resource-group values.
- [x] Deployed a test app & confirmed the correct attributes were detected.

<img width="1765" height="70" alt="Screenshot 2026-08-28 at 2 19 53 PM" src="https://github.com/user-attachments/assets/bf47f8b6-056a-4bd1-97ab-e5b1c2635065" />

**Documentation:**

This aligns the existing detector with the canonical Azure App Service resource attribute map.

**Outstanding items:**

Did not change `cloud.platform` from `azure_app_service` to `azure.app_service` even though that is the current convention per https://github.com/open-telemetry/semantic-conventions/pull/1698
