### PR TITLE
Exclude slack and ibm links from link check

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -19,5 +19,5 @@ exclude = [
   "^https?://www\\.ibm\\.com/(docs|support)/",
   # groovy-lang.org is frequently unreachable / times out
   "^https?://[^/]*groovy-lang\\.org",
-  "^https://cloud-native.slack.com/", # slack requires auth
+  "^https://cloud-native\\.slack\\.com/", # slack requires auth
 ]

--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -14,6 +14,9 @@ exclude = [
   "^https://github.com/open-telemetry/opentelemetry-java-contrib/(issues|pull)/\\d+$",
   # developer.ibm.com intermittently returns 500 for MQ downloads
   "^https://developer\\.ibm\\.com/articles/mq-downloads/$",
+  # ibm.com docs / knowledge center sit behind a bot wall that 403s every
+  # non-browser request, including real browser user agents
+  "^https?://www\\.ibm\\.com/(docs|support)/",
   # groovy-lang.org is frequently unreachable / times out
   "^https?://[^/]*groovy-lang\\.org",
   "^https://cloud-native.slack.com/", # slack requires auth

--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -16,4 +16,5 @@ exclude = [
   "^https://developer\\.ibm\\.com/articles/mq-downloads/$",
   # groovy-lang.org is frequently unreachable / times out
   "^https?://[^/]*groovy-lang\\.org",
+  "^https://cloud-native.slack.com/", # slack requires auth
 ]


### PR DESCRIPTION
inspired by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19804

we are seeing constant link check failures for the slack channel link and for IBM related links:

```
[403] http://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/sdkpolicyfiles.html (at 152:17) | Rejected status code: 403 Forbidden | Followed 2 redirects. Redirects: http://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/sdkpolicyfiles.html --[301]--> https://www.ibm.com/support/knowledgecenter/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/sdkpolicyfiles.html --[301]--> https://www.ibm.com/docs/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/sdkpolicyfiles.html
[403] https://www.ibm.com/docs/en/ibm-mq/8.0.0?topic=formats-pcf-command-messages (at 206:1) | Rejected status code: 403 Forbidden
[403] https://www.ibm.com/docs/en/ibm-mq/8.0.0?topic=java-ssltls-cipherspecs-ciphersuites-in-mq-classes (at 161:4) | Rejected status code: 403 Forbidden
[403] https://www.ibm.com/docs/en/ibm-mq/8.0.0?topic=tasks-introduction-programmable-command-formats (at 12:1) | Rejected status code: 403 Forbidden
[403] https://www.ibm.com/docs/en/ibm-mq/8.0.0?topic=tasks-introduction-programmable-command-formats (at 201:40) | Error (cached)
[403] https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.1.0/com.ibm.mq.doc/zr00610_.htm (at 235:40) | Rejected status code: 403 Forbidden | Followed 1 redirect. Redirects: https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.1.0/com.ibm.mq.doc/zr00610_.htm --[301]--> https://www.ibm.com/docs/en/SSFKSJ_7.1.0/com.ibm.mq.doc/zr00610_.htm
[403] https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q083240_.htm (at 211:1) | Rejected status code: 403 Forbidden | Followed 1 redirect. Redirects: https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q083240_.htm --[301]--> https://www.ibm.com/docs/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q083240_.htm
[403] https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q086870_.htm (at 202:1) | Rejected status code: 403 Forbidden | Followed 1 redirect. Redirects: https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q086870_.htm --[301]--> https://www.ibm.com/docs/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q086870_.htm

```

hopefully resolves #3066