### PR TITLE
[dynamic control] add TraceSamplingRateValidator

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRateValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRateValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Validator for {@code sampling-rate} policies expressed as ratios. */
+public final class TraceSamplingRateValidator extends AbstractTraceSamplingValidator {
+  private static final Logger logger = Logger.getLogger(TraceSamplingRateValidator.class.getName());
+
+  public TraceSamplingRateValidator() {
+    super("ratio");
+  }
+
+  @Override
+  public String getPolicyType() {
+    return TraceSamplingRatePolicy.POLICY_TYPE;
+  }
+
+  @Override
+  @Nullable
+  protected TelemetryPolicy createPolicy(double ratio, SourceKind sourceKind) {
+    try {
+      return new TraceSamplingRatePolicy(ratio, sourceKind);
+    } catch (IllegalArgumentException e) {
+      logger.info("Invalid sampling-rate ratio '" + ratio + "' will be ignored: " + e.getMessage());
+      return null;
+    }
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRateValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRateValidatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TraceSamplingRateValidatorTest {
+  private static final Set<String> MAPPED_POLICY_IDS =
+      Collections.singleton(TraceSamplingRatePolicy.POLICY_TYPE);
+  private final TraceSamplingRateValidator validator = new TraceSamplingRateValidator();
+
+  @Test
+  void getPolicyTypeReturnsTraceSampling() {
+    assertThat(validator.getPolicyType()).isEqualTo("trace-sampling");
+  }
+
+  @Test
+  void validatesFlatJsonRatio() {
+    TraceSamplingRatePolicy policy = validateJson("{\"trace-sampling\": 0.25}", SourceKind.CUSTOM);
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getSamplingProbability()).isEqualTo(0.25);
+    assertThat(policy.getType()).isEqualTo("trace-sampling");
+  }
+
+  @Test
+  void validatesJsonRatioKeyword() {
+    TraceSamplingRatePolicy policy =
+        validateJson("{\"trace-sampling\": {\"ratio\": 0.75}}", SourceKind.OPAMP);
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getSamplingProbability()).isEqualTo(0.75);
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
+  }
+
+  @Test
+  void rejectsProbabilityKeyword() {
+    assertThat(validateJson("{\"trace-sampling\": {\"probability\": 0.5}}", SourceKind.CUSTOM))
+        .isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {-0.1, 1.1})
+  void rejectsOutOfRangeRatios(double ratio) {
+    assertThat(validateJson("{\"trace-sampling\": " + ratio + "}", SourceKind.CUSTOM)).isNull();
+  }
+
+  @Test
+  void validatesKeyValueRatio() {
+    SourceWrapper source =
+        first(SourceFormat.KEYVALUE.parse("trace-sampling=0.5", MAPPED_POLICY_IDS));
+    TelemetryPolicy policy = validator.validate(source, SourceKind.CUSTOM);
+
+    assertThat(policy).isInstanceOf(TraceSamplingRatePolicy.class);
+    assertThat(((TraceSamplingRatePolicy) policy).getSamplingProbability()).isEqualTo(0.5);
+  }
+
+  private TraceSamplingRatePolicy validateJson(String json, SourceKind sourceKind) {
+    SourceWrapper source = first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS));
+    TelemetryPolicy policy = validator.validate(source, sourceKind);
+    return policy instanceof TraceSamplingRatePolicy ? (TraceSamplingRatePolicy) policy : null;
+  }
+
+  private static SourceWrapper first(List<SourceWrapper> parsedSources) {
+    assertThat(parsedSources).isNotNull();
+    assertThat(parsedSources).isNotEmpty();
+    return parsedSources.get(0);
+  }
+}


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the next step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- DONE: trace sampling policy refactored to abstract superclass and concrete class #3050
- DONE: validator refactored to abstract superclass and concrete class #3070 
- DONE: integrate the validators to policy wiring #3071
- THIS PR (part1) create/convert the ratio/percentage policy concrete classes
- add docs
- cleanup (a bit of renaming)

also #2868