### PR TITLE
Add Azure Functions account and resource group attributes

### DIFF
--- a/azure-resources/README.md
+++ b/azure-resources/README.md
@@ -8,7 +8,7 @@ The following OpenTelemetry semantic conventions will be detected:
 
 | Resource attribute          | VM       | Functions       | App Service       | Containers           |
 | --------------------------- | -------- | --------------- | ----------------- | -------------------- |
-| cloud.account.id            |          |                 | auto              |                      |
+| cloud.account.id            |          | auto            | auto              |                      |
 | cloud.platform              | azure.vm | azure.functions | azure.app_service | azure.container_apps |
 | cloud.provider              | azure    | azure           | azure             | azure                |
 | cloud.resource_id           | auto     |                 | auto              |                      |
@@ -21,11 +21,11 @@ The following OpenTelemetry semantic conventions will be detected:
 | os.version                  | auto     |                 |                   |                      |
 | azure.vm.scaleset.name      | auto     |                 |                   |                      |
 | azure.vm.sku                | auto     |                 |                   |                      |
-| service.name                |          |                 | auto              | auto                 |
+| service.name                |          | auto            | auto              | auto                 |
 | service.version             |          |                 |                   | auto                 |
 | service.instance.id         |          |                 | auto              | auto                 |
 | azure.app.service.stamp     |          |                 | auto              |                      |
-| azure.resource_group.name   |          |                 | auto              |                      |
+| azure.resource_group.name   |          | auto            | auto              |                      |
 | faas.name                   |          | auto            |                   |                      |
 | faas.version                |          | auto            |                   |                      |
 | faas.instance               |          | auto            |                   |                      |

--- a/azure-resources/README.md
+++ b/azure-resources/README.md
@@ -11,9 +11,9 @@ The following OpenTelemetry semantic conventions will be detected:
 | cloud.account.id            |          | auto            | auto              |                      |
 | cloud.platform              | azure.vm | azure.functions | azure.app_service | azure.container_apps |
 | cloud.provider              | azure    | azure           | azure             | azure                |
-| cloud.resource_id           | auto     |                 | auto              |                      |
+| cloud.resource_id           | auto     | auto            | auto              |                      |
 | cloud.region                | auto     | auto            | auto              |                      |
-| deployment.environment.name |          |                 | auto              |                      |
+| deployment.environment.name |          | auto            | auto              |                      |
 | host.id                     | auto     |                 | auto              |                      |
 | host.name                   | auto     |                 |                   |                      |
 | host.type                   | auto     |                 |                   |                      |

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
@@ -36,7 +36,7 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
   private static final String WEBSITE_OWNER_NAME = "WEBSITE_OWNER_NAME";
   private static final String WEBSITE_RESOURCE_GROUP = "WEBSITE_RESOURCE_GROUP";
   static final String WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
-  private static final String WEBSITE_SLOT_NAME = "WEBSITE_SLOT_NAME";
+  static final String WEBSITE_SLOT_NAME = "WEBSITE_SLOT_NAME";
 
   private static final Map<AttributeKey<String>, String> ENV_VAR_MAPPING = new HashMap<>();
 
@@ -104,7 +104,7 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
   }
 
   @Nullable
-  private static String resourceUri(
+  static String resourceUri(
       String websiteName, @Nullable String websiteResourceGroup, @Nullable String subscriptionId) {
     if (StringUtils.isNullOrEmpty(websiteResourceGroup)
         || StringUtils.isNullOrEmpty(subscriptionId)) {

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProvider.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +32,8 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
   private static final String WEBSITE_HOME_STAMPNAME = "WEBSITE_HOME_STAMPNAME";
   private static final String WEBSITE_HOSTNAME = "WEBSITE_HOSTNAME";
   static final String WEBSITE_INSTANCE_ID = "WEBSITE_INSTANCE_ID";
-  private static final String WEBSITE_OWNER_NAME = "WEBSITE_OWNER_NAME";
-  private static final String WEBSITE_RESOURCE_GROUP = "WEBSITE_RESOURCE_GROUP";
+  static final String WEBSITE_OWNER_NAME = "WEBSITE_OWNER_NAME";
+  static final String WEBSITE_RESOURCE_GROUP = "WEBSITE_RESOURCE_GROUP";
   static final String WEBSITE_SITE_NAME = "WEBSITE_SITE_NAME";
   static final String WEBSITE_SLOT_NAME = "WEBSITE_SLOT_NAME";
 
@@ -75,12 +74,12 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
     builder.put(SERVICE_NAME, name);
 
     String websiteResourceGroup = env.get(WEBSITE_RESOURCE_GROUP);
-    if (!StringUtils.isNullOrEmpty(websiteResourceGroup)) {
+    if (websiteResourceGroup != null && !websiteResourceGroup.isEmpty()) {
       builder.put(AZURE_RESOURCE_GROUP_NAME, websiteResourceGroup);
     }
 
-    String subscriptionId = subscriptionId();
-    if (!StringUtils.isNullOrEmpty(subscriptionId)) {
+    String subscriptionId = subscriptionId(env);
+    if (subscriptionId != null && !subscriptionId.isEmpty()) {
       builder.put(CLOUD_ACCOUNT_ID, subscriptionId);
     }
 
@@ -95,19 +94,26 @@ public final class AzureAppServiceResourceProvider extends CloudResourceProvider
   }
 
   @Nullable
-  private String subscriptionId() {
+  static String subscriptionId(Map<String, String> env) {
     String websiteOwnerName = env.get(WEBSITE_OWNER_NAME);
-    if (websiteOwnerName != null && websiteOwnerName.contains("+")) {
-      return websiteOwnerName.substring(0, websiteOwnerName.indexOf("+"));
+    if (websiteOwnerName == null) {
+      return null;
     }
-    return websiteOwnerName;
+    int plusIndex = websiteOwnerName.indexOf("+");
+    if (plusIndex <= 0) {
+      // No '+' delimiter, or '+' at index 0 (empty subscription segment).
+      return null;
+    }
+    return websiteOwnerName.substring(0, plusIndex);
   }
 
   @Nullable
   static String resourceUri(
       String websiteName, @Nullable String websiteResourceGroup, @Nullable String subscriptionId) {
-    if (StringUtils.isNullOrEmpty(websiteResourceGroup)
-        || StringUtils.isNullOrEmpty(subscriptionId)) {
+    if (websiteResourceGroup == null
+        || websiteResourceGroup.isEmpty()
+        || subscriptionId == null
+        || subscriptionId.isEmpty()) {
       return null;
     }
 

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
@@ -21,13 +21,11 @@ import static java.util.Objects.requireNonNull;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 public final class AzureFunctionsResourceProvider extends CloudResourceProvider {
 
@@ -36,8 +34,6 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
 
   static final String FUNCTIONS_VERSION = "FUNCTIONS_EXTENSION_VERSION";
   private static final String FUNCTIONS_MEM_LIMIT = "WEBSITE_MEMORY_LIMIT_MB";
-  private static final String WEBSITE_OWNER_NAME = "WEBSITE_OWNER_NAME";
-  private static final String WEBSITE_RESOURCE_GROUP = "WEBSITE_RESOURCE_GROUP";
 
   private static final Map<AttributeKey<String>, String> ENV_VAR_MAPPING = new HashMap<>();
 
@@ -77,13 +73,14 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
     AttributesBuilder builder = AzureVmResourceProvider.azureAttributeBuilder(AZURE_FUNCTIONS);
     builder.put(SERVICE_NAME, name);
 
-    String websiteResourceGroup = env.get(WEBSITE_RESOURCE_GROUP);
-    if (!StringUtils.isNullOrEmpty(websiteResourceGroup)) {
+    String websiteResourceGroup =
+        env.get(AzureAppServiceResourceProvider.WEBSITE_RESOURCE_GROUP);
+    if (websiteResourceGroup != null && !websiteResourceGroup.isEmpty()) {
       builder.put(AZURE_RESOURCE_GROUP_NAME, websiteResourceGroup);
     }
 
-    String subscriptionId = subscriptionId();
-    if (!StringUtils.isNullOrEmpty(subscriptionId)) {
+    String subscriptionId = AzureAppServiceResourceProvider.subscriptionId(env);
+    if (subscriptionId != null && !subscriptionId.isEmpty()) {
       builder.put(CLOUD_ACCOUNT_ID, subscriptionId);
     }
 
@@ -108,14 +105,5 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
     AzureEnvVarPlatform.addAttributesFromEnv(ENV_VAR_MAPPING, env, builder);
 
     return builder.build();
-  }
-
-  @Nullable
-  private String subscriptionId() {
-    String websiteOwnerName = env.get(WEBSITE_OWNER_NAME);
-    if (websiteOwnerName != null && websiteOwnerName.contains("+")) {
-      return websiteOwnerName.substring(0, websiteOwnerName.indexOf("+"));
-    }
-    return websiteOwnerName;
   }
 }

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
@@ -8,11 +8,13 @@ package io.opentelemetry.contrib.azure.resource;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_REGION;
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_RESOURCE_ID;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CloudPlatformIncubatingValues.AZURE_FUNCTIONS;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_INSTANCE;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_MAX_MEMORY;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_NAME;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_VERSION;
+import static io.opentelemetry.semconv.DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +43,8 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
 
   static {
     ENV_VAR_MAPPING.put(CLOUD_REGION, AzureAppServiceResourceProvider.REGION_NAME);
+    ENV_VAR_MAPPING.put(
+        DEPLOYMENT_ENVIRONMENT_NAME, AzureAppServiceResourceProvider.WEBSITE_SLOT_NAME);
     ENV_VAR_MAPPING.put(FAAS_NAME, AzureAppServiceResourceProvider.WEBSITE_SITE_NAME);
     ENV_VAR_MAPPING.put(FAAS_VERSION, FUNCTIONS_VERSION);
     ENV_VAR_MAPPING.put(FAAS_INSTANCE, AzureAppServiceResourceProvider.WEBSITE_INSTANCE_ID);
@@ -81,6 +85,12 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
     String subscriptionId = subscriptionId();
     if (!StringUtils.isNullOrEmpty(subscriptionId)) {
       builder.put(CLOUD_ACCOUNT_ID, subscriptionId);
+    }
+
+    String resourceUri =
+        AzureAppServiceResourceProvider.resourceUri(name, websiteResourceGroup, subscriptionId);
+    if (resourceUri != null) {
+      builder.put(CLOUD_RESOURCE_ID, resourceUri);
     }
 
     String limit = env.get(FUNCTIONS_MEM_LIMIT);

--- a/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
+++ b/azure-resources/src/main/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProvider.java
@@ -5,21 +5,27 @@
 
 package io.opentelemetry.contrib.azure.resource;
 
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
+import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CLOUD_REGION;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.CloudPlatformIncubatingValues.AZURE_FUNCTIONS;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_INSTANCE;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_MAX_MEMORY;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_NAME;
 import static io.opentelemetry.contrib.azure.resource.IncubatingAttributes.FAAS_VERSION;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static java.util.Objects.requireNonNull;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.internal.StringUtils;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 
 public final class AzureFunctionsResourceProvider extends CloudResourceProvider {
 
@@ -28,6 +34,8 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
 
   static final String FUNCTIONS_VERSION = "FUNCTIONS_EXTENSION_VERSION";
   private static final String FUNCTIONS_MEM_LIMIT = "WEBSITE_MEMORY_LIMIT_MB";
+  private static final String WEBSITE_OWNER_NAME = "WEBSITE_OWNER_NAME";
+  private static final String WEBSITE_RESOURCE_GROUP = "WEBSITE_RESOURCE_GROUP";
 
   private static final Map<AttributeKey<String>, String> ENV_VAR_MAPPING = new HashMap<>();
 
@@ -61,7 +69,19 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
       return Attributes.empty();
     }
 
+    String name = requireNonNull(env.get(AzureAppServiceResourceProvider.WEBSITE_SITE_NAME));
     AttributesBuilder builder = AzureVmResourceProvider.azureAttributeBuilder(AZURE_FUNCTIONS);
+    builder.put(SERVICE_NAME, name);
+
+    String websiteResourceGroup = env.get(WEBSITE_RESOURCE_GROUP);
+    if (!StringUtils.isNullOrEmpty(websiteResourceGroup)) {
+      builder.put(AZURE_RESOURCE_GROUP_NAME, websiteResourceGroup);
+    }
+
+    String subscriptionId = subscriptionId();
+    if (!StringUtils.isNullOrEmpty(subscriptionId)) {
+      builder.put(CLOUD_ACCOUNT_ID, subscriptionId);
+    }
 
     String limit = env.get(FUNCTIONS_MEM_LIMIT);
     if (limit != null) {
@@ -78,5 +98,14 @@ public final class AzureFunctionsResourceProvider extends CloudResourceProvider 
     AzureEnvVarPlatform.addAttributesFromEnv(ENV_VAR_MAPPING, env, builder);
 
     return builder.build();
+  }
+
+  @Nullable
+  private String subscriptionId() {
+    String websiteOwnerName = env.get(WEBSITE_OWNER_NAME);
+    if (websiteOwnerName != null && websiteOwnerName.contains("+")) {
+      return websiteOwnerName.substring(0, websiteOwnerName.indexOf("+"));
+    }
+    return websiteOwnerName;
   }
 }

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureAppServiceResourceProviderTest.java
@@ -33,7 +33,8 @@ class AzureAppServiceResourceProviderTest {
   private static final String TEST_WEBSITE_INSTANCE_ID = "TEST_WEBSITE_INSTANCE_ID";
   private static final String TEST_WEBSITE_HOME_STAMPNAME = "TEST_WEBSITE_HOME_STAMPNAME";
   private static final String TEST_WEBSITE_RESOURCE_GROUP = "TEST_WEBSITE_RESOURCE_GROUP";
-  private static final String TEST_WEBSITE_OWNER_NAME = "TEST_WEBSITE_OWNER_NAME";
+  private static final String TEST_SUBSCRIPTION_ID = "TEST_SUBSCRIPTION_ID";
+  private static final String TEST_WEBSITE_OWNER_NAME = TEST_SUBSCRIPTION_ID + "+TEST_OWNER";
   private static final ImmutableMap<String, String> DEFAULT_ENV_VARS =
       ImmutableMap.of(
           "WEBSITE_SITE_NAME", TEST_WEBSITE_SITE_NAME,
@@ -51,11 +52,11 @@ class AzureAppServiceResourceProviderTest {
         .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(CLOUD_PROVIDER, "azure")
         .containsEntry(CLOUD_PLATFORM, "azure.app_service")
-        .containsEntry(CLOUD_ACCOUNT_ID, TEST_WEBSITE_OWNER_NAME)
+        .containsEntry(CLOUD_ACCOUNT_ID, TEST_SUBSCRIPTION_ID)
         .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
         .containsEntry(
             CLOUD_RESOURCE_ID,
-            "/subscriptions/TEST_WEBSITE_OWNER_NAME/resourceGroups/TEST_WEBSITE_RESOURCE_GROUP/providers/Microsoft.Web/sites/TEST_WEBSITE_SITE_NAME")
+            "/subscriptions/TEST_SUBSCRIPTION_ID/resourceGroups/TEST_WEBSITE_RESOURCE_GROUP/providers/Microsoft.Web/sites/TEST_WEBSITE_SITE_NAME")
         .containsEntry(CLOUD_REGION, TEST_REGION_NAME)
         .containsEntry(DEPLOYMENT_ENVIRONMENT_NAME, TEST_WEBSITE_SLOT_NAME)
         .containsEntry(HOST_ID, TEST_WEBSITE_HOSTNAME)
@@ -83,7 +84,7 @@ class AzureAppServiceResourceProviderTest {
     map.remove("WEBSITE_RESOURCE_GROUP");
 
     createResource(map)
-        .containsEntry(CLOUD_ACCOUNT_ID, TEST_WEBSITE_OWNER_NAME)
+        .containsEntry(CLOUD_ACCOUNT_ID, TEST_SUBSCRIPTION_ID)
         .doesNotContainKey(AZURE_RESOURCE_GROUP_NAME)
         .doesNotContainKey(CLOUD_RESOURCE_ID);
   }

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
@@ -6,6 +6,9 @@
 package io.opentelemetry.contrib.azure.resource;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.AzureIncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PLATFORM;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PROVIDER;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INSTANCE;
@@ -26,23 +29,54 @@ class AzureFunctionsResourceProviderTest {
   private static final String TEST_FUNCTION_VERSION = "TEST_VERSION";
   private static final String TEST_WEBSITE_INSTANCE_ID = "TEST_WEBSITE_INSTANCE_ID";
   private static final String TEST_MEM_LIMIT = "1024";
+  private static final String TEST_WEBSITE_RESOURCE_GROUP = "TEST_WEBSITE_RESOURCE_GROUP";
+  private static final String TEST_WEBSITE_OWNER_NAME = "TEST_SUBSCRIPTION_ID+TEST_OWNER";
   private static final ImmutableMap<String, String> DEFAULT_ENV_VARS =
       ImmutableMap.of(
           "WEBSITE_SITE_NAME", TEST_WEBSITE_SITE_NAME,
           "REGION_NAME", TEST_REGION_NAME,
           "WEBSITE_MEMORY_LIMIT_MB", TEST_MEM_LIMIT,
           "FUNCTIONS_EXTENSION_VERSION", TEST_FUNCTION_VERSION,
-          "WEBSITE_INSTANCE_ID", TEST_WEBSITE_INSTANCE_ID);
+          "WEBSITE_INSTANCE_ID", TEST_WEBSITE_INSTANCE_ID,
+          "WEBSITE_RESOURCE_GROUP", TEST_WEBSITE_RESOURCE_GROUP,
+          "WEBSITE_OWNER_NAME", TEST_WEBSITE_OWNER_NAME);
 
   @Test
   void defaultValues() {
     createResource(DEFAULT_ENV_VARS)
         .containsEntry(CLOUD_PROVIDER, "azure")
         .containsEntry(CLOUD_PLATFORM, "azure.functions")
+        .containsEntry(CLOUD_ACCOUNT_ID, "TEST_SUBSCRIPTION_ID")
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_VERSION, TEST_FUNCTION_VERSION)
         .containsEntry(FAAS_INSTANCE, TEST_WEBSITE_INSTANCE_ID)
         .containsEntry(FAAS_MAX_MEMORY, Long.parseLong(TEST_MEM_LIMIT));
+  }
+
+  @Test
+  void noResourceGroup() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.remove("WEBSITE_RESOURCE_GROUP");
+
+    createResource(map)
+        .containsEntry(CLOUD_ACCOUNT_ID, "TEST_SUBSCRIPTION_ID")
+        .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
+        .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
+        .doesNotContainKey(AZURE_RESOURCE_GROUP_NAME);
+  }
+
+  @Test
+  void noOwner() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.remove("WEBSITE_OWNER_NAME");
+
+    createResource(map)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
+        .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
+        .doesNotContainKey(CLOUD_ACCOUNT_ID);
   }
 
   @Test

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
@@ -90,6 +90,40 @@ class AzureFunctionsResourceProviderTest {
   }
 
   @Test
+  void malformedOwnerNameNoPlus() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.put("WEBSITE_OWNER_NAME", "TEST_OWNER_NO_PLUS");
+
+    createResource(map)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
+        .doesNotContainKey(CLOUD_ACCOUNT_ID)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
+  }
+
+  @Test
+  void malformedOwnerNamePlusAtIndexZero() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.put("WEBSITE_OWNER_NAME", "+TEST_OWNER");
+
+    createResource(map)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .doesNotContainKey(CLOUD_ACCOUNT_ID)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
+  }
+
+  @Test
+  void malformedOwnerNameEmptySubscriptionSegment() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.put("WEBSITE_OWNER_NAME", "+");
+
+    createResource(map)
+        .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .doesNotContainKey(CLOUD_ACCOUNT_ID)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
+  }
+
+  @Test
   void noWebsiteSlot() {
     HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
     map.remove("WEBSITE_SLOT_NAME");

--- a/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
+++ b/azure-resources/src/test/java/io/opentelemetry/contrib/azure/resource/AzureFunctionsResourceProviderTest.java
@@ -6,11 +6,13 @@
 package io.opentelemetry.contrib.azure.resource;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME;
 import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 import static io.opentelemetry.semconv.incubating.AzureIncubatingAttributes.AZURE_RESOURCE_GROUP_NAME;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_ACCOUNT_ID;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PLATFORM;
 import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_PROVIDER;
+import static io.opentelemetry.semconv.incubating.CloudIncubatingAttributes.CLOUD_RESOURCE_ID;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_INSTANCE;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_MAX_MEMORY;
 import static io.opentelemetry.semconv.incubating.FaasIncubatingAttributes.FAAS_NAME;
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.Test;
 class AzureFunctionsResourceProviderTest {
   private static final String TEST_WEBSITE_SITE_NAME = "TEST_WEBSITE_SITE_NAME";
   private static final String TEST_REGION_NAME = "TEST_REGION_NAME";
+  private static final String TEST_WEBSITE_SLOT_NAME = "TEST_WEBSITE_SLOT_NAME";
   private static final String TEST_FUNCTION_VERSION = "TEST_VERSION";
   private static final String TEST_WEBSITE_INSTANCE_ID = "TEST_WEBSITE_INSTANCE_ID";
   private static final String TEST_MEM_LIMIT = "1024";
@@ -35,6 +38,7 @@ class AzureFunctionsResourceProviderTest {
       ImmutableMap.of(
           "WEBSITE_SITE_NAME", TEST_WEBSITE_SITE_NAME,
           "REGION_NAME", TEST_REGION_NAME,
+          "WEBSITE_SLOT_NAME", TEST_WEBSITE_SLOT_NAME,
           "WEBSITE_MEMORY_LIMIT_MB", TEST_MEM_LIMIT,
           "FUNCTIONS_EXTENSION_VERSION", TEST_FUNCTION_VERSION,
           "WEBSITE_INSTANCE_ID", TEST_WEBSITE_INSTANCE_ID,
@@ -48,6 +52,10 @@ class AzureFunctionsResourceProviderTest {
         .containsEntry(CLOUD_PLATFORM, "azure.functions")
         .containsEntry(CLOUD_ACCOUNT_ID, "TEST_SUBSCRIPTION_ID")
         .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
+        .containsEntry(
+            CLOUD_RESOURCE_ID,
+            "/subscriptions/TEST_SUBSCRIPTION_ID/resourceGroups/TEST_WEBSITE_RESOURCE_GROUP/providers/Microsoft.Web/sites/TEST_WEBSITE_SITE_NAME")
+        .containsEntry(DEPLOYMENT_ENVIRONMENT_NAME, TEST_WEBSITE_SLOT_NAME)
         .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_VERSION, TEST_FUNCTION_VERSION)
@@ -64,7 +72,8 @@ class AzureFunctionsResourceProviderTest {
         .containsEntry(CLOUD_ACCOUNT_ID, "TEST_SUBSCRIPTION_ID")
         .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
-        .doesNotContainKey(AZURE_RESOURCE_GROUP_NAME);
+        .doesNotContainKey(AZURE_RESOURCE_GROUP_NAME)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
   }
 
   @Test
@@ -76,7 +85,16 @@ class AzureFunctionsResourceProviderTest {
         .containsEntry(AZURE_RESOURCE_GROUP_NAME, TEST_WEBSITE_RESOURCE_GROUP)
         .containsEntry(SERVICE_NAME, TEST_WEBSITE_SITE_NAME)
         .containsEntry(FAAS_NAME, TEST_WEBSITE_SITE_NAME)
-        .doesNotContainKey(CLOUD_ACCOUNT_ID);
+        .doesNotContainKey(CLOUD_ACCOUNT_ID)
+        .doesNotContainKey(CLOUD_RESOURCE_ID);
+  }
+
+  @Test
+  void noWebsiteSlot() {
+    HashMap<String, String> map = new HashMap<>(DEFAULT_ENV_VARS);
+    map.remove("WEBSITE_SLOT_NAME");
+
+    createResource(map).doesNotContainKey(DEPLOYMENT_ENVIRONMENT_NAME);
   }
 
   @Test


### PR DESCRIPTION
**Description:**

Update the Azure Functions resource detector to emit:

* `cloud.account.id` - from the subscription portion of `WEBSITE_OWNER_NAME` before `+` - [sem-conv](https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/#cloud-account-id), [discussion](https://github.com/open-telemetry/semantic-conventions/issues/3708)
* `azure.resource_group.name` - from `WEBSITE_RESOURCE_GROUP` - [sem-conv](https://opentelemetry.io/docs/specs/semconv/registry/attributes/azure/#azure-resource-group-name), [discussion](https://github.com/open-telemetry/semantic-conventions/issues/3697)
* `service.name` - from `WEBSITE_SITE_NAME` - [sem-conv](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name)

Goal: Align the Java Azure Functions detector with Azure environment metadata mapping and the Java Azure App Service parsing/building pattern added in [#3074](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/3074).

**AI Disclosure:** Pi Coding Agent was used to draft this PR, but I wrote this PR description and can explain all changes.

**Existing Issue(s):** n/a

**Testing:**

- [x] Unit Tests
- [x] Deployed a test app & confirmed the correct attributes were detected.

<img width="1362" height="118" alt="Screenshot 2026-09-03 at 7 28 38 AM" src="https://github.com/user-attachments/assets/ff0e013b-d1ac-4399-a31a-4f754c5a1ea0" />

**Documentation:**

Updated:
* `azure-resources/README.md`

**Outstanding items:** n/a
