### PR TITLE
[dynamic control] refactor TraceSamplingRatePolicy to use ratio instead of probability

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -19,11 +19,8 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
   public static final TelemetryPolicyIdentity DEFAULT_IDENTITY =
       new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
 
-  private final double ratio;
-
   public TraceSamplingRatePolicy(double ratio, SourceKind sourceKind) {
     super(DEFAULT_IDENTITY, normalizeRatio(ratio), sourceKind);
-    this.ratio = getSamplingProbability();
   }
 
   @Override
@@ -32,11 +29,11 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
   }
 
   public double getRatio() {
-    return ratio;
+    return getSamplingProbability();
   }
 
   public double getProbability() {
-    return getRatio();
+    return getSamplingProbability();
   }
 
   /**
@@ -55,14 +52,14 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
   }
 
   /**
-   * Creates the composed sampler used for this policy probability.
+   * Creates the composed sampler used for this policy ratio.
    *
-   * @param probability sampling probability in the inclusive range {@code [0.0, 1.0]}
-   * @return a sampler equivalent to the configured probability with parent-based behavior
-   * @throws IllegalArgumentException if probability is NaN or outside {@code [0.0, 1.0]}
+   * @param ratio sampling ratio (sampling probability) in the inclusive range {@code [0.0, 1.0]}
+   * @return a sampler equivalent to the configured ratio with parent-based behavior
+   * @throws IllegalArgumentException if ratio is NaN or outside {@code [0.0, 1.0]}
    */
-  public static Sampler createSampler(double probability) {
-    return AbstractTraceSamplingPolicy.createSampler(probability);
+  public static Sampler createSampler(double ratio) {
+    return AbstractTraceSamplingPolicy.createSampler(ratio);
   }
 
   private static double normalizeRatio(double ratio) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -66,6 +66,7 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
     if (Double.isNaN(ratio) || ratio < 0.0 || ratio > 1.0) {
       throw new IllegalArgumentException("ratio must be within [0.0, 1.0]");
     }
+    // normalize -0.0
     return ratio == 0.0 ? 0.0 : ratio;
   }
 

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicy.java
@@ -13,16 +13,17 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.trace.samplers.Sampler;
 import javax.annotation.Nullable;
 
+/** Trace sampling policy expressed as a ratio in the inclusive range {@code [0.0, 1.0]}. */
 public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
   public static final String POLICY_TYPE = "trace-sampling";
   public static final TelemetryPolicyIdentity DEFAULT_IDENTITY =
       new TelemetryPolicyIdentity("trace-sampling", "Trace sampling rate");
 
-  private final double probability;
+  private final double ratio;
 
-  public TraceSamplingRatePolicy(double probability, SourceKind sourceKind) {
-    super(DEFAULT_IDENTITY, probability, sourceKind);
-    this.probability = getSamplingProbability();
+  public TraceSamplingRatePolicy(double ratio, SourceKind sourceKind) {
+    super(DEFAULT_IDENTITY, normalizeRatio(ratio), sourceKind);
+    this.ratio = getSamplingProbability();
   }
 
   @Override
@@ -30,8 +31,12 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
     return POLICY_TYPE;
   }
 
+  public double getRatio() {
+    return ratio;
+  }
+
   public double getProbability() {
-    return probability;
+    return getRatio();
   }
 
   /**
@@ -58,6 +63,13 @@ public final class TraceSamplingRatePolicy extends AbstractTraceSamplingPolicy {
    */
   public static Sampler createSampler(double probability) {
     return AbstractTraceSamplingPolicy.createSampler(probability);
+  }
+
+  private static double normalizeRatio(double ratio) {
+    if (Double.isNaN(ratio) || ratio < 0.0 || ratio > 1.0) {
+      throw new IllegalArgumentException("ratio must be within [0.0, 1.0]");
+    }
+    return ratio == 0.0 ? 0.0 : ratio;
   }
 
   @Nullable

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -45,8 +45,7 @@ class PolicyStoreTest {
     assertThat(store.updatePolicies(singletonList(traceSampling(0.25)))).isTrue();
     assertThat(store.updatePolicies(singletonList(traceSampling(0.75)))).isTrue();
     assertThat(store.getPolicies()).hasSize(1);
-    assertThat(((TraceSamplingRatePolicy) store.getPolicies().get(0)).getProbability())
-        .isEqualTo(0.75);
+    assertThat(((TraceSamplingRatePolicy) store.getPolicies().get(0)).getRatio()).isEqualTo(0.75);
   }
 
   @Test
@@ -289,7 +288,7 @@ class PolicyStoreTest {
       return false;
     }
     TraceSamplingRatePolicy policy = (TraceSamplingRatePolicy) policies.get(0);
-    return Double.compare(policy.getProbability(), probability) == 0;
+    return Double.compare(policy.getRatio(), probability) == 0;
   }
 
   private static final class TestTelemetryPolicy implements TelemetryPolicy {

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/PolicyStoreTest.java
@@ -40,7 +40,7 @@ class PolicyStoreTest {
   }
 
   @Test
-  void updatePoliciesReturnsTrueWhenProbabilityChanges() {
+  void updatePoliciesReturnsTrueWhenRatioChanges() {
     PolicyStore store = new PolicyStore();
     assertThat(store.updatePolicies(singletonList(traceSampling(0.25)))).isTrue();
     assertThat(store.updatePolicies(singletonList(traceSampling(0.75)))).isTrue();
@@ -140,7 +140,7 @@ class PolicyStoreTest {
     store.registerImplementer(implementer);
 
     verify(implementer)
-        .onPoliciesChanged(argThat(policies -> containsTraceSamplingProbability(policies, 0.5)));
+        .onPoliciesChanged(argThat(policies -> containsTraceSamplingRatio(policies, 0.5)));
   }
 
   @Test
@@ -153,7 +153,7 @@ class PolicyStoreTest {
     store.updatePolicies(Arrays.asList(unrelatedPolicy(), traceSampling(0.25)));
 
     verify(implementer)
-        .onPoliciesChanged(argThat(policies -> containsTraceSamplingProbability(policies, 0.25)));
+        .onPoliciesChanged(argThat(policies -> containsTraceSamplingRatio(policies, 0.25)));
   }
 
   @Test
@@ -265,8 +265,8 @@ class PolicyStoreTest {
     return implementerFor(TraceSamplingRatePolicy.POLICY_TYPE);
   }
 
-  private static TraceSamplingRatePolicy traceSampling(double probability) {
-    return new TraceSamplingRatePolicy(probability, SourceKind.CUSTOM);
+  private static TraceSamplingRatePolicy traceSampling(double ratio) {
+    return new TraceSamplingRatePolicy(ratio, SourceKind.CUSTOM);
   }
 
   private static PolicyImplementer implementerFor(String policyType) {
@@ -282,13 +282,12 @@ class PolicyStoreTest {
         new TelemetryPolicyIdentity("other-policy", "Other policy"), "other-policy");
   }
 
-  private static boolean containsTraceSamplingProbability(
-      List<TelemetryPolicy> policies, double probability) {
+  private static boolean containsTraceSamplingRatio(List<TelemetryPolicy> policies, double ratio) {
     if (policies.size() != 1 || !(policies.get(0) instanceof TraceSamplingRatePolicy)) {
       return false;
     }
     TraceSamplingRatePolicy policy = (TraceSamplingRatePolicy) policies.get(0);
-    return Double.compare(policy.getRatio(), probability) == 0;
+    return Double.compare(policy.getRatio(), ratio) == 0;
   }
 
   private static final class TestTelemetryPolicy implements TelemetryPolicy {

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingRatePolicyTest.java
@@ -25,10 +25,11 @@ class TraceSamplingRatePolicyTest {
   }
 
   @Test
-  void constructorStoresProbabilityAndType() {
+  void constructorStoresRatioAndType() {
     TraceSamplingRatePolicy policy = new TraceSamplingRatePolicy(0.25, SourceKind.CUSTOM);
 
     assertThat(policy.getIdentity()).isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
+    assertThat(policy.getRatio()).isEqualTo(0.25);
     assertThat(policy.getProbability()).isEqualTo(0.25);
     assertThat(policy.getSamplingProbability()).isEqualTo(0.25);
     assertThat(policy.getType()).isEqualTo(TraceSamplingRatePolicy.POLICY_TYPE);
@@ -40,7 +41,7 @@ class TraceSamplingRatePolicyTest {
     TraceSamplingRatePolicy policy = new TraceSamplingRatePolicy(0.25, SourceKind.OPAMP);
 
     assertThat(policy.getIdentity()).isEqualTo(TraceSamplingRatePolicy.DEFAULT_IDENTITY);
-    assertThat(policy.getProbability()).isEqualTo(0.25);
+    assertThat(policy.getRatio()).isEqualTo(0.25);
     assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
   }
 
@@ -49,23 +50,23 @@ class TraceSamplingRatePolicyTest {
     TraceSamplingRatePolicy negativeZero = new TraceSamplingRatePolicy(-0.0, SourceKind.CUSTOM);
     TraceSamplingRatePolicy positiveZero = new TraceSamplingRatePolicy(0.0, SourceKind.CUSTOM);
 
-    assertThat(negativeZero.getProbability()).isEqualTo(0.0);
-    assertThat(Double.doubleToRawLongBits(negativeZero.getProbability()))
+    assertThat(negativeZero.getRatio()).isEqualTo(0.0);
+    assertThat(Double.doubleToRawLongBits(negativeZero.getRatio()))
         .isEqualTo(Double.doubleToRawLongBits(0.0));
-    assertThat(positiveZero.getProbability()).isEqualTo(0.0);
+    assertThat(positiveZero.getRatio()).isEqualTo(0.0);
   }
 
   @Test
-  void constructorRejectsOutOfRangeOrNaNProbabilities() {
+  void constructorRejectsOutOfRangeOrNaNRatios() {
     assertThatThrownBy(() -> new TraceSamplingRatePolicy(Double.NaN, SourceKind.CUSTOM))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("probability must be within [0.0, 1.0]");
+        .hasMessage("ratio must be within [0.0, 1.0]");
     assertThatThrownBy(() -> new TraceSamplingRatePolicy(-0.001, SourceKind.CUSTOM))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("probability must be within [0.0, 1.0]");
+        .hasMessage("ratio must be within [0.0, 1.0]");
     assertThatThrownBy(() -> new TraceSamplingRatePolicy(1.001, SourceKind.CUSTOM))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("probability must be within [0.0, 1.0]");
+        .hasMessage("ratio must be within [0.0, 1.0]");
   }
 
   @Test


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the next step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- DONE: trace sampling policy refactored to abstract superclass and concrete class #3050
- DONE: validator refactored to abstract superclass and concrete class #3070 
- DONE: integrate the validators to policy wiring #3071
- THIS PR (part2) create/convert the ratio/percentage policy concrete classes (part 1 #3076 )
- add docs
- cleanup (a bit of renaming)

also #2868