### PR TITLE
Extract the task ID in the ECS detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### AWS resources
+
+- Set `aws.ecs.task.id` on the ECS resource, extracted from the task ARN as the semantic
+  conventions require.
+  ([#3098](https://github.com/open-telemetry/opentelemetry-java-contrib/pull/3098))
+
 ### JMX Scraper
 
 - Add `experimental-cassandra` target system, inheriting the aligned Cassandra metric

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/EcsResource.java
@@ -10,6 +10,7 @@ import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS_LAUNCHTYPE;
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS_TASK_ARN;
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS_TASK_FAMILY;
+import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS_TASK_ID;
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_ECS_TASK_REVISION;
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_LOG_GROUP_ARNS;
 import static io.opentelemetry.contrib.aws.resource.IncubatingAttributes.AWS_LOG_GROUP_NAMES;
@@ -122,6 +123,21 @@ public final class EcsResource {
     return getArnPart(arn, ArnPart.REGION);
   }
 
+  /**
+   * The task metadata has no field for the task ID, so the conventions require it to be extracted
+   * from the task ARN, where it is the last path segment - of {@code task/<cluster>/<id>} in the
+   * current ARN format, or of {@code task/<id>} in the older one.
+   */
+  private static Optional<String> getTaskId(@Nullable String taskArn) {
+    if (taskArn == null) {
+      return Optional.empty();
+    }
+
+    String taskId = taskArn.substring(taskArn.lastIndexOf('/') + 1);
+
+    return taskId.isEmpty() ? Optional.empty() : Optional.of(taskId);
+  }
+
   private enum ArnPart {
     REGION(3),
     ACCOUNT(4);
@@ -211,6 +227,7 @@ public final class EcsResource {
         case "TaskARN":
           arn = value;
           attrBuilders.put(AWS_ECS_TASK_ARN, value);
+          getTaskId(value).ifPresent(taskId -> attrBuilders.put(AWS_ECS_TASK_ID, taskId));
           break;
         case "LaunchType":
           attrBuilders.put(AWS_ECS_LAUNCHTYPE, value.toLowerCase(Locale.ROOT));

--- a/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/IncubatingAttributes.java
+++ b/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/IncubatingAttributes.java
@@ -69,6 +69,8 @@ class IncubatingAttributes {
       AttributeKey.stringKey("aws.ecs.task.arn");
   public static final AttributeKey<String> AWS_ECS_TASK_FAMILY =
       AttributeKey.stringKey("aws.ecs.task.family");
+  public static final AttributeKey<String> AWS_ECS_TASK_ID =
+      AttributeKey.stringKey("aws.ecs.task.id");
   public static final AttributeKey<String> AWS_ECS_TASK_REVISION =
       AttributeKey.stringKey("aws.ecs.task.revision");
   public static final AttributeKey<List<String>> AWS_LOG_GROUP_ARNS =

--- a/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
+++ b/aws-resources/src/test/java/io/opentelemetry/contrib/aws/resource/EcsResourceTest.java
@@ -14,6 +14,7 @@ import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_EC
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_LAUNCHTYPE;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_TASK_ARN;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_TASK_FAMILY;
+import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_TASK_ID;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_ECS_TASK_REVISION;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_LOG_GROUP_ARNS;
 import static io.opentelemetry.semconv.incubating.AwsIncubatingAttributes.AWS_LOG_GROUP_NAMES;
@@ -86,6 +87,7 @@ class EcsResourceTest {
             entry(
                 AWS_ECS_TASK_ARN,
                 "arn:aws:ecs:us-east-2:012345678910:task/9781c248-0edd-4cdb-9a93-f63cb662a5d3"),
+            entry(AWS_ECS_TASK_ID, "9781c248-0edd-4cdb-9a93-f63cb662a5d3"),
             entry(AWS_ECS_TASK_FAMILY, "nginx"),
             entry(AWS_ECS_TASK_REVISION, "5"));
   }
@@ -137,6 +139,7 @@ class EcsResourceTest {
             entry(
                 AWS_ECS_TASK_ARN,
                 "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c"),
+            entry(AWS_ECS_TASK_ID, "158d1c8083dd49d6b527399fd6414f5c"),
             entry(AWS_ECS_LAUNCHTYPE, "ec2"),
             entry(AWS_ECS_TASK_FAMILY, "curltest"),
             entry(AWS_ECS_TASK_REVISION, "26"));


### PR DESCRIPTION
Fixes #3096.

`EcsResource` sets `aws.ecs.task.arn` but not `aws.ecs.task.id`, so the only identifier telemetry carries for a task is the full ARN. The bare id is the value that shows up in the ECS console, in `aws ecs describe-tasks` and in CloudWatch log stream names, so without it there is no cheap way to correlate a span with any of those — and the ARN is unwieldy to read in a trace UI and awkward to group by.

The convention is explicit that this one is derived rather than read from a metadata field:

> **aws.ecs.task.id** — The ID of a running ECS task. The ID MUST be extracted from `task.arn`.

It was added in semantic conventions v1.25.0, which is the schema version this resource already declares (`SchemaUrls.V1_25_0`), so there is no schema change here.

The id is taken as the segment after the last `/`, covering both the current cluster-qualified ARN format and the older `task/<id>` one. `getTaskId` follows the shape of the existing `getRegion`/`getAccountId` helpers, and the assertion is added to the existing v3 and v4 metadata tests.

`parseResponse` is otherwise a field-by-field transcription of the metadata document, but it already derives `cloud.region`, `cloud.account.id` and `aws.ecs.cluster.arn`, so one more derived attribute is not out of keeping.
