### PR TITLE
[dynamic control] New TraceSamplingPercentagePolicy parallel to TraceSamplingRatePolicy

### DIFF
--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/AbstractTraceSamplingPolicy.java
@@ -67,7 +67,7 @@ public abstract class AbstractTraceSamplingPolicy implements TelemetryPolicy {
    *
    * @param probability sampling probability in the inclusive range {@code [0.0, 1.0]}
    */
-  public static Sampler createSampler(double probability) {
+  protected static Sampler createSampler(double probability) {
     probability = normalizeProbability(probability);
     return CompositeSampler.wrap(
         ComposableSampler.parentThreshold(ComposableSampler.probability(probability)));

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicy.java
@@ -10,6 +10,7 @@ import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
 import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import javax.annotation.Nullable;
 
 /** Trace sampling policy expressed as a percentage in the inclusive range {@code [0.0, 100.0]}. */
@@ -29,6 +30,17 @@ public final class TraceSamplingPercentagePolicy extends AbstractTraceSamplingPo
 
   public double getPercentage() {
     return getSamplingProbability() * 100.0;
+  }
+
+  /**
+   * Creates the composed sampler used for this policy percentage.
+   *
+   * @param percentage sampling percentage in the inclusive range {@code [0.0, 100.0]}
+   * @return a sampler equivalent to the configured percentage with parent-based behavior
+   * @throws IllegalArgumentException if percentage is NaN or outside {@code [0.0, 100.0]}
+   */
+  public static Sampler createSampler(double percentage) {
+    return AbstractTraceSamplingPolicy.createSampler(normalizePercentage(percentage) / 100.0);
   }
 
   public static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicy.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicyIdentity;
+import io.opentelemetry.contrib.dynamic.policy.registry.PolicyInit;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import javax.annotation.Nullable;
+
+/** Trace sampling policy expressed as a percentage in the inclusive range {@code [0.0, 100.0]}. */
+public final class TraceSamplingPercentagePolicy extends AbstractTraceSamplingPolicy {
+  public static final String POLICY_TYPE = "trace-sampling";
+  public static final TelemetryPolicyIdentity DEFAULT_IDENTITY =
+      new TelemetryPolicyIdentity("trace-sampling", "Trace sampling percentage");
+
+  public TraceSamplingPercentagePolicy(double percentage, SourceKind sourceKind) {
+    super(DEFAULT_IDENTITY, normalizePercentage(percentage) / 100.0, sourceKind);
+  }
+
+  @Override
+  public String getType() {
+    return POLICY_TYPE;
+  }
+
+  public double getPercentage() {
+    return getSamplingProbability() * 100.0;
+  }
+
+  public static PolicyImplementer initialize(AutoConfigurationCustomizer autoConfiguration) {
+    return initialize(autoConfiguration, new TraceSamplingPercentageValidator());
+  }
+
+  public static void registerPolicyType() {
+    PolicyInit.registerPolicyType(
+        POLICY_TYPE,
+        TraceSamplingPercentagePolicy.class,
+        TraceSamplingPercentagePolicy::initialize);
+  }
+
+  @Nullable
+  public static DelegatingSampler getInitializedSampler() {
+    return AbstractTraceSamplingPolicy.getInitializedSampler();
+  }
+
+  static void resetForTest() {
+    AbstractTraceSamplingPolicy.resetForTest();
+  }
+
+  private static double normalizePercentage(double percentage) {
+    if (Double.isNaN(percentage) || percentage < 0.0 || percentage > 100.0) {
+      throw new IllegalArgumentException("percentage must be within [0.0, 100.0]");
+    }
+    return percentage == 0.0 ? 0.0 : percentage;
+  }
+}

--- a/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentageValidator.java
+++ b/dynamic-control/src/main/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentageValidator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Validator for {@code trace-sampling} policies expressed as percentages. */
+public final class TraceSamplingPercentageValidator extends AbstractTraceSamplingValidator {
+  private static final Logger logger =
+      Logger.getLogger(TraceSamplingPercentageValidator.class.getName());
+
+  public TraceSamplingPercentageValidator() {
+    super("percentage");
+  }
+
+  @Override
+  public String getPolicyType() {
+    return TraceSamplingPercentagePolicy.POLICY_TYPE;
+  }
+
+  @Override
+  @Nullable
+  protected TelemetryPolicy createPolicy(double percentage, SourceKind sourceKind) {
+    try {
+      return new TraceSamplingPercentagePolicy(percentage, sourceKind);
+    } catch (IllegalArgumentException e) {
+      logger.info(
+          "Invalid trace-sampling percentage '"
+              + percentage
+              + "' will be ignored: "
+              + e.getMessage());
+      return null;
+    }
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TraceSamplingPercentagePolicyTest {
+
+  @AfterEach
+  void tearDown() {
+    AbstractTraceSamplingPolicy.resetForTest();
+  }
+
+  @Test
+  void constructorStoresPercentageAndConvertsToProbability() {
+    TraceSamplingPercentagePolicy policy =
+        new TraceSamplingPercentagePolicy(25.0, SourceKind.CUSTOM);
+
+    assertThat(policy.getIdentity()).isEqualTo(TraceSamplingPercentagePolicy.DEFAULT_IDENTITY);
+    assertThat(policy.getPercentage()).isEqualTo(25.0);
+    assertThat(policy.getSamplingProbability()).isEqualTo(0.25);
+    assertThat(policy.getType()).isEqualTo(TraceSamplingPercentagePolicy.POLICY_TYPE);
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
+  }
+
+  @Test
+  void constructorAcceptsBoundaryPercentages() {
+    assertThat(new TraceSamplingPercentagePolicy(0.0, SourceKind.CUSTOM).getSamplingProbability())
+        .isEqualTo(0.0);
+    assertThat(new TraceSamplingPercentagePolicy(100.0, SourceKind.CUSTOM).getSamplingProbability())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void constructorNormalizesNegativeZero() {
+    TraceSamplingPercentagePolicy policy =
+        new TraceSamplingPercentagePolicy(-0.0, SourceKind.CUSTOM);
+
+    assertThat(Double.doubleToRawLongBits(policy.getPercentage()))
+        .isEqualTo(Double.doubleToRawLongBits(0.0));
+  }
+
+  @Test
+  void constructorRejectsOutOfRangeOrNaNPercentages() {
+    assertThatThrownBy(() -> new TraceSamplingPercentagePolicy(Double.NaN, SourceKind.CUSTOM))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+    assertThatThrownBy(() -> new TraceSamplingPercentagePolicy(-0.001, SourceKind.CUSTOM))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+    assertThatThrownBy(() -> new TraceSamplingPercentagePolicy(100.001, SourceKind.CUSTOM))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+  }
+
+  @Test
+  void initializeStoresSharedSamplerAndRegistersCustomizer() {
+    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
+
+    TraceSamplingPercentagePolicy.initialize(customizer);
+
+    assertThat(AbstractTraceSamplingPolicy.getInitializedSampler()).isNotNull();
+    verify(customizer).addSamplerCustomizer(any());
+  }
+
+  @Test
+  void ratioAndPercentageInitializersShareSamplerButExposeTheirOwnValidators() {
+    AutoConfigurationCustomizer customizer = mock(AutoConfigurationCustomizer.class);
+
+    PolicyImplementer ratioImplementer = TraceSamplingRatePolicy.initialize(customizer);
+    DelegatingSampler ratioSampler = AbstractTraceSamplingPolicy.getInitializedSampler();
+    PolicyImplementer percentageImplementer = TraceSamplingPercentagePolicy.initialize(customizer);
+
+    assertThat(AbstractTraceSamplingPolicy.getInitializedSampler()).isSameAs(ratioSampler);
+    assertThat(ratioImplementer.getValidators())
+        .extracting(validator -> validator.getPolicyType())
+        .containsExactly(TraceSamplingRatePolicy.POLICY_TYPE);
+    assertThat(percentageImplementer.getValidators())
+        .extracting(validator -> validator.getPolicyType())
+        .containsExactly(TraceSamplingPercentagePolicy.POLICY_TYPE);
+    verify(customizer, times(1)).addSamplerCustomizer(any());
+  }
+}

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicyTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentagePolicyTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import io.opentelemetry.contrib.dynamic.policy.PolicyImplementer;
 import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,30 @@ class TraceSamplingPercentagePolicyTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("percentage must be within [0.0, 100.0]");
     assertThatThrownBy(() -> new TraceSamplingPercentagePolicy(100.001, SourceKind.CUSTOM))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+  }
+
+  @Test
+  void createSamplerAcceptsPercentageRange() {
+    Sampler zero = TraceSamplingPercentagePolicy.createSampler(0.0);
+    Sampler fifty = TraceSamplingPercentagePolicy.createSampler(50.0);
+    Sampler oneHundred = TraceSamplingPercentagePolicy.createSampler(100.0);
+
+    assertThat(zero).isNotNull();
+    assertThat(fifty).isNotNull();
+    assertThat(oneHundred).isNotNull();
+  }
+
+  @Test
+  void createSamplerRejectsOutOfRangeOrNaNPercentages() {
+    assertThatThrownBy(() -> TraceSamplingPercentagePolicy.createSampler(Double.NaN))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+    assertThatThrownBy(() -> TraceSamplingPercentagePolicy.createSampler(-0.01))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("percentage must be within [0.0, 100.0]");
+    assertThatThrownBy(() -> TraceSamplingPercentagePolicy.createSampler(100.01))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("percentage must be within [0.0, 100.0]");
   }

--- a/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentageValidatorTest.java
+++ b/dynamic-control/src/test/java/io/opentelemetry/contrib/dynamic/policy/tracesampling/TraceSamplingPercentageValidatorTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.contrib.dynamic.policy.tracesampling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.opentelemetry.contrib.dynamic.policy.TelemetryPolicy;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceFormat;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceKind;
+import io.opentelemetry.contrib.dynamic.policy.source.SourceWrapper;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TraceSamplingPercentageValidatorTest {
+
+  private static final String TRACE_SAMPLING_POLICY_TYPE =
+      TraceSamplingPercentagePolicy.POLICY_TYPE;
+  private static final Set<String> MAPPED_POLICY_IDS =
+      new HashSet<>(Arrays.asList(TRACE_SAMPLING_POLICY_TYPE, "other-policy", "other.key"));
+
+  private final TraceSamplingPercentageValidator validator = new TraceSamplingPercentageValidator();
+
+  @Test
+  void testGetPolicyType() {
+    assertThat(validator.getPolicyType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+  }
+
+  @Test
+  void testValidate_ValidJson() {
+    TelemetryPolicy policy = validateJson(jsonForPercentage(50.0));
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+    assertThat(policy).isInstanceOf(TraceSamplingPercentagePolicy.class);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getIdentity())
+        .isEqualTo(TraceSamplingPercentagePolicy.DEFAULT_IDENTITY);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(50.0, within(1e-9));
+    assertThat(((TraceSamplingPercentagePolicy) policy).getSamplingProbability())
+        .isCloseTo(0.5, within(1e-9));
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.CUSTOM);
+  }
+
+  @Test
+  void validateStoresExplicitSourceKind() {
+    TelemetryPolicy policy =
+        validator.validate(
+            first(SourceFormat.JSONKEYVALUE.parse(jsonForPercentage(50.0), MAPPED_POLICY_IDS)),
+            SourceKind.OPAMP);
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getSourceKind()).isEqualTo(SourceKind.OPAMP);
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 100.0})
+  void testValidate_ValidJson_BoundaryValues(double percentage) {
+    TelemetryPolicy policy = validateJson(jsonForPercentage(percentage));
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+    assertThat(policy).isInstanceOf(TraceSamplingPercentagePolicy.class);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(percentage, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_FullPolicyStruct() {
+    TelemetryPolicy policy = validateJson(fullPolicyStructForPercentage("10.0"));
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+    assertThat(policy).isInstanceOf(TraceSamplingPercentagePolicy.class);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(10.0, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_FullPolicyStructWithOptionalFields() {
+    String json =
+        "{"
+            + "\"id\":\"trace-sampling\","
+            + "\"name\":\"Trace sampling percentage\","
+            + "\"description\":\"Set the global trace sampling rate to 10%.\","
+            + "\"enabled\":true,"
+            + "\"created_at_unix_nano\":\"1718890000000000000\","
+            + "\"modified_at_unix_nano\":\"1718893600000000000\","
+            + "\"labels\":[{\"key\":\"policy.scope\","
+            + "\"value\":{\"string_value\":\"global\"}}],"
+            + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true,"
+            + "\"negate\":false,\"case_insensitive\":false}],"
+            + "\"keep\":{\"percentage\":10.0,\"mode\":\"proportional\","
+            + "\"sampling_precision\":6,\"hash_seed\":0,\"fail_closed\":false}}"
+            + "}";
+
+    TelemetryPolicy policy = validateJson(json);
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(10.0, within(1e-9));
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 100.0})
+  void testValidate_ValidJson_FullPolicyStructPercentageBoundaries(double percentage) {
+    TelemetryPolicy policy =
+        validateJson(fullPolicyStructForPercentage(Double.toString(percentage)));
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(percentage, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_ObjectShapeWithPercentageField() {
+    TelemetryPolicy policy =
+        validateJson("{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"percentage\": 50.0}}");
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+    assertThat(policy).isInstanceOf(TraceSamplingPercentagePolicy.class);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(50.0, within(1e-9));
+  }
+
+  @Test
+  void testValidate_InvalidJson_ObjectShapeWithProbabilityField() {
+    assertThat(validateJson("{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"probability\": 0.5}}"))
+        .isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {0.0, 100.0})
+  void testValidate_ValidJson_ObjectShape_BoundaryValues(double percentage) {
+    TelemetryPolicy policy =
+        validateJson(
+            "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"percentage\": " + percentage + "}}");
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(percentage, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_PercentageAsQuotedStringInObject() {
+    TelemetryPolicy policy =
+        validateJson("{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": {\"percentage\": \"62.5\"}}");
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(62.5, within(1e-9));
+  }
+
+  @Test
+  void testValidate_ValidJson_PercentageAsQuotedStringFlat() {
+    TelemetryPolicy policy = validateJson("{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"37.5\"}");
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(37.5, within(1e-9));
+  }
+
+  @Test
+  void testValidate_InvalidJson_MissingPolicyType() {
+    assertThat(validateJson("{\"other-policy\": 50.0}")).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(doubles = {-0.1, 100.1})
+  void testValidate_InvalidJson_PercentageOutOfRange(double percentage) {
+    assertThat(validateJson(jsonForPercentage(percentage))).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"-0.1", "100.1"})
+  void testValidate_InvalidJson_FullPolicyPercentageOutOfRange(String percentage) {
+    assertThat(validateJson(fullPolicyStructForPercentage(percentage))).isNull();
+  }
+
+  @Test
+  void testValidate_InvalidJson_FullPolicyMissingPercentage() {
+    assertThat(
+            validateJson(
+                "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling percentage\","
+                    + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+                    + "\"keep\":{}}}"))
+        .isNull();
+  }
+
+  @Test
+  void testValidate_ValidJson_DoesNotInterpretGenericMatchConcern() {
+    TelemetryPolicy policy =
+        validateJson(
+            "{\"id\":\"trace-sampling\",\"name\":\"Trace sampling percentage\","
+                + "\"trace\":{\"match\":[{\"span_attribute\":[\"db.system\"],\"exists\":true}],"
+                + "\"keep\":{\"percentage\":10.0}}}");
+
+    assertThat(policy).isNotNull();
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(10.0, within(1e-9));
+  }
+
+  @Test
+  void testValidate_InvalidJson_ValueNotNumber() {
+    assertThat(validateJson("{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": \"high\"}")).isNull();
+  }
+
+  @Test
+  void testValidate_ValidKeyValue() {
+    TelemetryPolicy policy =
+        validator.validate(
+            first(
+                SourceFormat.KEYVALUE.parse(
+                    TRACE_SAMPLING_POLICY_TYPE + "=50.0", MAPPED_POLICY_IDS)),
+            SourceKind.CUSTOM);
+
+    assertThat(policy).isNotNull();
+    assertThat(policy.getType()).isEqualTo(TRACE_SAMPLING_POLICY_TYPE);
+    assertThat(policy).isInstanceOf(TraceSamplingPercentagePolicy.class);
+    assertThat(((TraceSamplingPercentagePolicy) policy).getPercentage())
+        .isCloseTo(50.0, within(1e-9));
+  }
+
+  @Test
+  void testValidate_InvalidKeyValue_WrongKey() {
+    assertThat(
+            validator.validate(
+                first(SourceFormat.KEYVALUE.parse("other.key=50.0", MAPPED_POLICY_IDS)),
+                SourceKind.CUSTOM))
+        .isNull();
+  }
+
+  @Test
+  void testValidate_InvalidKeyValue_NotNumber() {
+    assertThat(
+            validator.validate(
+                first(
+                    SourceFormat.KEYVALUE.parse(
+                        TRACE_SAMPLING_POLICY_TYPE + "=invalid", MAPPED_POLICY_IDS)),
+                SourceKind.CUSTOM))
+        .isNull();
+  }
+
+  private static String jsonForPercentage(double percentage) {
+    return "{\"" + TRACE_SAMPLING_POLICY_TYPE + "\": " + percentage + "}";
+  }
+
+  private TelemetryPolicy validateJson(String json) {
+    return validator.validate(
+        first(SourceFormat.JSONKEYVALUE.parse(json, MAPPED_POLICY_IDS)), SourceKind.CUSTOM);
+  }
+
+  private static String fullPolicyStructForPercentage(String percentage) {
+    return "{"
+        + "\"id\":\""
+        + TRACE_SAMPLING_POLICY_TYPE
+        + "\","
+        + "\"name\":\"Trace sampling percentage\","
+        + "\"trace\":{\"match\":[{\"trace_field\":\"trace_id\",\"exists\":true}],"
+        + "\"keep\":{\"percentage\":"
+        + percentage
+        + "}}"
+        + "}";
+  }
+
+  private static SourceWrapper first(List<SourceWrapper> parsedSources) {
+    assertThat(parsedSources).isNotNull();
+    assertThat(parsedSources).isNotEmpty();
+    return parsedSources.get(0);
+  }
+}


### PR DESCRIPTION
**Description:**

TraceSamplingRatePolicy is implemented to use ratio, a value between 0-1. While this is technically correct, the examples in the telemetry policy spec provide percentages, and it's clear that both ratios and percentages need to be supported. The cleanest way to do this is to provide two policies which share the same behaviour except for naming and value conversion. Implementation is best done by abstracting common behaviour and providing minimal implementations of concrete subclasses. This is the next step to achieve that.

**Existing Issue(s):**

#2868

**Testing:**

Included

**Documentation:**

To be added

**Outstanding items:**

Expected set of PRs:
- DONE: trace sampling policy refactored to abstract superclass and concrete class #3050
- DONE: validator refactored to abstract superclass and concrete class #3070 
- DONE: integrate the validators to policy wiring #3071
- THIS PR (part3) create/convert the ratio/percentage policy concrete classes (earlier parts #3076 #3097 )
- add docs
- cleanup (a bit of renaming)

also #2868